### PR TITLE
Intervention Reasons Bug Fix

### DIFF
--- a/API.Tests/MapperTests/PostProjectsRequestMapperTests.cs
+++ b/API.Tests/MapperTests/PostProjectsRequestMapperTests.cs
@@ -360,7 +360,7 @@ namespace API.Tests.MapperTests
 
             Assert.Equal("596500002,596500001,596500000", result.Academies[0].RddOrRscInterventionReasons);
             Assert.Equal("596500002", result.Academies[1].RddOrRscInterventionReasons);
-            Assert.True(string.IsNullOrEmpty(result.Academies[2].RddOrRscInterventionReasons));
+            Assert.Null(result.Academies[2].RddOrRscInterventionReasons);
         }
 
         [Fact]

--- a/API.Tests/MapperTests/PostProjectsRequestMapperTests.cs
+++ b/API.Tests/MapperTests/PostProjectsRequestMapperTests.cs
@@ -189,7 +189,7 @@ namespace API.Tests.MapperTests
 
             var result = _mapper.Map(request);
 
-            Assert.Equal(string.Empty, result.Academies[0].EsfaInterventionReasons);
+            Assert.Null(result.Academies[0].EsfaInterventionReasons);
             Assert.Equal("596500001", result.Academies[1].EsfaInterventionReasons);
             Assert.Equal("596500001,596500002,596500003", result.Academies[2].EsfaInterventionReasons);
         }

--- a/TRAMS-API/API.xml
+++ b/TRAMS-API/API.xml
@@ -92,6 +92,14 @@
             2. Completed
             </summary>
         </member>
+        <member name="T:API.Models.Upstream.Enums.RddOrRscInterventionReasonEnum">
+            <summary>
+            Allowed values for the RDD or RSC intervention status codes:
+            1. Termination Warning Notice
+            2. RSC Minded to Terminate Notice
+            3. Ofsted Inadequate Rating
+            </summary>
+        </member>
         <member name="P:API.Models.Upstream.Response.GetProjectsResponseModel.ProjectId">
             <summary>
             The ID of the Academy Transfers project

--- a/TRAMS-API/Mapping/PostProjectsRequestMapper.cs
+++ b/TRAMS-API/Mapping/PostProjectsRequestMapper.cs
@@ -20,12 +20,12 @@ namespace API.Mapping
                 EsfaInterventionReasons = p.EsfaInterventionReasons != null 
                                           ? string.Join(',', p.EsfaInterventionReasons.Select(r => ((int)MappingDictionaries.EsfaInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                       .ToList()) 
-                                          : string.Empty,
+                                          : null,
                 EsfaInterventionReasonsExplained = p.EsfaInterventionReasonsExplained,
                 RddOrRscInterventionReasons = p.RddOrRscInterventionReasons != null 
                                               ? string.Join(',', p.RddOrRscInterventionReasons.Select(r => ((int)MappingDictionaries.RddOrRscInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                               .ToList())
-                                              : string.Empty,
+                                              : null,
                 RddOrRscInterventionReasonsExplained = p.RddOrRscInterventionReasonsExplained,
                 Trusts = p.Trusts != null 
                          ? p.Trusts.Select(t => new PostAcademyTransfersProjectAcademyTrustD365Model { TrustId = $"/accounts({t.TrustId})" })

--- a/TRAMS-API/Mapping/PostProjectsRequestMapper.cs
+++ b/TRAMS-API/Mapping/PostProjectsRequestMapper.cs
@@ -17,12 +17,12 @@ namespace API.Mapping
             var academies = input.ProjectAcademies?.Select(p => new PostAcademyTransfersProjectAcademyD365Model
             {
                 AcademyId = $"/accounts({p.AcademyId})",
-                EsfaInterventionReasons = p.EsfaInterventionReasons != null 
+                EsfaInterventionReasons = p.EsfaInterventionReasons != null && p.EsfaInterventionReasons.Any()
                                           ? string.Join(',', p.EsfaInterventionReasons.Select(r => ((int)MappingDictionaries.EsfaInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                       .ToList()) 
                                           : null,
                 EsfaInterventionReasonsExplained = p.EsfaInterventionReasonsExplained,
-                RddOrRscInterventionReasons = p.RddOrRscInterventionReasons != null 
+                RddOrRscInterventionReasons = p.RddOrRscInterventionReasons != null && p.RddOrRscInterventionReasons.Any()
                                               ? string.Join(',', p.RddOrRscInterventionReasons.Select(r => ((int)MappingDictionaries.RddOrRscInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                               .ToList())
                                               : null,


### PR DESCRIPTION
Intervention Reasons: D365 POST Model properties must be null (not empty string) if the upstream reason arrays are null or empty  
Update tests to assert downstream reason string properties are null