### PR TITLE
Add page for outgoing academies

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using API.Mapping;
 using API.Models.Downstream.D365;
 using API.Models.Upstream.Response;
@@ -8,8 +11,10 @@ using API.Repositories;
 using Frontend.Controllers;
 using Frontend.Views.Transfers;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Session;
 using Moq;
 using Xunit;
 
@@ -17,23 +22,85 @@ namespace Frontend.Tests.ControllerTests
 {
     public class TransfersControllerTests
     {
+        class MockSession : ISession
+        {
+            public readonly Dictionary<string, string> SessionStore;
+
+            public MockSession()
+            {
+                SessionStore = new Dictionary<string, string>();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task CommitAsync(CancellationToken cancellationToken = new CancellationToken())
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task LoadAsync(CancellationToken cancellationToken = new CancellationToken())
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Remove(string key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Set(string key, byte[] value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool TryGetValue(string key, out byte[] value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetString(string key, string value)
+            {
+                SessionStore[key] = value;
+            }
+
+            public string Id { get; }
+            public bool IsAvailable { get; }
+            public IEnumerable<string> Keys { get; }
+        }
+
         private readonly Mock<ITrustsRepository> _trustRepository;
+        private readonly Mock<IAcademiesRepository> _academiesRepository;
         private readonly Mock<IMapper<GetTrustsD365Model, GetTrustsModel>> _getTrustMapper;
+        private readonly Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>> _getAcademiesMapper;
         private readonly TransfersController _subject;
+        private readonly Mock<ISession> _session;
 
         public TransfersControllerTests()
         {
             _trustRepository = new Mock<ITrustsRepository>();
+            _academiesRepository = new Mock<IAcademiesRepository>();
             _getTrustMapper = new Mock<IMapper<GetTrustsD365Model, GetTrustsModel>>();
+            _getAcademiesMapper = new Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>>();
+            _session = new Mock<ISession>();
 
             var tempDataProvider = new Mock<ITempDataProvider>();
+            var httpContext = new DefaultHttpContext();
+            var sessionFeature = new SessionFeature {Session = _session.Object};
+            httpContext.Features.Set<ISessionFeature>(sessionFeature);
+
             var tempDataDictionaryFactory =
                 new TempDataDictionaryFactory(tempDataProvider.Object);
-            var tempData = tempDataDictionaryFactory.GetTempData(new DefaultHttpContext());
+            var tempData = tempDataDictionaryFactory.GetTempData(httpContext);
 
             _subject = new TransfersController(
                 _trustRepository.Object,
-                _getTrustMapper.Object) {TempData = tempData};
+                _academiesRepository.Object,
+                _getTrustMapper.Object,
+                _getAcademiesMapper.Object
+            ) {TempData = tempData, ControllerContext = {HttpContext = httpContext}};
         }
 
         #region TrustName
@@ -106,32 +173,6 @@ namespace Frontend.Tests.ControllerTests
             AssertTrustsAreMappedCorrectly(trustId, trustTwoId);
         }
 
-        private void AssertTrustsAreMappedCorrectly(Guid trustId, Guid trustTwoId)
-        {
-            _getTrustMapper.Verify(m => m.Map(It.Is<GetTrustsD365Model>(model => model.Id == trustId)), Times.Once);
-            _getTrustMapper.Verify(m => m.Map(It.Is<GetTrustsD365Model>(model => model.Id == trustTwoId)), Times.Once);
-        }
-
-        private void AssertTrustRepositoryIsCalledCorrectly()
-        {
-            _trustRepository.Verify(r => r.SearchTrusts("Trust name"));
-        }
-
-        private static void AssertTrustsAreAssignedToTheView(IActionResult result, Guid trustId, Guid trustTwoId)
-        {
-            var viewResult = Assert.IsType<ViewResult>(result);
-            var viewModel = Assert.IsType<TrustSearch>(viewResult.ViewData.Model);
-
-            Assert.Equal(trustId, viewModel.Trusts[0].Id);
-            Assert.Equal(trustTwoId, viewModel.Trusts[1].Id);
-        }
-
-        private static void AssertRedirectToTrustName(IActionResult response)
-        {
-            var redirectResponse = Assert.IsType<RedirectToActionResult>(response);
-            Assert.Equal("TrustName", redirectResponse.ActionName);
-        }
-
         #endregion
 
         #region OutgoingTrustDetails
@@ -175,6 +216,53 @@ namespace Frontend.Tests.ControllerTests
             var viewModel = Assert.IsType<OutgoingTrustDetails>(viewResponse.Model);
 
             Assert.Equal(mappedTrust, viewModel.Trust);
+        }
+
+        #endregion
+
+        #region ConfirmOutgoingTrust
+
+        [Fact]
+        public void GivenTrustGuid_StoresTheTrustInTheSessionAndRedirects()
+        {
+            var trustId = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
+            _subject.ConfirmOutgoingTrust(trustId);
+
+            _session.Verify(s => s.Set(
+                "OutgoingTrustId",
+                It.Is<byte[]>(input =>
+                    Encoding.UTF8.GetString(input) == trustId.ToString()
+                )));
+        }
+
+        #endregion
+
+        #region HelperMethods
+
+        private void AssertTrustsAreMappedCorrectly(Guid trustId, Guid trustTwoId)
+        {
+            _getTrustMapper.Verify(m => m.Map(It.Is<GetTrustsD365Model>(model => model.Id == trustId)), Times.Once);
+            _getTrustMapper.Verify(m => m.Map(It.Is<GetTrustsD365Model>(model => model.Id == trustTwoId)), Times.Once);
+        }
+
+        private void AssertTrustRepositoryIsCalledCorrectly()
+        {
+            _trustRepository.Verify(r => r.SearchTrusts("Trust name"));
+        }
+
+        private static void AssertTrustsAreAssignedToTheView(IActionResult result, Guid trustId, Guid trustTwoId)
+        {
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var viewModel = Assert.IsType<TrustSearch>(viewResult.ViewData.Model);
+
+            Assert.Equal(trustId, viewModel.Trusts[0].Id);
+            Assert.Equal(trustTwoId, viewModel.Trusts[1].Id);
+        }
+
+        private static void AssertRedirectToTrustName(IActionResult response)
+        {
+            var redirectResponse = Assert.IsType<RedirectToActionResult>(response);
+            Assert.Equal("TrustName", redirectResponse.ActionName);
         }
 
         #endregion

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -78,12 +78,28 @@ namespace Frontend.Controllers
 
         public async Task<IActionResult> OutgoingTrustAcademies()
         {
-            var outgoingTrustId = Guid.Parse(HttpContext.Session.GetString("OutgoingTrustId"));
-            var result = await _academiesRepository.GetAcademiesByTrustId(outgoingTrustId);
-            var academies = result.Result.Select(a => _getAcademiesMapper.Map(a)).ToList();
+            var sessionGuid = HttpContext.Session.GetString("OutgoingTrustId");
+            var outgoingTrustId = Guid.Parse(sessionGuid);
+            var academiesRepoResult = await _academiesRepository.GetAcademiesByTrustId(outgoingTrustId);
+            var academies = academiesRepoResult.Result
+                ?.Select(a => _getAcademiesMapper.Map(a))
+                .ToList();
 
             var model = new OutgoingTrustAcademies {Academies = academies};
             return View(model);
+        }
+
+        public IActionResult SubmitOutgoingTrustAcademies(Guid[] academyIds)
+        {
+            var academyIdsString = string.Join(",", academyIds.Select(id => id.ToString()).ToList());
+            HttpContext.Session.SetString("OutgoingAcademyIds", academyIdsString);
+            
+            return RedirectToAction("IncomingTrustIdentified");
+        }
+
+        public IActionResult IncomingTrustIdentified()
+        {
+            return View();
         }
     }
 }

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using API.HttpHelpers;
 using API.Mapping;
 using API.Mapping.Request;
@@ -12,10 +9,8 @@ using API.Models.Upstream.Response;
 using API.ODataHelpers;
 using API.Repositories;
 using API.Repositories.Interfaces;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,15 +33,21 @@ namespace Frontend
             services.AddControllersWithViews().AddSessionStateTempDataProvider();
             services.Configure<RouteOptions>(options => { options.LowercaseUrls = true; });
 
-            services.AddSingleton(this.CreateHttpClient());
-            services.AddSingleton<IAuthenticatedHttpClient>(r => this.CreateHttpClient());
+            services.AddSingleton(CreateHttpClient());
+            services.AddSingleton<IAuthenticatedHttpClient>(r => CreateHttpClient());
             services.AddTransient<IMapper<GetTrustsD365Model, GetTrustsModel>, GetTrustsReponseMapper>();
 
             ConfigureRepositories(services);
             ConfigureHelpers(services);
             ConfigureMappers(services);
             
-            services.AddSession();
+            services.AddSession(options =>
+            {
+                options.IdleTimeout = TimeSpan.FromHours(24);
+                options.Cookie.Name = ".AcademyTransfers.Session";
+                options.Cookie.HttpOnly = true;
+                options.Cookie.IsEssential = true;
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Frontend/Views/Transfers/IncomingTrustIdentified.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrustIdentified.cshtml
@@ -1,0 +1,8 @@
+@* @model  *@
+
+@{
+    ViewBag.Title = "title";
+    Layout = "_Layout";
+}
+
+<h2>title</h2>

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -1,0 +1,36 @@
+@model Frontend.Views.Transfers.OutgoingTrustAcademies
+
+@{
+    ViewBag.Title = "title";
+    Layout = "_Layout";
+}
+<h1 class="govuk-heading-xl"></h1>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <form class="govuk-form" asp-action="SubmitOutgoingTrustAcademies" method="get">
+            <div class="govuk-form-group">
+
+                <fieldset class="govuk-fieldset" aria-describedby="add-academies-hint">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading">Add the transferring academies</h1>
+                    </legend>
+                    <div id="add-academies-hint" class="govuk-hint">
+                        Select all the academies that are transferring.
+                    </div>
+                    <div class="govuk-checkboxes">
+                        @foreach (var academy in Model.Academies)
+                        {
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="@academy.Id" name="academyIds" type="checkbox" value="@academy.Id">
+                                <label class="govuk-label govuk-checkboxes__label" for="@academy.Id">
+                                    @academy.AcademyName (URN @academy.Urn)
+                                </label>
+                            </div>
+                        }
+                    </div>
+                </fieldset>
+            </div>
+            <button class="govuk-button" type="submit">Save and continue</button>
+        </form>
+    </div>
+</div>

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml.cs
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using API.Models.Upstream.Response;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Frontend.Views.Transfers
+{
+    public class OutgoingTrustAcademies : PageModel
+    {
+        public List<GetAcademiesModel> Academies;
+    }
+}

--- a/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
@@ -36,6 +36,6 @@
                 </dd>
             </div>
         </dl>
-        <a class="govuk-button" href="meow" role="button" draggable="false">Select trust</a>
+        <a class="govuk-button" asp-action="ConfirmOutgoingTrust" asp-route-trustId="@Model.Trust.Id" role="button" draggable="false">Select trust</a>
     </div>
 </div>


### PR DESCRIPTION
- Add confirm outgoing trusts route
- Outgoing academies page
- Outgoing academies page

### Context

Part of the .NET rewrite of the Rails frontend adding in the page for selecting acadmies to be transfered

### Changes proposed in this pull request

- Add route for confirming the outgoing academy trust
- Add route for displaying the acadmies beloinging to the outgoing trust
- Add route to store the selected academies in the session

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

