### PR TITLE
Add outgoing trust details confirmation page

### DIFF
--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -25,16 +25,16 @@ namespace Frontend.Controllers
         public IActionResult TrustName()
         {
             ViewData["Error.Exists"] = false;
-            
+
             if (TempData.Peek("ErrorMessage") == null) return View();
-            
+
             ViewData["Error.Exists"] = true;
             ViewData["Error.Message"] = TempData["ErrorMessage"];
             return View();
         }
 
         public async Task<IActionResult> TrustSearch(string query)
-       {
+        {
             if (string.IsNullOrEmpty(query))
             {
                 TempData["ErrorMessage"] = "Please enter a search term";
@@ -48,10 +48,18 @@ namespace Frontend.Controllers
                 TempData["ErrorMessage"] = result.Error.ErrorMessage;
                 return RedirectToAction("TrustName");
             }
-            
-            var mappedResults = result.Result.Select(r => _getTrustMapper.Map(r)).ToList();
-            var model = new TrustSearch { Trusts = mappedResults };
 
+            var mappedResults = result.Result.Select(r => _getTrustMapper.Map(r)).ToList();
+            var model = new TrustSearch {Trusts = mappedResults};
+
+            return View(model);
+        }
+
+        public async Task<IActionResult> OutgoingTrustDetails(Guid trustId)
+        {
+            var result = await _trustRepository.GetTrustById(trustId);
+            var mappedResult = _getTrustMapper.Map(result.Result);
+            var model = new OutgoingTrustDetails {Trust = mappedResult};
             return View(model);
         }
     }

--- a/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
@@ -1,0 +1,41 @@
+@using System.Text.RegularExpressions
+@model Frontend.Views.Transfers.OutgoingTrustDetails
+
+@{
+    ViewBag.Title = "title";
+    Layout = "_Layout";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-xl">Outgoing trust details</h1>
+        <dl class="govuk-summary-list govuk-summary-list--no-border">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Name</dt>
+                <dd class="govuk-summary-list__value">@Model.Trust.TrustName</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Companies House number</dt>
+                <dd class="govuk-summary-list__value">@Model.Trust.CompaniesHouseNumber</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Type</dt>
+                <dd class="govuk-summary-list__value">@Model.Trust.EstablishmentType</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Trust reference number</dt>
+                <dd class="govuk-summary-list__value">@Model.Trust.TrustReferenceNumber</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Address</dt>
+                <dd class="govuk-summary-list__value">
+                    @foreach (var line in Regex.Split(@Model.Trust.Address, "\\r\\n|,"))
+                    {
+                        <p class="govuk-body">@line.Trim()</p>
+                    }
+                </dd>
+            </div>
+        </dl>
+        <a class="govuk-button" href="meow" role="button" draggable="false">Select trust</a>
+    </div>
+</div>

--- a/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml.cs
+++ b/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml.cs
@@ -1,0 +1,10 @@
+using API.Models.Upstream.Response;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Frontend.Views.Transfers
+{
+    public class OutgoingTrustDetails : PageModel
+    {
+        public GetTrustsModel Trust;
+    }
+}

--- a/Frontend/Views/Transfers/TrustSearch.cshtml
+++ b/Frontend/Views/Transfers/TrustSearch.cshtml
@@ -11,7 +11,7 @@
     @foreach (var trust in Model.Trusts)
     {
         <li>
-            <a class="govuk-link" href="meow">@trust.TrustName</a>
+            <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Id">@trust.TrustName</a>
         </li>
     }
 </ul>


### PR DESCRIPTION
### Context

As part of the ongoing rewrite, this recreates the confirmation page for the outgoing trust.

### Changes proposed in this pull request

- Add links to the outgoing trust page from the trust search results
- Add confirmation details page for outgoing trust

### Checklist

- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally

