### PR TITLE
Refactor projects & trusts repo

### DIFF
--- a/API.Tests/ControllersTests/AcademiesControllerTests.cs
+++ b/API.Tests/ControllersTests/AcademiesControllerTests.cs
@@ -1,6 +1,4 @@
 ﻿using API.Controllers;
-using API.Mapping;
-using API.Models.Downstream.D365;
 using API.Models.Upstream.Response;
 using API.Repositories;
 using API.Repositories.Interfaces;
@@ -34,8 +32,6 @@ namespace API.Tests.ControllersTests
                     }
                 });
 
-            var mapperMock = new Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>>();
-
             var errorHandler = new Mock<IRepositoryErrorResultHandler>();
 
             //Set up error handler to return a random result
@@ -60,8 +56,6 @@ namespace API.Tests.ControllersTests
                         r.Error.ErrorMessage == "Bad Request" &&
                         r.Error.StatusCode == HttpStatusCode.BadRequest)),
                 Times.Once);
-            //Mapper not to be called when repo fails
-            mapperMock.Verify(m => m.Map(It.IsAny<GetAcademiesD365Model>()), Times.Never);
 
             //Final result should be what the error handler returns
             Assert.Equal("Some error message", castedResult.Value);
@@ -82,7 +76,6 @@ namespace API.Tests.ControllersTests
                     Result = null
                 });
 
-            var mapperMock = new Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>>();
             var errorHandler = new Mock<IRepositoryErrorResultHandler>();
 
             var academiesController = new AcademiesController(academyRepoMock.Object,
@@ -96,9 +89,6 @@ namespace API.Tests.ControllersTests
 
             //Error handler should not be called when repo returns valid result
             errorHandler.Verify(h => h.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
-            //Mapper not to be called when repo returns null but valid result
-            mapperMock.Verify(m => m.Map(It.IsAny<GetAcademiesD365Model>()), Times.Never);
-
             //Final result should be a 404 - Not Found with the correct message
             Assert.Equal("The academy with the id: 'a16e9020-9123-4420-8055-851d1b672fa9' was not found",
                 castedResult.Value);

--- a/API.Tests/ControllersTests/ProjectsControllerTests.cs
+++ b/API.Tests/ControllersTests/ProjectsControllerTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net;
 using API.Controllers;
-using API.Models.Downstream.D365;
 using API.Models.Upstream.Enums;
 using API.Models.Upstream.Request;
 using API.Models.Upstream.Response;
@@ -922,7 +921,7 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to return a bad request
             _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                 {
                     Error = new RepositoryResultBase.RepositoryError
                     {
@@ -1001,11 +1000,11 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to all pass
             _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
             _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Execute
             var result = _subject.InsertProject(request);
@@ -1056,12 +1055,12 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to all pass
             _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Execute
             var result = _subject.InsertProject(request);
@@ -1123,12 +1122,12 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to all pass but one
             _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //This trust check will fail
             _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> {Result = null});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel> {Result = null});
 
             //Execute
             var result = _subject.InsertProject(request);
@@ -1189,7 +1188,7 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to all fail
             _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> {Result = null});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel> {Result = null});
 
             //Execute
             var result = _subject.InsertProject(request);
@@ -1241,8 +1240,8 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to all pass
             _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Set up project repository to return a bad request when inserting a project
             _projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostProjectsRequestModel>()))
@@ -1313,8 +1312,8 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to all pass
             _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Set up project repository to a valid set result when inserting a project
             _projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostProjectsRequestModel>()))
@@ -1391,8 +1390,8 @@ namespace API.Tests.ControllersTests
 
             //Set up the trust id checks to all pass
             _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
-                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+                .ReturnsAsync(new RepositoryResult<GetTrustsModel>
+                    {Result = new GetTrustsModel {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Set up project repository to a valid set result when inserting a project
             _projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostProjectsRequestModel>()))

--- a/API.Tests/ControllersTests/ProjectsControllerTests.cs
+++ b/API.Tests/ControllersTests/ProjectsControllerTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net;
 using API.Controllers;
-using API.Mapping;
 using API.Models.Downstream.D365;
 using API.Models.Upstream.Enums;
 using API.Models.Upstream.Request;
@@ -18,34 +17,23 @@ namespace API.Tests.ControllersTests
 {
     public class ProjectsControllerTests
     {
-        //These default mocks are passed to the constructor in tests for methods that don't use them
-        private readonly IProjectsRepository _projectsRepository;
-        private readonly IAcademiesRepository _academiesRepository;
-        private readonly ITrustsRepository _trustsRepository;
-        private readonly IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> _postProjectsMapper;
-        private readonly IMapper<GetProjectsD365Model, GetProjectsResponseModel> _getProjectsMapper;
-        private readonly IMapper<AcademyTransfersProjectAcademy,
-                                 GetProjectsAcademyResponseModel> _getProjectAcademyMapper;
-        private readonly IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model> _putProjectAcademiesMapper;
-        private readonly IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> _searchProjectsMapper;
-        private readonly IRepositoryErrorResultHandler _repositoryErrorHandler;
-        private readonly IConfiguration _config;
+        private readonly Mock<IProjectsRepository> _projectsRepository;
+        private readonly Mock<IAcademiesRepository> _academiesRepository;
+        private readonly Mock<ITrustsRepository> _trustsRepository;
+        private readonly Mock<IRepositoryErrorResultHandler> _repositoryErrorHandler;
+        private readonly ProjectsController _subject;
 
         public ProjectsControllerTests()
         {
-            _projectsRepository = new Mock<IProjectsRepository>().Object;
-            _academiesRepository = new Mock<IAcademiesRepository>().Object;
-            _trustsRepository = new Mock<ITrustsRepository>().Object;
+            _projectsRepository = new Mock<IProjectsRepository>();
+            _academiesRepository = new Mock<IAcademiesRepository>();
+            _trustsRepository = new Mock<ITrustsRepository>();
+            _repositoryErrorHandler = new Mock<IRepositoryErrorResultHandler>();
+            var config = new Mock<IConfiguration>();
 
-
-            _postProjectsMapper = new Mock<IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>>().Object;
-            _getProjectsMapper = new Mock<IMapper<GetProjectsD365Model, GetProjectsResponseModel>>().Object;
-            _getProjectAcademyMapper = new Mock<IMapper<AcademyTransfersProjectAcademy,
-                                 GetProjectsAcademyResponseModel>>().Object;
-            _putProjectAcademiesMapper = new Mock<IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>>().Object;
-            _searchProjectsMapper = new Mock<IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>>().Object;
-            _repositoryErrorHandler = new Mock<IRepositoryErrorResultHandler>().Object;
-            _config = new Mock<IConfiguration>().Object;
+            _subject = new ProjectsController(_projectsRepository.Object, _academiesRepository.Object,
+                _trustsRepository.Object,
+                _repositoryErrorHandler.Object, config.Object);
         }
 
         #region Search Projects Tests
@@ -53,52 +41,39 @@ namespace API.Tests.ControllersTests
         [Fact]
         public void SearchProjects_DefaultPaging_Test()
         {
-            //Arrange 
-            var projectRepository = new Mock<IProjectsRepository>();
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, _repositoryErrorHandler, _config);
-
-            //Execute
-            var result = controller.SearchProjects(string.Empty, ProjectStatusEnum.Completed, null, null, null);
+            _subject.SearchProjects(string.Empty, ProjectStatusEnum.Completed, null, null, null);
 
             //Assert that defaults are applied
-            projectRepository.Verify(p => p.SearchProject(string.Empty, Models.D365.Enums.ProjectStatusEnum.Completed, true, 10, 1), Times.Once);
+            _projectsRepository.Verify(
+                p => p.SearchProject(string.Empty, ProjectStatusEnum.Completed, true, 10, 1),
+                Times.Once);
         }
 
         [Fact]
         public void SearchProjects_InvalidPageSize_ReturnsBadRequest()
         {
-            //Arrange 
-            var controller = new ProjectsController(_projectsRepository, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, _repositoryErrorHandler, _config);
-
             //Execute
-            var result = controller.SearchProjects(string.Empty, ProjectStatusEnum.Completed, true, 0, 1);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.SearchProjects(string.Empty, ProjectStatusEnum.Completed, true, 0, 1);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a 400 Bad Request
-            Assert.Equal("Page size cannot be zero", (string)castedResult.Value);
+            Assert.Equal("Page size cannot be zero", (string) castedResult.Value);
             Assert.Equal(400, castedResult.StatusCode);
         }
 
         [Fact]
         public void SearchProjects_InvalidPageNumber_ReturnsBadRequest()
         {
-            //Arrange 
-            var controller = new ProjectsController(_projectsRepository, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, _repositoryErrorHandler, _config);
-
             //Execute
-            var result = controller.SearchProjects(string.Empty, ProjectStatusEnum.Completed, true, 1, 0);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.SearchProjects(string.Empty, ProjectStatusEnum.Completed, true, 1, 0);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a 400 Bad Request
-            Assert.Equal("Page number cannot be 0", (string)castedResult.Value);
+            Assert.Equal("Page number cannot be 0", (string) castedResult.Value);
             Assert.Equal(400, castedResult.StatusCode);
         }
 
@@ -108,37 +83,35 @@ namespace API.Tests.ControllersTests
             //Arrange 
 
             //Set up project repository to return a bad request
-            var projectRepoMock = new Mock<IProjectsRepository>();
-            projectRepoMock.Setup(r => r.SearchProject("searchQuery", Models.D365.Enums.ProjectStatusEnum.Completed, true, 10, 1))
-                           .ReturnsAsync(new RepositoryResult<SearchProjectsD365PageModel>
-                           {
-                               Error = new RepositoryResultBase.RepositoryError
-                               {
-                                   StatusCode = HttpStatusCode.BadRequest,
-                                   ErrorMessage = "Bad request error message"
-                               }
-                           });
+            _projectsRepository.Setup(r =>
+                    r.SearchProject("searchQuery", ProjectStatusEnum.Completed, true, 10, 1))
+                .ReturnsAsync(new RepositoryResult<SearchProjectsPageModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
-
-            var controller = new ProjectsController(projectRepoMock.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
 
             //Execute
-            var result = controller.SearchProjects("searchQuery", ProjectStatusEnum.Completed, true, 10, 1);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.SearchProjects("searchQuery", ProjectStatusEnum.Completed, true, 10, 1);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -148,51 +121,33 @@ namespace API.Tests.ControllersTests
             //Arrange 
 
             //Set up project repository to return a good request
-            var projectRepoMock = new Mock<IProjectsRepository>();
-            projectRepoMock.Setup(r => r.SearchProject("searchQuery", Models.D365.Enums.ProjectStatusEnum.Completed, true, 2, 1))
-                           .ReturnsAsync(new RepositoryResult<SearchProjectsD365PageModel>
-                           {
-                               Result = new SearchProjectsD365PageModel
-                               {
-                                   Projects = new List<SearchProjectsD365Model>
-                                   {
-                                       new SearchProjectsD365Model {ProjectName = "AT-10000"},
-                                       new SearchProjectsD365Model {ProjectName = "AT-10001"}
-                                   },
-                                   CurrentPage = 1,
-                                   TotalPages = 3
-                               }
-                           });
-
-            //Set up mapper to return slim mapped objecs
-            var mapper = new Mock<IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>>();
-            mapper.Setup(m => m.Map(It.Is<SearchProjectsD365PageModel>(s => s.CurrentPage == 1 && s.TotalPages == 3 && s.Projects.Count == 2)))
-                  .Returns(new SearchProjectsPageModel
-                  {
-                      Projects = new List<SearchProjectsModel>
-                                   {
-                                       new SearchProjectsModel {ProjectName = "Mapped AT-10000"},
-                                       new SearchProjectsModel{ProjectName = "Mapped AT-10001"}
-                                   },
-                      CurrentPage = 1,
-                      TotalPages = 3
-                  });
-
-
-            var controller = new ProjectsController(projectRepoMock.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, mapper.Object, _repositoryErrorHandler, _config);
+            _projectsRepository.Setup(r =>
+                    r.SearchProject("searchQuery", ProjectStatusEnum.Completed, true, 2, 1))
+                .ReturnsAsync(new RepositoryResult<SearchProjectsPageModel>
+                {
+                    Result = new SearchProjectsPageModel
+                    {
+                        Projects = new List<SearchProjectsModel>
+                        {
+                            new SearchProjectsModel {ProjectName = "AT-10000"},
+                            new SearchProjectsModel {ProjectName = "AT-10001"}
+                        },
+                        CurrentPage = 1,
+                        TotalPages = 3
+                    }
+                });
 
             //Execute
-            var result = controller.SearchProjects("searchQuery", ProjectStatusEnum.Completed, true, 2, 1);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.SearchProjects("searchQuery", ProjectStatusEnum.Completed, true, 2, 1);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a 200OK wrapped around what the mapper returns
-            Assert.Equal(1, ((SearchProjectsPageModel)castedResult.Value).CurrentPage);
-            Assert.Equal(3, ((SearchProjectsPageModel)castedResult.Value).TotalPages);
-            Assert.Equal(2, ((SearchProjectsPageModel)castedResult.Value).Projects.Count);
-            Assert.Equal("Mapped AT-10000", ((SearchProjectsPageModel)castedResult.Value).Projects[0].ProjectName);
+            Assert.Equal(1, ((SearchProjectsPageModel) castedResult.Value).CurrentPage);
+            Assert.Equal(3, ((SearchProjectsPageModel) castedResult.Value).TotalPages);
+            Assert.Equal(2, ((SearchProjectsPageModel) castedResult.Value).Projects.Count);
+            Assert.Equal("AT-10000", ((SearchProjectsPageModel) castedResult.Value).Projects[0].ProjectName);
             Assert.Equal(200, castedResult.StatusCode);
         }
 
@@ -207,36 +162,33 @@ namespace API.Tests.ControllersTests
             var projectId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000");
 
             //Set up project repository to return a bad request when getting a project by id
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Error = new RepositoryResultBase.RepositoryError
-                                 {
-                                     StatusCode = HttpStatusCode.BadRequest,
-                                     ErrorMessage = "Bad request error message"
-                                 }
-                             });
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.GetProjectById(projectId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectById(projectId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -247,29 +199,25 @@ namespace API.Tests.ControllersTests
             var projectId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000");
 
             //Set up project repository to return null when getting a project by id
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Result = null
-                             });
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Result = null
+                });
 
-            
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
 
             //Execute
-            var result = controller.GetProjectById(projectId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectById(projectId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Repository Error Handler result should not be called
-            repositoryErrorHandlerMock.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
+            _repositoryErrorHandler.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()),
+                Times.Never);
             //Final result should be 404 Not Found with the proper message
-            Assert.Equal("Project with id '00000003-0000-0ff1-ce00-000000000000' not found", (string)castedResult.Value);
+            Assert.Equal("Project with id '00000003-0000-0ff1-ce00-000000000000' not found",
+                (string) castedResult.Value);
             Assert.Equal(404, castedResult.StatusCode);
         }
 
@@ -279,38 +227,26 @@ namespace API.Tests.ControllersTests
             //Arrange
             var projectId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000");
 
-            //Set up project repository to return a valid set result
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Result = new GetProjectsD365Model
-                                 {
-                                     ProjectName = "AT-10000"
-                                 }
-                             });
-
-            //Set up mapper to return slim objects when called with the expected input
-            var projectMapper = new Mock<IMapper<GetProjectsD365Model, GetProjectsResponseModel>>();
-            projectMapper.Setup(m => m.Map(It.Is<GetProjectsD365Model>(p => p.ProjectName == "AT-10000")))
-                         .Returns(new GetProjectsResponseModel { ProjectName = "Mapped AT-10000" });
-                        
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, projectMapper.Object,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Result = new GetProjectsResponseModel
+                    {
+                        ProjectName = "AT-10000"
+                    }
+                });
 
             //Execute
-            var result = controller.GetProjectById(projectId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectById(projectId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Repository Error Handler result should not be called
-            repositoryErrorHandlerMock.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
+            _repositoryErrorHandler.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()),
+                Times.Never);
             //Final result should be 200 OK wrapped around the mapped result
-            Assert.Equal("Mapped AT-10000", ((GetProjectsResponseModel)castedResult.Value).ProjectName);
+            Assert.Equal("AT-10000", ((GetProjectsResponseModel) castedResult.Value).ProjectName);
             Assert.Equal(200, castedResult.StatusCode);
         }
 
@@ -327,39 +263,36 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
 
             //Set up project repository to return bad request when getting a project by id
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Error = new RepositoryResultBase.RepositoryError
-                                 {
-                                     StatusCode = HttpStatusCode.BadRequest,
-                                     ErrorMessage = "Bad request error message"
-                                 }
-                             });
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.GetProjectAcademy(projectId, projectAcademyId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectAcademy(projectId, projectAcademyId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
-
         }
+
 
         [Fact]
         public void GetProjectAcademyById_ProjectNotFound()
@@ -370,30 +303,26 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
 
             //Set up project repository to return an a null result
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Result = null
-                             });
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Result = null
+                });
 
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
 
             //Execute
-            var result = controller.GetProjectAcademy(projectId, projectAcademyId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectAcademy(projectId, projectAcademyId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Repository Error Handler result should not be called
-            repositoryErrorHandlerMock.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
+            _repositoryErrorHandler.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()),
+                Times.Never);
             //Final result should be a what the 404 Not Found with the correct message
-            Assert.Equal("Project with id '00000003-0000-0ff1-ce00-000000000000' not found", (string)castedResult.Value);
+            Assert.Equal("Project with id '00000003-0000-0ff1-ce00-000000000000' not found",
+                (string) castedResult.Value);
             Assert.Equal(404, castedResult.StatusCode);
-
         }
 
         [Fact]
@@ -405,43 +334,40 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
 
             //Set up project repository to return a valid set result
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Result = new GetProjectsD365Model { ProjectName = "AT-1000"}
-                             });
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Result = new GetProjectsResponseModel {ProjectName = "AT-1000"}
+                });
 
             //Set up project repo to return a failed result when getting the Project Academy by id
-            projectRepository.Setup(p => p.GetProjectAcademyById(projectAcademyId))
-                             .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                             {
-                                 Error = new RepositoryResultBase.RepositoryError
-                                 {
-                                     StatusCode = HttpStatusCode.BadRequest,
-                                     ErrorMessage = "Bad request error message"
-                                 }
-                             });
+            _projectsRepository.Setup(p => p.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.GetProjectAcademy(projectId, projectAcademyId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectAcademy(projectId, projectAcademyId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -454,35 +380,31 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
 
             //Set up project repository to return a valid set found project
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Result = new GetProjectsD365Model { ProjectName = "AT-1000" }
-                             });
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Result = new GetProjectsResponseModel {ProjectName = "AT-1000"}
+                });
 
             //Set up project repo to return a null result when getting the Project Academy by id
-            projectRepository.Setup(p => p.GetProjectAcademyById(projectAcademyId))
-                             .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                             {
-                                 Result = null
-                             });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _projectsRepository.Setup(p => p.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = null
+                });
 
             //Execute
-            var result = controller.GetProjectAcademy(projectId, projectAcademyId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectAcademy(projectId, projectAcademyId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Repository Error Handler result should not be called
-            repositoryErrorHandlerMock.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
+            _repositoryErrorHandler.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()),
+                Times.Never);
             //Final result should be a what the 404 Not Found with the correct message
-            Assert.Equal("Project Academy with id '00000003-0000-0ff1-ce00-000000000001' not found", (string)castedResult.Value);
+            Assert.Equal("Project Academy with id '00000003-0000-0ff1-ce00-000000000001' not found",
+                (string) castedResult.Value);
             Assert.Equal(404, castedResult.StatusCode);
         }
 
@@ -495,41 +417,30 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
 
             //Set up project repository to return a valid set result when getting the project by id
-            var projectRepository = new Mock<IProjectsRepository>();
-            projectRepository.Setup(p => p.GetProjectById(projectId))
-                             .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                             {
-                                 Result = new GetProjectsD365Model { ProjectName = "AT-1000" }
-                             });
+            _projectsRepository.Setup(p => p.GetProjectById(projectId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Result = new GetProjectsResponseModel {ProjectName = "AT-1000"}
+                });
 
             //Set up project repo to return a valid set result when getting the Project Academy by id
-            projectRepository.Setup(p => p.GetProjectAcademyById(projectAcademyId))
-                             .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                             {
-                                 Result = new AcademyTransfersProjectAcademy { AcademyName = "Project Academy 001"}
-                             });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            //Set up ProjectAcademy mapper to return slim result
-            var projectAcademyMapper = new Mock<IMapper<AcademyTransfersProjectAcademy,
-                                 GetProjectsAcademyResponseModel>>();
-
-            projectAcademyMapper.Setup(m => m.Map(It.Is<AcademyTransfersProjectAcademy>(a => a.AcademyName == "Project Academy 001")))
-                                .Returns(new GetProjectsAcademyResponseModel { AcademyName = "Mapped Project Academy 001" });
-
-            var controller = new ProjectsController(projectRepository.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                projectAcademyMapper.Object, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _projectsRepository.Setup(p => p.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel {AcademyName = "Project Academy 001"}
+                });
 
             //Execute
-            var result = controller.GetProjectAcademy(projectId, projectAcademyId);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.GetProjectAcademy(projectId, projectAcademyId);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
-            repositoryErrorHandlerMock.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
+            _repositoryErrorHandler.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()),
+                Times.Never);
             //Final result should be 200 OK wrapped around the mapped result
-            Assert.Equal("Mapped Project Academy 001", ((GetProjectsAcademyResponseModel)castedResult.Value).AcademyName);
+            Assert.Equal("Project Academy 001",
+                ((GetProjectsAcademyResponseModel) castedResult.Value).AcademyName);
             Assert.Equal(200, castedResult.StatusCode);
         }
 
@@ -546,37 +457,34 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
 
             //Set up project repository to return a bad request when looking for a ProjectAcademy by id
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Error = new RepositoryResultBase.RepositoryError
-                                     {
-                                         StatusCode = HttpStatusCode.BadRequest,
-                                         ErrorMessage = "Bad request error message"
-                                     }
-                                 });
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, null);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, null);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -589,28 +497,24 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
 
             //Set up project repository to return a null result when getting a ProjectAcademy by id
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Result = null
-                                 });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = null
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, null);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, null);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Repository Error Handler result should not be called
-            repositoryErrorHandlerMock.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
+            _repositoryErrorHandler.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()),
+                Times.Never);
             //Final result should be a 404 Not Found with the correct message
-            Assert.Equal("Project Academy with id '00000003-0000-0ff1-ce00-000000000001' not found", (string)castedResult.Value);
+            Assert.Equal("Project Academy with id '00000003-0000-0ff1-ce00-000000000001' not found",
+                (string) castedResult.Value);
             Assert.Equal(404, castedResult.StatusCode);
         }
 
@@ -624,28 +528,25 @@ namespace API.Tests.ControllersTests
             var mismatchingProjectId = Guid.Parse("00000003-0000-0ff1-ce00-000000000002");
 
             //Set up project repository to return a ProjectAcademy with a mismatching ProjectId
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Result = new AcademyTransfersProjectAcademy { ProjectId = mismatchingProjectId }
-                                 });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, _academiesRepository, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel {ProjectId = mismatchingProjectId}
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, null);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, null);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Repository Error Handler result should not be called
-            repositoryErrorHandlerMock.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
+            _repositoryErrorHandler.Verify(r => r.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()),
+                Times.Never);
             //Final result should be an Unprocessable Entity with the correct message
-            Assert.Equal("Project Academy with id '00000003-0000-0ff1-ce00-000000000001' not found within project with id '00000003-0000-0ff1-ce00-000000000000'", (string)castedResult.Value);
+            Assert.Equal(
+                "Project Academy with id '00000003-0000-0ff1-ce00-000000000001' not found within project with id '00000003-0000-0ff1-ce00-000000000000'",
+                (string) castedResult.Value);
             Assert.Equal(422, castedResult.StatusCode);
         }
 
@@ -658,48 +559,44 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
             var referencedAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000003");
 
-            var request = new PutProjectAcademiesRequestModel { AcademyId = referencedAcademyId };
+            var request = new PutProjectAcademiesRequestModel {AcademyId = referencedAcademyId};
 
             //Set up project repository to return a ProjectAcademy with a matching ProjectId
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Result = new AcademyTransfersProjectAcademy { ProjectId = projectId }
-                                 });
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel {ProjectId = projectId}
+                });
 
             //Set up the academies repository to return bad request when verifying the referenced academy
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(m => m.GetAcademyById(referencedAcademyId))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Error = new RepositoryResultBase.RepositoryError
-                                       {
-                                           StatusCode = HttpStatusCode.BadRequest,
-                                           ErrorMessage = "Bad request error message"
-                                       }
-                                   });
+            _academiesRepository.Setup(m => m.GetAcademyById(referencedAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, academiesRepositoryMock.Object, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -712,38 +609,30 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
             var referencedAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000003");
 
-            var request = new PutProjectAcademiesRequestModel { AcademyId = referencedAcademyId };
+            var request = new PutProjectAcademiesRequestModel {AcademyId = referencedAcademyId};
 
             //Set up project repository to return a ProjectAcademy with a matching ProjectId
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Result = new AcademyTransfersProjectAcademy { ProjectId = projectId }
-                                 });
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel {ProjectId = projectId}
+                });
 
             //Set up the academies repository to return a null result when verifying the referenced academy
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(m => m.GetAcademyById(referencedAcademyId))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = null
-                                   });
-
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, academiesRepositoryMock.Object, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _academiesRepository.Setup(m => m.GetAcademyById(referencedAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = null
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be an Unprocessable Entity
-            Assert.Equal($"No academy found with the id of: {referencedAcademyId}", (string)castedResult.Value);
+            Assert.Equal($"No academy found with the id of: {referencedAcademyId}", (string) castedResult.Value);
             Assert.Equal(422, castedResult.StatusCode);
         }
 
@@ -756,64 +645,54 @@ namespace API.Tests.ControllersTests
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
             var referencedAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000003");
 
-            var request = new PutProjectAcademiesRequestModel { AcademyId = referencedAcademyId };
+            var request = new PutProjectAcademiesRequestModel {AcademyId = referencedAcademyId};
 
             //Set up project repository to return a ProjectAcademy with a matching ProjectId
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Result = new AcademyTransfersProjectAcademy { ProjectId = projectId }
-                                 });
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel {ProjectId = projectId}
+                });
 
             //Set up the projects repository to fail when updating the Project Academy entity
-            projectRepositoryMock.Setup(r => r.UpdateProjectAcademy(It.IsAny<Guid>(), It.IsAny<PatchProjectAcademiesD365Model>()))
-                                 .ReturnsAsync(new RepositoryResult<Guid?>
-                                 {
-                                     Error = new RepositoryResultBase.RepositoryError
-                                     {
-                                         StatusCode = HttpStatusCode.BadRequest,
-                                         ErrorMessage = "Bad request error message"
-                                     }
-                                 });
+            _projectsRepository.Setup(r =>
+                    r.UpdateProjectAcademy(It.IsAny<Guid>(), It.IsAny<PutProjectAcademiesRequestModel>()))
+                .ReturnsAsync(new RepositoryResult<Guid?>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up the academies repository to return a null result when verifying the referenced academy
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(m => m.GetAcademyById(referencedAcademyId))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = referencedAcademyId }
-                                   });
-
-            //Set up the mapper to return a slimmed result
-            var putProjectAcademyMapper = new Mock<IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>>();
-            putProjectAcademyMapper.Setup(m => m.Map(It.Is<PutProjectAcademiesRequestModel>(p => p.AcademyId == referencedAcademyId)))
-                                   .Returns(new PatchProjectAcademiesD365Model { AcademyId = referencedAcademyId.ToString() });
-
-            
+            _academiesRepository.Setup(m => m.GetAcademyById(referencedAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = referencedAcademyId}
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, academiesRepositoryMock.Object, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, putProjectAcademyMapper.Object, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
+
 
         [Fact]
         public void UpdateProjectAcademy_UpdateSucceeds_WhenRefreshingProjectAcademy_RepositoryFailure()
@@ -826,68 +705,58 @@ namespace API.Tests.ControllersTests
             //Using this alternative Id to mock up the responses so that the second call to get ProjectAcademy by id fails
             var alternativeProjectAcademyIdForFailingRepo = Guid.Parse("00000003-0000-0ff1-ce00-000000000004");
 
-            var request = new PutProjectAcademiesRequestModel { AcademyId = referencedAcademyId };
+            var request = new PutProjectAcademiesRequestModel {AcademyId = referencedAcademyId};
 
             //Set up project repository to return a ProjectAcademy with a matching ProjectId
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Result = new AcademyTransfersProjectAcademy { ProjectId = projectId }
-                                 });
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel {ProjectId = projectId}
+                });
 
             //Set up project repository to fail when refreshing the ProjectAcademy entity
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(alternativeProjectAcademyIdForFailingRepo))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Error = new RepositoryResultBase.RepositoryError
-                                     {
-                                         StatusCode = HttpStatusCode.BadRequest,
-                                         ErrorMessage = "Bad request error message"
-                                     }
-                                 });
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(alternativeProjectAcademyIdForFailingRepo))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up the projects repository to return a valid set result when updating the entity
-            projectRepositoryMock.Setup(r => r.UpdateProjectAcademy(It.IsAny<Guid>(), It.IsAny<PatchProjectAcademiesD365Model>()))
-                                 .ReturnsAsync(new RepositoryResult<Guid?>
-                                 {
-                                     Result = alternativeProjectAcademyIdForFailingRepo
-                                 });
+            _projectsRepository.Setup(r =>
+                    r.UpdateProjectAcademy(It.IsAny<Guid>(), It.IsAny<PutProjectAcademiesRequestModel>()))
+                .ReturnsAsync(new RepositoryResult<Guid?>
+                {
+                    Result = alternativeProjectAcademyIdForFailingRepo
+                });
 
             //Set up the academies repository to return a null result when verifying the referenced academy
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(m => m.GetAcademyById(referencedAcademyId))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = referencedAcademyId }
-                                   });
-
-            //Set up the mapper to return a slimmed result
-            var putProjectAcademyMapper = new Mock<IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>>();
-            putProjectAcademyMapper.Setup(m => m.Map(It.Is<PutProjectAcademiesRequestModel>(p => p.AcademyId == referencedAcademyId)))
-                                   .Returns(new PatchProjectAcademiesD365Model { AcademyId = referencedAcademyId.ToString() });
-
+            _academiesRepository.Setup(m => m.GetAcademyById(referencedAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = referencedAcademyId}
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, academiesRepositoryMock.Object, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                _getProjectAcademyMapper, putProjectAcademyMapper.Object, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -898,66 +767,58 @@ namespace API.Tests.ControllersTests
 
             var projectId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000");
             var projectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000001");
+            var updatedProjectAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000002");
             var referencedAcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000003");
 
-            var request = new PutProjectAcademiesRequestModel { AcademyId = referencedAcademyId };
+            var request = new PutProjectAcademiesRequestModel {AcademyId = referencedAcademyId};
 
             //Set up project repository to return a ProjectAcademy with a matching ProjectId
-            var projectRepositoryMock = new Mock<IProjectsRepository>();
-            projectRepositoryMock.Setup(r => r.GetProjectAcademyById(projectAcademyId))
-                                 .ReturnsAsync(new RepositoryResult<AcademyTransfersProjectAcademy>
-                                 {
-                                     Result = new AcademyTransfersProjectAcademy { ProjectId = projectId }
-                                 });
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(projectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel {ProjectId = projectId}
+                });
 
 
             //Set up the projects repository to return a valid set result when updating the entity
-            projectRepositoryMock.Setup(r => r.UpdateProjectAcademy(It.IsAny<Guid>(), It.IsAny<PatchProjectAcademiesD365Model>()))
-                                 .ReturnsAsync(new RepositoryResult<Guid?>
-                                 {
-                                     Result = projectAcademyId
-                                 });
+            _projectsRepository.Setup(r =>
+                    r.UpdateProjectAcademy(It.IsAny<Guid>(), It.IsAny<PutProjectAcademiesRequestModel>()))
+                .ReturnsAsync(new RepositoryResult<Guid?>
+                {
+                    Result = updatedProjectAcademyId
+                });
 
             //Set up the academies repository to return a valid set result when verifying the referenced academy
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(m => m.GetAcademyById(referencedAcademyId))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = referencedAcademyId }
-                                   });
+            _academiesRepository.Setup(m => m.GetAcademyById(referencedAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = referencedAcademyId}
+                });
 
-            //Set up the mapper to return a slimmed result
-            var putProjectAcademyMapper = new Mock<IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>>();
-            putProjectAcademyMapper.Setup(m => m.Map(It.Is<PutProjectAcademiesRequestModel>(p => p.AcademyId == referencedAcademyId)))
-                                   .Returns(new PatchProjectAcademiesD365Model { AcademyId = referencedAcademyId.ToString() });
-
-
+            _projectsRepository.Setup(r => r.GetProjectAcademyById(updatedProjectAcademyId))
+                .ReturnsAsync(new RepositoryResult<GetProjectsAcademyResponseModel>
+                {
+                    Result = new GetProjectsAcademyResponseModel
+                        {ProjectId = projectId, ProjectAcademyId = projectAcademyId}
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            //Set up mapper to return final result back
-            var getProjectAcademyMapper = new Mock<IMapper<AcademyTransfersProjectAcademy,
-                                 GetProjectsAcademyResponseModel>>();
-            getProjectAcademyMapper.Setup(m => m.Map(It.Is<AcademyTransfersProjectAcademy>(a => a.ProjectId == projectId)))
-                                   .Returns(new GetProjectsAcademyResponseModel { ProjectAcademyId = projectAcademyId });
-
-            var controller = new ProjectsController(projectRepositoryMock.Object, academiesRepositoryMock.Object, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-                getProjectAcademyMapper.Object, putProjectAcademyMapper.Object, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.UpdateProjectAcademy(projectId, projectAcademyId, request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.UpdateProjectAcademy(projectId, projectAcademyId, request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a 200 OK wrapped around the output of the final mapper
-            Assert.Equal(projectAcademyId, ((GetProjectsAcademyResponseModel)castedResult.Value).ProjectAcademyId);
+            Assert.Equal(projectAcademyId, ((GetProjectsAcademyResponseModel) castedResult.Value).ProjectAcademyId);
             Assert.Equal(200, castedResult.StatusCode);
         }
 
@@ -975,14 +836,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    } 
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -992,36 +855,33 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy id checks to return a bad request
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Error = new RepositoryResultBase.RepositoryError
-                                       {
-                                           StatusCode = HttpStatusCode.BadRequest,
-                                           ErrorMessage = "Bad request error message"
-                                       }
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(_projectsRepository, academiesRepositoryMock.Object, _trustsRepository, _postProjectsMapper, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -1035,14 +895,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1052,45 +914,41 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy checks to all return a valid and set result
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel()
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel()
+                });
 
             //Set up the trust id checks to return a bad request
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> 
-                            {
-                                Error = new RepositoryResultBase.RepositoryError
-                                {
-                                    StatusCode = HttpStatusCode.BadRequest,
-                                    ErrorMessage = "Bad request error message"
-                                }
-                            });
+            _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(_projectsRepository, academiesRepositoryMock.Object, trustsRepository.Object, _postProjectsMapper, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -1104,14 +962,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1121,45 +981,41 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy id checks to all pass but one
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("00000003-0000-0ff1-ce00-000000000000")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("00000003-0000-0ff1-ce00-000000000000")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
+                });
 
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("10000003-0000-0ff1-ce00-000000000001")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000") }
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("10000003-0000-0ff1-ce00-000000000001")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
+                });
             //This is the one academy that won't be found
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("20000003-0000-0ff1-ce00-000000000002")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = null 
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("20000003-0000-0ff1-ce00-000000000002")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = null
+                });
 
             //Set up the trust id checks to all pass
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
-            trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(_projectsRepository, academiesRepositoryMock.Object, trustsRepository.Object, _postProjectsMapper, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
+            _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be an Unprocessable Entity
-            Assert.Equal("No academy found with the id of: 20000003-0000-0ff1-ce00-000000000002", (string)castedResult.Value);
+            Assert.Equal("No academy found with the id of: 20000003-0000-0ff1-ce00-000000000002",
+                (string) castedResult.Value);
             Assert.Equal(422, castedResult.StatusCode);
         }
 
@@ -1173,14 +1029,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1189,37 +1047,32 @@ namespace API.Tests.ControllersTests
                 }
             };
 
-            //Set up academy id checks to all pass but one
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-
             //All academies will fail
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = null
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = null
+                });
 
             //Set up the trust id checks to all pass
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
+            _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
-            trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(_projectsRepository, academiesRepositoryMock.Object, trustsRepository.Object, _postProjectsMapper, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be an Unprocessable Entity
-            Assert.Equal("No academy found with the id of: 00000003-0000-0ff1-ce00-000000000000. No academy found with the id of: 10000003-0000-0ff1-ce00-000000000001. No academy found with the id of: 20000003-0000-0ff1-ce00-000000000002", (string)castedResult.Value);
+            Assert.Equal(
+                "No academy found with the id of: 00000003-0000-0ff1-ce00-000000000000. No academy found with the id of: 10000003-0000-0ff1-ce00-000000000001. No academy found with the id of: 20000003-0000-0ff1-ce00-000000000002",
+                (string) castedResult.Value);
             Assert.Equal(422, castedResult.StatusCode);
         }
 
@@ -1233,14 +1086,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1250,45 +1105,40 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy id checks to all pass
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("00000003-0000-0ff1-ce00-000000000000")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000") }
-                                   });
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("10000003-0000-0ff1-ce00-000000000001")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("10000003-0000-0ff1-ce00-000000000001") }
-                                   });
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("20000003-0000-0ff1-ce00-000000000002")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("20000003-0000-0ff1-ce00-000000000002") }
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("00000003-0000-0ff1-ce00-000000000000")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
+                });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("10000003-0000-0ff1-ce00-000000000001")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")}
+                });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("20000003-0000-0ff1-ce00-000000000002")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("20000003-0000-0ff1-ce00-000000000002")}
+                });
 
             //Set up the trust id checks to all pass but one
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
+            _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("30000003-0000-0ff1-ce00-000000000003")))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //This trust check will fail
-            trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = null });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(_projectsRepository, academiesRepositoryMock.Object, trustsRepository.Object, _postProjectsMapper, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _trustsRepository.Setup(r => r.GetTrustById(Guid.Parse("40000003-0000-0ff1-ce00-000000000004")))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> {Result = null});
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be an Unprocessable Entity
-            Assert.Equal("No trust found with the id of: 40000003-0000-0ff1-ce00-000000000004", (string)castedResult.Value);
+            Assert.Equal("No trust found with the id of: 40000003-0000-0ff1-ce00-000000000004",
+                (string) castedResult.Value);
             Assert.Equal(422, castedResult.StatusCode);
         }
 
@@ -1302,14 +1152,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1319,41 +1171,36 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy id checks to all pass
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("00000003-0000-0ff1-ce00-000000000000")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000") }
-                                   });
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("10000003-0000-0ff1-ce00-000000000001")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("10000003-0000-0ff1-ce00-000000000001") }
-                                   });
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(Guid.Parse("20000003-0000-0ff1-ce00-000000000002")))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("20000003-0000-0ff1-ce00-000000000002") }
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("00000003-0000-0ff1-ce00-000000000000")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
+                });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("10000003-0000-0ff1-ce00-000000000001")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")}
+                });
+            _academiesRepository.Setup(r => r.GetAcademyById(Guid.Parse("20000003-0000-0ff1-ce00-000000000002")))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("20000003-0000-0ff1-ce00-000000000002")}
+                });
 
             //Set up the trust id checks to all fail
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = null });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(_projectsRepository, academiesRepositoryMock.Object, trustsRepository.Object, _postProjectsMapper, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> {Result = null});
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be an Unprocessable Entity with the trust messages concatenated
-            Assert.Equal("No trust found with the id of: 30000003-0000-0ff1-ce00-000000000003. No trust found with the id of: 40000003-0000-0ff1-ce00-000000000004", (string)castedResult.Value);
+            Assert.Equal(
+                "No trust found with the id of: 30000003-0000-0ff1-ce00-000000000003. No trust found with the id of: 40000003-0000-0ff1-ce00-000000000004",
+                (string) castedResult.Value);
             Assert.Equal(422, castedResult.StatusCode);
         }
 
@@ -1367,14 +1214,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1384,58 +1233,46 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy id checks to all pass
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000") }
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
+                });
 
             //Set up the trust id checks to all pass
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
-
-            //Set up mapper to return a slim mock result
-            var postProjectsMapper = new Mock<IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>>();
-            postProjectsMapper.Setup(m => m.Map(It.IsAny<PostProjectsRequestModel>()))
-                              .Returns(new PostAcademyTransfersProjectsD365Model
-                              {
-                                  ProjectInitiatorFullName = "Joe Bloggs"
-                              });
+            _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Set up project repository to return a bad request when inserting a project
-            var projectsRepository = new Mock<IProjectsRepository>();
-            projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostAcademyTransfersProjectsD365Model>()))
-                              .ReturnsAsync(new RepositoryResult<Guid?>
-                              {
-                                  Error = new RepositoryResultBase.RepositoryError
-                                  {
-                                      StatusCode = HttpStatusCode.BadRequest,
-                                      ErrorMessage = "Bad request error message"
-                                  }
-                              });
+            _projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostProjectsRequestModel>()))
+                .ReturnsAsync(new RepositoryResult<Guid?>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(projectsRepository.Object, academiesRepositoryMock.Object, trustsRepository.Object, postProjectsMapper.Object, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -1449,14 +1286,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1466,65 +1305,52 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy id checks to all pass
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000") }
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
+                });
 
             //Set up the trust id checks to all pass
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
-
-            //Set up mapper to return a slim mock result
-            var postProjectsMapper = new Mock<IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>>();
-            postProjectsMapper.Setup(m => m.Map(It.IsAny<PostProjectsRequestModel>()))
-                              .Returns(new PostAcademyTransfersProjectsD365Model
-                              {
-                                  ProjectInitiatorFullName = "Joe Bloggs"
-                              });
-
+            _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Set up project repository to a valid set result when inserting a project
-            var projectsRepository = new Mock<IProjectsRepository>();
-            projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostAcademyTransfersProjectsD365Model>()))
-                              .ReturnsAsync(new RepositoryResult<Guid?>
-                              {
-                                  Result = Guid.Parse("40000003-0000-0ff1-ce00-000000000004")
-                              });
+            _projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostProjectsRequestModel>()))
+                .ReturnsAsync(new RepositoryResult<Guid?>
+                {
+                    Result = Guid.Parse("40000003-0000-0ff1-ce00-000000000004")
+                });
 
             //Set up project repo to fail when obtaining the full project from the repo
-            projectsRepository.Setup(r => r.GetProjectById(It.IsAny<Guid>()))
-                              .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                              {
-                                  Error = new RepositoryResultBase.RepositoryError
-                                  {
-                                      StatusCode = HttpStatusCode.BadRequest,
-                                      ErrorMessage = "Bad request error message"
-                                  }
-                              });
+            _projectsRepository.Setup(r => r.GetProjectById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        ErrorMessage = "Bad request error message"
+                    }
+                });
 
             //Set up repository error handler to handle the bad request result described above
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-            repositoryErrorHandlerMock.Setup(h => h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e => e.Error.StatusCode == HttpStatusCode.BadRequest)))
-                                      .Returns(new ObjectResult("Some error message")
-                                      {
-                                          StatusCode = 499
-                                      });
-
-            var controller = new ProjectsController(projectsRepository.Object, academiesRepositoryMock.Object, trustsRepository.Object, postProjectsMapper.Object, _getProjectsMapper,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _repositoryErrorHandler.Setup(h =>
+                    h.LogAndCreateResponse(It.Is<RepositoryResultBase>(e =>
+                        e.Error.StatusCode == HttpStatusCode.BadRequest)))
+                .Returns(new ObjectResult("Some error message")
+                {
+                    StatusCode = 499
+                });
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be what the Error Handler returns
-            Assert.Equal("Some error message", (string)castedResult.Value);
+            Assert.Equal("Some error message", (string) castedResult.Value);
             Assert.Equal(499, castedResult.StatusCode);
         }
 
@@ -1538,14 +1364,16 @@ namespace API.Tests.ControllersTests
                 {
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")},
                     new PostProjectsAcademiesModel {AcademyId = Guid.Parse("10000003-0000-0ff1-ce00-000000000001")},
-                    new PostProjectsAcademiesModel {AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
-                                                    Trusts = new List<PostProjectsAcademiesTrustsModel>
-                                                    {
-                                                        new PostProjectsAcademiesTrustsModel
-                                                        {
-                                                            TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
-                                                        }
-                                                    }
+                    new PostProjectsAcademiesModel
+                    {
+                        AcademyId = Guid.Parse("20000003-0000-0ff1-ce00-000000000002"),
+                        Trusts = new List<PostProjectsAcademiesTrustsModel>
+                        {
+                            new PostProjectsAcademiesTrustsModel
+                            {
+                                TrustId = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")
+                            }
+                        }
                     }
                 },
                 ProjectTrusts = new List<PostProjectsTrustsModel>
@@ -1555,64 +1383,44 @@ namespace API.Tests.ControllersTests
             };
 
             //Set up academy id checks to all pass
-            var academiesRepositoryMock = new Mock<IAcademiesRepository>();
-            academiesRepositoryMock.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
-                                   .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
-                                   {
-                                       Result = new GetAcademiesModel { Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000") }
-                                   });
+            _academiesRepository.Setup(r => r.GetAcademyById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetAcademiesModel>
+                {
+                    Result = new GetAcademiesModel {Id = Guid.Parse("00000003-0000-0ff1-ce00-000000000000")}
+                });
 
             //Set up the trust id checks to all pass
-            var trustsRepository = new Mock<ITrustsRepository>();
-            trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
-                            .ReturnsAsync(new RepositoryResult<GetTrustsD365Model> { Result = new GetTrustsD365Model { Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003") } });
-
-            //Set up mapper to return a slim mock result
-            var postProjectsMapper = new Mock<IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>>();
-            postProjectsMapper.Setup(m => m.Map(It.IsAny<PostProjectsRequestModel>()))
-                              .Returns(new PostAcademyTransfersProjectsD365Model
-                              {
-                                  ProjectInitiatorFullName = "Joe Bloggs"
-                              });
-
+            _trustsRepository.Setup(r => r.GetTrustById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                    {Result = new GetTrustsD365Model {Id = Guid.Parse("30000003-0000-0ff1-ce00-000000000003")}});
 
             //Set up project repository to a valid set result when inserting a project
-            var projectsRepository = new Mock<IProjectsRepository>();
-            projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostAcademyTransfersProjectsD365Model>()))
-                              .ReturnsAsync(new RepositoryResult<Guid?>
-                              {
-                                  Result = Guid.Parse("40000003-0000-0ff1-ce00-000000000004")
-                              });
+            _projectsRepository.Setup(r => r.InsertProject(It.IsAny<PostProjectsRequestModel>()))
+                .ReturnsAsync(new RepositoryResult<Guid?>
+                {
+                    Result = Guid.Parse("40000003-0000-0ff1-ce00-000000000004")
+                });
 
             //Set up project repo to fail when obtaining the full project from the repo
-            projectsRepository.Setup(r => r.GetProjectById(It.IsAny<Guid>()))
-                              .ReturnsAsync(new RepositoryResult<GetProjectsD365Model>
-                              {
-                                  Result = new GetProjectsD365Model { ProjectId = Guid.Parse("80000003-0000-0ff1-ce00-000000000008") }
-                              });
-
-            //Set up get projects mapper to return mock slim object
-            var getProjectAcademyMapper = new Mock<IMapper<GetProjectsD365Model, GetProjectsResponseModel>>();
-            getProjectAcademyMapper.Setup(m => m.Map(It.IsAny<GetProjectsD365Model>()))
-                                   .Returns(new GetProjectsResponseModel { ProjectId = Guid.Parse("80000003-0000-0ff1-ce00-000000000008") });
-
-            var repositoryErrorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
-
-            var controller = new ProjectsController(projectsRepository.Object, academiesRepositoryMock.Object, trustsRepository.Object, postProjectsMapper.Object, getProjectAcademyMapper.Object,
-               _getProjectAcademyMapper, _putProjectAcademiesMapper, _searchProjectsMapper, repositoryErrorHandlerMock.Object, _config);
+            _projectsRepository.Setup(r => r.GetProjectById(It.IsAny<Guid>()))
+                .ReturnsAsync(new RepositoryResult<GetProjectsResponseModel>
+                {
+                    Result = new GetProjectsResponseModel
+                        {ProjectId = Guid.Parse("80000003-0000-0ff1-ce00-000000000008")}
+                });
 
             //Execute
-            var result = controller.InsertProject(request);
-            var castedResult = (ObjectResult)result.Result;
+            var result = _subject.InsertProject(request);
+            var castedResult = (ObjectResult) result.Result;
 
             //Assert
 
             //Final result should be a 200OK wrapped around what the final mapper returns
-            Assert.Equal(Guid.Parse("80000003-0000-0ff1-ce00-000000000008"), ((GetProjectsResponseModel)castedResult.Value).ProjectId);
+            Assert.Equal(Guid.Parse("80000003-0000-0ff1-ce00-000000000008"),
+                ((GetProjectsResponseModel) castedResult.Value).ProjectId);
             Assert.Equal(201, castedResult.StatusCode);
         }
 
         #endregion
-
     }
 }

--- a/API.Tests/ControllersTests/TrustsControllerTests.cs
+++ b/API.Tests/ControllersTests/TrustsControllerTests.cs
@@ -42,7 +42,7 @@ namespace API.Tests.ControllersTests
             //Set up trusts repo to return a failure
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
                               Error = new RepositoryResultBase.RepositoryError
                               {
@@ -63,7 +63,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
 
@@ -96,7 +95,7 @@ namespace API.Tests.ControllersTests
             //Set up mock repository to return a null result (not found)
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
                               Result = null
                           });
@@ -106,7 +105,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
 
@@ -135,29 +133,18 @@ namespace API.Tests.ControllersTests
             //Set up mock repository to return a valid and set result
             var trustsRepoMock = new Mock<ITrustsRepository>(); 
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
-                              Result = new GetTrustsD365Model
+                              Result = new GetTrustsModel
                               {
                                   Id = trustId
                               }
                           });
 
-            var mapperMock = new Mock<IMapper<GetTrustsD365Model, GetTrustsModel>>();
-
-            //Set up mapper to return a slim result when called with the expected input
-            mapperMock.Setup(m => m.Map(It.Is<GetTrustsD365Model>(p => p.Id == trustId)))
-                      .Returns(new GetTrustsModel
-                      {
-                          Id = trustId,
-                          Address = "Some address"
-                      });
-
             var errorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
 
@@ -169,12 +156,8 @@ namespace API.Tests.ControllersTests
 
             //Error handler should not be called when repo returns valid result
             errorHandlerMock.Verify(h => h.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
-            //Mapper to be called once with the expected input
-            mapperMock.Verify(m => m.Map(It.Is<GetTrustsD365Model>(p => p.Id == trustId)), Times.Once);
-
             //Final result should be a 200 OK with the result of the mapping operation
             Assert.Equal(trustId, ((GetTrustsModel)castedResult.Value).Id);
-            Assert.Equal("Some address", ((GetTrustsModel)castedResult.Value).Address);
             Assert.Equal(200, castedResult.StatusCode);
         }
 
@@ -190,7 +173,7 @@ namespace API.Tests.ControllersTests
             //Set up mock repository to return a failed D365 call
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.SearchTrusts(searchTerm))
-                           .ReturnsAsync(new RepositoryResult<List<GetTrustsD365Model>>
+                           .ReturnsAsync(new RepositoryResult<List<GetTrustsModel>>
                            {
                                Error = new RepositoryResultBase.RepositoryError
                                {
@@ -211,7 +194,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
             //Execute
@@ -242,7 +224,7 @@ namespace API.Tests.ControllersTests
             //Set up mock repository to return a failed D365 call
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.SearchTrusts(searchTerm))
-                           .ReturnsAsync(new RepositoryResult<List<GetTrustsD365Model>>
+                           .ReturnsAsync(new RepositoryResult<List<GetTrustsModel>>
                            {
                                Result = null
                            });
@@ -252,7 +234,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
             //Execute
@@ -279,32 +260,20 @@ namespace API.Tests.ControllersTests
             //Set up mock repository to return a failed D365 call
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.SearchTrusts(searchTerm))
-                           .ReturnsAsync(new RepositoryResult<List<GetTrustsD365Model>>
+                           .ReturnsAsync(new RepositoryResult<List<GetTrustsModel>>
                            {
-                               Result = new List<GetTrustsD365Model>
+                               Result = new List<GetTrustsModel>
                                {
-                                   new GetTrustsD365Model { TrustName = "Trust 001" },
-                                   new GetTrustsD365Model { TrustName = "Trust 002" },
-                                   new GetTrustsD365Model { TrustName = "Trust 003" }
+                                   new GetTrustsModel { TrustName = "Trust 001" },
+                                   new GetTrustsModel { TrustName = "Trust 002" },
+                                   new GetTrustsModel { TrustName = "Trust 003" }
                                }
                            });
-
-            //Set up mock mapper to return slim models
-            var mapperMock = new Mock<IMapper<GetTrustsD365Model, GetTrustsModel>>();
-            mapperMock.Setup(m => m.Map(It.Is<GetTrustsD365Model>(t => t.TrustName == "Trust 001")))
-                      .Returns(new GetTrustsModel { TrustName = "Mapped Trust 001" });
-
-            mapperMock.Setup(m => m.Map(It.Is<GetTrustsD365Model>(t => t.TrustName == "Trust 002")))
-                      .Returns(new GetTrustsModel { TrustName = "Mapped Trust 002" });
-
-            mapperMock.Setup(m => m.Map(It.Is<GetTrustsD365Model>(t => t.TrustName == "Trust 003")))
-                      .Returns(new GetTrustsModel { TrustName = "Mapped Trust 003" });
 
             var errorHandlerMock = new Mock<IRepositoryErrorResultHandler>();
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
             //Execute
@@ -315,14 +284,12 @@ namespace API.Tests.ControllersTests
 
             //Error handler should not be called when repo returns valid result
             errorHandlerMock.Verify(h => h.LogAndCreateResponse(It.IsAny<RepositoryResultBase>()), Times.Never);
-            //Mapper to be called three times, once for each result
-            mapperMock.Verify(m => m.Map(It.IsAny<GetTrustsD365Model>()), Times.Exactly(3));
 
             //Final result should be a 200OK wrapped around a a list with three results
             Assert.Equal(3, ((List<GetTrustsModel>)castedResult.Value).Count);
-            Assert.Equal("Mapped Trust 001", ((List<GetTrustsModel>)castedResult.Value)[0].TrustName);
-            Assert.Equal("Mapped Trust 002", ((List<GetTrustsModel>)castedResult.Value)[1].TrustName);
-            Assert.Equal("Mapped Trust 003", ((List<GetTrustsModel>)castedResult.Value)[2].TrustName);
+            Assert.Equal("Trust 001", ((List<GetTrustsModel>)castedResult.Value)[0].TrustName);
+            Assert.Equal("Trust 002", ((List<GetTrustsModel>)castedResult.Value)[1].TrustName);
+            Assert.Equal("Trust 003", ((List<GetTrustsModel>)castedResult.Value)[2].TrustName);
             Assert.Equal(200, castedResult.StatusCode);
         }
 
@@ -339,7 +306,7 @@ namespace API.Tests.ControllersTests
             //Set up trusts repo to return a failure
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
                               Error = new RepositoryResultBase.RepositoryError
                               {
@@ -360,7 +327,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
 
@@ -393,7 +359,7 @@ namespace API.Tests.ControllersTests
             //Set up mock trust repository to return a null result (not found)
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
                               Result = null
                           });
@@ -403,7 +369,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         _academiesRepository.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
 
@@ -432,9 +397,9 @@ namespace API.Tests.ControllersTests
             //Set up mock trust repository to return a valid and set result
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
-                              Result = new GetTrustsD365Model
+                              Result = new GetTrustsModel
                               {
                                   Id = trustId
                               }
@@ -472,7 +437,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         academiesRepoMock.Object,
-                                                        mapperMock.Object,
                                                         errorHandlerMock.Object);
 
 
@@ -498,9 +462,9 @@ namespace API.Tests.ControllersTests
             //Set up mock trust repository to return a valid and set result
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
-                              Result = new GetTrustsD365Model
+                              Result = new GetTrustsModel
                               {
                                   Id = trustId
                               }
@@ -519,7 +483,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         academiesRepoMock.Object,
-                                                        _getTrustMapper.Object,
                                                         errorHandlerMock.Object);
 
 
@@ -548,9 +511,9 @@ namespace API.Tests.ControllersTests
             //Set up mock trust repository to return a valid and set result
             var trustsRepoMock = new Mock<ITrustsRepository>();
             trustsRepoMock.Setup(m => m.GetTrustById(trustId))
-                          .ReturnsAsync(new RepositoryResult<GetTrustsD365Model>
+                          .ReturnsAsync(new RepositoryResult<GetTrustsModel>
                           {
-                              Result = new GetTrustsD365Model
+                              Result = new GetTrustsModel
                               {
                                   Id = trustId
                               }
@@ -572,7 +535,6 @@ namespace API.Tests.ControllersTests
 
             var trustsController = new TrustsController(trustsRepoMock.Object,
                                                         academiesRepoMock.Object,
-                                                        _getTrustMapper.Object,
                                                         errorHandlerMock.Object);
 
 

--- a/API.Tests/RepositoriesTests/TrustsRepositoryTests.cs
+++ b/API.Tests/RepositoriesTests/TrustsRepositoryTests.cs
@@ -9,12 +9,31 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using API.Mapping;
+using API.Models.Upstream.Response;
 using Xunit;
 
 namespace API.Tests.RepositoriesTests
 {
     public class TrustsRepositoryTests
     {
+        private readonly TrustsRepository _subject;
+        private readonly Mock<IOdataUrlBuilder<GetTrustsD365Model>> _mockUrlBuilder;
+        private readonly Mock<IAuthenticatedHttpClient> _mockClient;
+        private readonly Mock<IMapper<GetTrustsD365Model, GetTrustsModel>> _getTrustMapper;
+
+        public TrustsRepositoryTests()
+        {
+            _mockClient = new Mock<IAuthenticatedHttpClient>();
+            _mockUrlBuilder = new Mock<IOdataUrlBuilder<GetTrustsD365Model>>();
+            _getTrustMapper = new Mock<IMapper<GetTrustsD365Model, GetTrustsModel>>();
+            var mockedLogger = new Mock<ILogger<TrustsRepository>>();
+            var mockSanitizer = new Mock<IODataSanitizer>();
+
+            _subject = new TrustsRepository(_mockClient.Object, _mockUrlBuilder.Object, mockSanitizer.Object,
+                mockedLogger.Object, _getTrustMapper.Object);
+        }
+
         [Fact]
         public async void GetTrustById_FailedHttpClientCall_ReturnsFailedResult()
         {
@@ -26,25 +45,18 @@ namespace API.Tests.RepositoriesTests
                 StatusCode = HttpStatusCode.BadRequest,
                 Content = new StringContent("Error - Bad Request", Encoding.UTF8, "application/json")
             };
-            var mockClient = new Mock<IAuthenticatedHttpClient>();
-            mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
 
-            var mockedLogger = new Mock<ILogger<TrustsRepository>>();
+            _mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
 
-            var mockUrlBuilder = new Mock<IOdataUrlBuilder<GetTrustsD365Model>>();
-            mockUrlBuilder.Setup(m => m.BuildRetrieveOneUrl("accounts", It.IsAny<Guid>()))
-                          .Returns("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)");
-
-            var mockSanitizer = new Mock<IODataSanitizer>();
-
-            var academiesRepository = new TrustsRepository(mockClient.Object, mockUrlBuilder.Object, mockSanitizer.Object, mockedLogger.Object);
+            _mockUrlBuilder.Setup(m => m.BuildRetrieveOneUrl("accounts", It.IsAny<Guid>()))
+                .Returns("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)");
 
             //Execute
-            var result = await academiesRepository.GetTrustById(trustId);
+            var result = await _subject.GetTrustById(trustId);
 
             //Assert
-            mockUrlBuilder.Verify(m => m.BuildRetrieveOneUrl("accounts", trustId), Times.Once);
-            mockClient.Verify(m => m.GetAsync("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)"), Times.Once);
+            _mockUrlBuilder.Verify(m => m.BuildRetrieveOneUrl("accounts", trustId), Times.Once);
+            _mockClient.Verify(m => m.GetAsync("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)"), Times.Once);
 
             Assert.False(result.IsValid);
             Assert.Null(result.Result);
@@ -69,25 +81,16 @@ namespace API.Tests.RepositoriesTests
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
             };
 
-            var mockClient = new Mock<IAuthenticatedHttpClient>();
-            mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
-
-            var mockedLogger = new Mock<ILogger<TrustsRepository>>();
-
-            var mockUrlBuilder = new Mock<IOdataUrlBuilder<GetTrustsD365Model>>();
-            mockUrlBuilder.Setup(m => m.BuildRetrieveOneUrl("accounts", It.IsAny<Guid>()))
-                          .Returns("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)");
-
-            var mockSanitizer = new Mock<IODataSanitizer>();
-
-            var academiesRepository = new TrustsRepository(mockClient.Object, mockUrlBuilder.Object, mockSanitizer.Object, mockedLogger.Object);
+            _mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
+            _mockUrlBuilder.Setup(m => m.BuildRetrieveOneUrl("accounts", It.IsAny<Guid>()))
+                .Returns("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)");
 
             //Execute
-            var result = await academiesRepository.GetTrustById(trustId);
+            var result = await _subject.GetTrustById(trustId);
 
             //Assert
-            mockUrlBuilder.Verify(m => m.BuildRetrieveOneUrl("accounts", trustId), Times.Once);
-            mockClient.Verify(m => m.GetAsync("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)"), Times.Once);
+            _mockUrlBuilder.Verify(m => m.BuildRetrieveOneUrl("accounts", trustId), Times.Once);
+            _mockClient.Verify(m => m.GetAsync("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)"), Times.Once);
 
             Assert.True(result.IsValid);
             Assert.Null(result.Result);
@@ -112,62 +115,51 @@ namespace API.Tests.RepositoriesTests
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
             };
 
-            var mockClient = new Mock<IAuthenticatedHttpClient>();
-            mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
+            _mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
+            _mockUrlBuilder.Setup(m => m.BuildRetrieveOneUrl("accounts", It.IsAny<Guid>()))
+                .Returns("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)");
 
-            var mockedLogger = new Mock<ILogger<TrustsRepository>>();
-
-            var mockUrlBuilder = new Mock<IOdataUrlBuilder<GetTrustsD365Model>>();
-            mockUrlBuilder.Setup(m => m.BuildRetrieveOneUrl("accounts", It.IsAny<Guid>()))
-                          .Returns("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)");
-
-            var mockSanitizer = new Mock<IODataSanitizer>();
-
-            var academiesRepository = new TrustsRepository(mockClient.Object, mockUrlBuilder.Object, mockSanitizer.Object, mockedLogger.Object);
+            _getTrustMapper.Setup(m => m.Map(It.IsAny<GetTrustsD365Model>())).Returns(new GetTrustsModel
+            {
+                TrustName = "Mapped Trust",
+                TrustReferenceNumber = "Mapped TR100001"
+            });
 
             //Execute
-            var result = await academiesRepository.GetTrustById(trustId);
+            var result = await _subject.GetTrustById(trustId);
 
             //Assert
-            mockUrlBuilder.Verify(m => m.BuildRetrieveOneUrl("accounts", trustId), Times.Once);
-            mockClient.Verify(m => m.GetAsync("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)"), Times.Once);
+            _mockUrlBuilder.Verify(m => m.BuildRetrieveOneUrl("accounts", trustId), Times.Once);
+            _mockClient.Verify(m => m.GetAsync("/accounts(a16e9020-9123-4420-8055-851d1b672fb1)"), Times.Once);
 
             Assert.True(result.IsValid);
             Assert.NotNull(result.Result);
-            Assert.Equal("Some Trust", result.Result.TrustName);
-            Assert.Equal("TR100001", result.Result.TrustReferenceNumber);
+            Assert.Equal("Mapped Trust", result.Result.TrustName);
+            Assert.Equal("Mapped TR100001", result.Result.TrustReferenceNumber);
         }
 
         [Fact]
         public async void SearchTrusts_FailedHttpClientCall_ReturnsFailedResult()
         {
             //Arrange
-            var query = "searchQuery";
+            const string query = "searchQuery";
 
             HttpResponseMessage httpResponse = new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.BadRequest,
                 Content = new StringContent("Error - Bad Request", Encoding.UTF8, "application/json")
             };
-            var mockClient = new Mock<IAuthenticatedHttpClient>();
-            mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
 
-            var mockedLogger = new Mock<ILogger<TrustsRepository>>();
-            
-            Mock<IOdataUrlBuilder<GetTrustsD365Model>> mockUrlBuilder = new Mock<IOdataUrlBuilder<GetTrustsD365Model>>();
-            mockUrlBuilder.Setup(m => m.BuildFilterUrl("accounts", It.IsAny<List<string>>()))
-                          .Returns("buildFilterUrl");
-
-            var mockSanitizer = new Mock<IODataSanitizer>();
-
-            var academiesRepository = new TrustsRepository(mockClient.Object, mockUrlBuilder.Object, mockSanitizer.Object, mockedLogger.Object);
+            _mockClient.Setup(m => m.GetAsync(It.IsAny<string>())).ReturnsAsync(httpResponse);
+            _mockUrlBuilder.Setup(m => m.BuildFilterUrl("accounts", It.IsAny<List<string>>()))
+                .Returns("buildFilterUrl");
 
             //Execute
-            var result = await academiesRepository.SearchTrusts(query);
+            var result = await _subject.SearchTrusts(query);
 
             //Assert
-            mockUrlBuilder.Verify(m => m.BuildFilterUrl("accounts", It.IsAny<List<string>>()), Times.Once);
-            mockClient.Verify(m => m.GetAsync("buildFilterUrl"), Times.Once);
+            _mockUrlBuilder.Verify(m => m.BuildFilterUrl("accounts", It.IsAny<List<string>>()), Times.Once);
+            _mockClient.Verify(m => m.GetAsync("buildFilterUrl"), Times.Once);
 
             Assert.False(result.IsValid);
             Assert.Null(result.Result);

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -2,11 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using API.Mapping;
-using API.Models.Downstream.D365;
 using API.Models.Upstream.Enums;
 using API.Models.Upstream.Request;
-using API.Models.Upstream.Response;
 using API.Repositories;
 using API.Repositories.Interfaces;
 using Frontend.Helpers;
@@ -23,15 +20,12 @@ namespace Frontend.Controllers
         private readonly ITrustsRepository _trustRepository;
         private readonly IAcademiesRepository _academiesRepository;
         private readonly IProjectsRepository _projectsRepository;
-        private readonly IMapper<GetTrustsD365Model, GetTrustsModel> _getTrustMapper;
 
         public TransfersController(ITrustsRepository trustRepository, IAcademiesRepository academiesRepository,
-            IMapper<GetTrustsD365Model, GetTrustsModel> getTrustMapper,
             IProjectsRepository projectsRepository)
         {
             _trustRepository = trustRepository;
             _academiesRepository = academiesRepository;
-            _getTrustMapper = getTrustMapper;
             _projectsRepository = projectsRepository;
         }
 
@@ -62,8 +56,7 @@ namespace Frontend.Controllers
                 return RedirectToAction("TrustName");
             }
 
-            var mappedResults = result.Result.Select(r => _getTrustMapper.Map(r)).ToList();
-            var model = new TrustSearch {Trusts = mappedResults};
+            var model = new TrustSearch {Trusts = result.Result};
 
             return View(model);
         }
@@ -71,8 +64,7 @@ namespace Frontend.Controllers
         public async Task<IActionResult> OutgoingTrustDetails(Guid trustId)
         {
             var result = await _trustRepository.GetTrustById(trustId);
-            var mappedResult = _getTrustMapper.Map(result.Result);
-            var model = new OutgoingTrustDetails {Trust = mappedResult};
+            var model = new OutgoingTrustDetails {Trust = result.Result};
             return View(model);
         }
 
@@ -141,8 +133,7 @@ namespace Frontend.Controllers
                 return RedirectToAction("IncomingTrust");
             }
 
-            var mappedResults = result.Result.Select(r => _getTrustMapper.Map(r)).ToList();
-            var model = new TrustSearch {Trusts = mappedResults};
+            var model = new TrustSearch {Trusts = result.Result};
 
             return View(model);
         }
@@ -150,8 +141,7 @@ namespace Frontend.Controllers
         public async Task<IActionResult> IncomingTrustDetails(Guid trustId)
         {
             var result = await _trustRepository.GetTrustById(trustId);
-            var mappedResult = _getTrustMapper.Map(result.Result);
-            var model = new OutgoingTrustDetails {Trust = mappedResult};
+            var model = new OutgoingTrustDetails {Trust = result.Result};
             return View(model);
         }
 
@@ -170,18 +160,16 @@ namespace Frontend.Controllers
                 .Select(Guid.Parse);
 
             var outgoingTrustResponse = await _trustRepository.GetTrustById(outgoingTrustId);
-            var outgoingTrust = _getTrustMapper.Map(outgoingTrustResponse.Result);
 
             var incomingTrustResponse = await _trustRepository.GetTrustById(incomingTrustId);
-            var incomingTrust = _getTrustMapper.Map(incomingTrustResponse.Result);
 
             var academiesForTrust = await _academiesRepository.GetAcademiesByTrustId(outgoingTrustId);
             var selectedAcademies = academiesForTrust.Result.Where(academy => academyIds.Contains(academy.Id)).ToList();
 
             var model = new CheckYourAnswers
             {
-                IncomingTrust = incomingTrust,
-                OutgoingTrust = outgoingTrust,
+                IncomingTrust = incomingTrustResponse.Result,
+                OutgoingTrust = outgoingTrustResponse.Result,
                 OutgoingAcademies = selectedAcademies
             };
 

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Mapping;
-using API.Mapping.Response;
 using API.Models.Downstream.D365;
 using API.Models.Upstream.Enums;
 using API.Models.Upstream.Request;
@@ -25,18 +24,15 @@ namespace Frontend.Controllers
         private readonly IAcademiesRepository _academiesRepository;
         private readonly IProjectsRepository _projectsRepository;
         private readonly IMapper<GetTrustsD365Model, GetTrustsModel> _getTrustMapper;
-        private readonly IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> _postProjectsMapper;
 
         public TransfersController(ITrustsRepository trustRepository, IAcademiesRepository academiesRepository,
             IMapper<GetTrustsD365Model, GetTrustsModel> getTrustMapper,
-            IProjectsRepository projectsRepository,
-            IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> postProjectsMapper)
+            IProjectsRepository projectsRepository)
         {
             _trustRepository = trustRepository;
             _academiesRepository = academiesRepository;
             _getTrustMapper = getTrustMapper;
             _projectsRepository = projectsRepository;
-            _postProjectsMapper = postProjectsMapper;
         }
 
         public IActionResult TrustName()
@@ -221,8 +217,7 @@ namespace Frontend.Controllers
                 }
             };
 
-            var mappedProject = _postProjectsMapper.Map(project);
-            var result = await _projectsRepository.InsertProject(mappedProject);
+            var result = await _projectsRepository.InsertProject(project);
 
             HttpContext.Session.Remove("OutgoingTrustId");
             HttpContext.Session.Remove("IncomingTrustId");

--- a/TRAMS-API/Controllers/ProjectsController.cs
+++ b/TRAMS-API/Controllers/ProjectsController.cs
@@ -1,5 +1,8 @@
-﻿using API.Mapping;
-using API.Models.Downstream.D365;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Mapping;
 using API.Models.Upstream.Enums;
 using API.Models.Upstream.Request;
 using API.Models.Upstream.Response;
@@ -9,10 +12,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace API.Controllers
 {
@@ -32,34 +31,19 @@ namespace API.Controllers
         private readonly IProjectsRepository _projectsRepository;
         private readonly IAcademiesRepository _academiesRepository;
         private readonly ITrustsRepository _trustsRepository;
-        private readonly IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> _postProjectsMapper;
-        private readonly IMapper<GetProjectsD365Model, GetProjectsResponseModel> _getProjectsMapper;
-        private readonly IMapper<AcademyTransfersProjectAcademy, 
-                                 Models.Upstream.Response.GetProjectsAcademyResponseModel> _getProjectAcademyMapper;
-        private readonly IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model> _putProjectAcademiesMapper;
-        private readonly IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> _searchProjectsMapper;
+
         private readonly IRepositoryErrorResultHandler _repositoryErrorHandler;
         private readonly IConfiguration _config;
 
         public ProjectsController(IProjectsRepository projectsRepository,
-                                  IAcademiesRepository academiesRepository,
-                                  ITrustsRepository trustsRepository,
-                                  IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> postProjectsMapper,
-                                  IMapper<GetProjectsD365Model, GetProjectsResponseModel> getProjectsMapper,
-                                  IMapper<AcademyTransfersProjectAcademy, Models.Upstream.Response.GetProjectsAcademyResponseModel> getProjectAcademyMapper,
-                                  IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model> putProjectAcademiesMapper,
-                                  IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> searchProjectsMapper,
-                                  IRepositoryErrorResultHandler repositoryErrorHandler,
-                                  IConfiguration config)
+            IAcademiesRepository academiesRepository,
+            ITrustsRepository trustsRepository,
+            IRepositoryErrorResultHandler repositoryErrorHandler,
+            IConfiguration config)
         {
             _projectsRepository = projectsRepository;
             _academiesRepository = academiesRepository;
             _trustsRepository = trustsRepository;
-            _postProjectsMapper = postProjectsMapper;
-            _putProjectAcademiesMapper = putProjectAcademiesMapper;
-            _getProjectsMapper = getProjectsMapper;
-            _getProjectAcademyMapper = getProjectAcademyMapper;
-            _searchProjectsMapper = searchProjectsMapper;
             _repositoryErrorHandler = repositoryErrorHandler;
             _config = config;
         }
@@ -83,11 +67,11 @@ namespace API.Controllers
         [Route("/projects")]
         [ProducesResponseType(typeof(SearchProjectsPageModel), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> SearchProjects(string searchTerm, 
-                                                        ProjectStatusEnum? status,
-                                                        bool? ascending,
-                                                        uint? pageSize,
-                                                        uint? pageNumber)
+        public async Task<IActionResult> SearchProjects(string searchTerm,
+            ProjectStatusEnum? status,
+            bool? ascending,
+            uint? pageSize,
+            uint? pageNumber)
         {
             var ascendingOption = ascending ?? true;
             var pageSizeOption = pageSize ?? 10;
@@ -103,35 +87,18 @@ namespace API.Controllers
                 return BadRequest("Page number cannot be 0");
             }
 
-            Models.D365.Enums.ProjectStatusEnum projectStatus = default;
-
-            if (status.HasValue)
-            {
-                if (MappingDictionaries.ProjecStatusEnumMap.TryGetValue(status.Value, out var internalStatus))
-                {
-                    projectStatus = internalStatus;
-                }
-                else
-                {
-                    //If project status cannot be mapped to D365 Project Status, return an error
-                    return BadRequest("Project Status not recognised");
-                }
-            }
-                
-            var projSearchResult = await _projectsRepository.SearchProject(searchTerm, 
-                                                                           projectStatus,
-                                                                           ascendingOption,
-                                                                           pageSizeOption,
-                                                                           pageNumberOption);
+            var projSearchResult = await _projectsRepository.SearchProject(searchTerm,
+                status,
+                ascendingOption,
+                pageSizeOption,
+                pageNumberOption);
 
             if (!projSearchResult.IsValid)
             {
                 return _repositoryErrorHandler.LogAndCreateResponse(projSearchResult);
             }
 
-            var externalModels = _searchProjectsMapper.Map(projSearchResult.Result);
-
-            return Ok(externalModels);
+            return Ok(projSearchResult.Result);
         }
 
         /// <summary>
@@ -157,9 +124,7 @@ namespace API.Controllers
                 return NotFound($"Project with id '{id}' not found");
             }
 
-            var externalModel = _getProjectsMapper.Map(getProjectRepositoryResult.Result);
-
-            return Ok(externalModel);
+            return Ok(getProjectRepositoryResult.Result);
         }
 
         /// <summary>
@@ -198,9 +163,7 @@ namespace API.Controllers
                 return NotFound($"Project Academy with id '{projectAcademyId}' not found");
             }
 
-            var externalModel = _getProjectAcademyMapper.Map(getProjectRepositoryResult.Result);
-
-            return Ok(externalModel);
+            return Ok(getProjectRepositoryResult.Result);
         }
 
         /// <summary>
@@ -212,7 +175,7 @@ namespace API.Controllers
         [Route("/projects/")]
         [ProducesResponseType(typeof(GetProjectsResponseModel), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(string), StatusCodes.Status422UnprocessableEntity)]
-        public async Task<IActionResult> InsertProject([FromBody]PostProjectsRequestModel model)
+        public async Task<IActionResult> InsertProject([FromBody] PostProjectsRequestModel model)
         {
             var projectAcademiesIds = model.ProjectAcademies?.Select(a => a.AcademyId).ToList();
             var unprocessableEntityErrors = new List<string>();
@@ -239,8 +202,8 @@ namespace API.Controllers
             if (model.ProjectAcademies != null && model.ProjectAcademies.Any())
             {
                 allTrustIds.AddRange(model.ProjectAcademies.Where(a => a.Trusts != null && a.Trusts.Any())
-                                                           .SelectMany(s => s.Trusts)
-                                                           .Select(s => s.TrustId));
+                    .SelectMany(s => s.Trusts)
+                    .Select(s => s.TrustId));
             }
 
             if (model.ProjectTrusts != null && model.ProjectTrusts.Any())
@@ -276,29 +239,29 @@ namespace API.Controllers
                 return UnprocessableEntity(error);
             }
 
-            var internalModel = _postProjectsMapper.Map(model);
-
-            var insertProjectRepositoryResult = await _projectsRepository.InsertProject(internalModel);
+            var insertProjectRepositoryResult = await _projectsRepository.InsertProject(model);
 
             if (!insertProjectRepositoryResult.IsValid)
             {
                 return _repositoryErrorHandler.LogAndCreateResponse(insertProjectRepositoryResult);
             }
 
-            var getProjectRepositoryResult = await _projectsRepository.GetProjectById(insertProjectRepositoryResult.Result.Value);
+            var getProjectRepositoryResult =
+                await _projectsRepository.GetProjectById(insertProjectRepositoryResult.Result.Value);
 
             if (!getProjectRepositoryResult.IsValid)
             {
                 return _repositoryErrorHandler.LogAndCreateResponse(getProjectRepositoryResult);
             }
 
-            var externalModel = _getProjectsMapper.Map(getProjectRepositoryResult.Result);
+            // var externalModel = _getProjectsMapper.Map(getProjectRepositoryResult.Result);
 
             var apiBaseUrl = _config["API:Url"];
 
-            return Created($"{apiBaseUrl}/projects/{externalModel.ProjectId}", externalModel);
+            return Created($"{apiBaseUrl}/projects/{getProjectRepositoryResult.Result.ProjectId}",
+                getProjectRepositoryResult.Result);
         }
-        
+
         /// <summary>
         /// Endpoint for updating a Project Academy entity
         /// </summary>
@@ -311,7 +274,8 @@ namespace API.Controllers
         [ProducesResponseType(typeof(GetProjectsAcademyResponseModel), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(string), StatusCodes.Status422UnprocessableEntity)]
-        public async Task<IActionResult> UpdateProjectAcademy(Guid projectId, Guid projectAcademyId, [FromBody]PutProjectAcademiesRequestModel model)
+        public async Task<IActionResult> UpdateProjectAcademy(Guid projectId, Guid projectAcademyId,
+            [FromBody] PutProjectAcademiesRequestModel model)
         {
             //Verify that the Id of the ProjectAcademy entity is correct before updating the object
             var projectAcademyRepoResult = await _projectsRepository.GetProjectAcademyById(projectAcademyId);
@@ -329,7 +293,8 @@ namespace API.Controllers
             //If the ProjectAcademy doesn't belong to the specified project, return a 422
             if (projectAcademyRepoResult.Result.ProjectId != projectId)
             {
-                return UnprocessableEntity($"Project Academy with id '{projectAcademyId}' not found within project with id '{projectId}'");
+                return UnprocessableEntity(
+                    $"Project Academy with id '{projectAcademyId}' not found within project with id '{projectId}'");
             }
 
             //Verify that the referenced academy for the ProjectAcademy entity is correct
@@ -345,10 +310,8 @@ namespace API.Controllers
                 return UnprocessableEntity($"No academy found with the id of: {model.AcademyId}");
             }
 
-            //Map the model to internal representation before updating the entity
-            var internalModel = _putProjectAcademiesMapper.Map(model);
-
-            var updateProjectAcademyResult = await _projectsRepository.UpdateProjectAcademy(projectAcademyId, internalModel);
+            var updateProjectAcademyResult =
+                await _projectsRepository.UpdateProjectAcademy(projectAcademyId, model);
 
             if (!updateProjectAcademyResult.IsValid || !updateProjectAcademyResult.Result.HasValue)
             {
@@ -356,7 +319,8 @@ namespace API.Controllers
             }
 
             //Once the entity has been modified, obtain the full entity from D365
-            var retrievedFullProjectAcademy = await _projectsRepository.GetProjectAcademyById(updateProjectAcademyResult.Result.Value);
+            var retrievedFullProjectAcademy =
+                await _projectsRepository.GetProjectAcademyById(updateProjectAcademyResult.Result.Value);
 
             if (!retrievedFullProjectAcademy.IsValid)
             {
@@ -364,9 +328,7 @@ namespace API.Controllers
             }
 
             //Map the ProjectAcademy representation to the external model
-            var externalModel = _getProjectAcademyMapper.Map(retrievedFullProjectAcademy.Result);
-
-            return Ok(externalModel);
+            return Ok(retrievedFullProjectAcademy.Result);
         }
     }
 }

--- a/TRAMS-API/Controllers/TrustsController.cs
+++ b/TRAMS-API/Controllers/TrustsController.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using API.Mapping;
-using API.Models.Downstream.D365;
 using API.Models.Upstream.Response;
 using API.Repositories;
 using API.Repositories.Interfaces;
@@ -28,17 +25,14 @@ namespace API.Controllers
     {
         private readonly ITrustsRepository _trustRepostiory;
         private readonly IAcademiesRepository _academiesRepository;
-        private readonly IMapper<GetTrustsD365Model, GetTrustsModel> _getTrustMapper;
         private readonly IRepositoryErrorResultHandler _repositoryErrorHandler;
 
         public TrustsController(ITrustsRepository trustRepostiory,
                                 IAcademiesRepository academiesRepository,
-                                IMapper<GetTrustsD365Model, GetTrustsModel> mapper,
                                 IRepositoryErrorResultHandler repositoryErrorHandler)
         {
             _trustRepostiory = trustRepostiory;
             _academiesRepository = academiesRepository;
-            _getTrustMapper = mapper;
             _repositoryErrorHandler = repositoryErrorHandler;
         }
 
@@ -65,9 +59,9 @@ namespace API.Controllers
                 return NotFound($"The trust with the id: '{id}' was not found");
             }
 
-            var formattedResult = _getTrustMapper.Map(trustsRepositoryResult.Result);
+            // var formattedResult = _getTrustMapper.Map(trustsRepositoryResult.Result);
 
-            return Ok(formattedResult);
+            return Ok(trustsRepositoryResult.Result);
         }
 
         /// <summary>
@@ -86,12 +80,8 @@ namespace API.Controllers
             {
                 return _repositoryErrorHandler.LogAndCreateResponse(trustsRepositoryResult);
             }
-
-            var formattedOutput = trustsRepositoryResult.Result
-                                                       ?.Select(r => _getTrustMapper.Map(r))
-                                                        .ToList();
-
-            return Ok(formattedOutput);
+            
+            return Ok(trustsRepositoryResult.Result);
         }
 
         /// <summary>

--- a/TRAMS-API/Models/Upstream/Request/PostProjectsRequestModel.cs
+++ b/TRAMS-API/Models/Upstream/Request/PostProjectsRequestModel.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using ProjectStatusEnum = API.Models.D365.Enums.ProjectStatusEnum;
 
 namespace API.Models.Upstream.Request
 {
@@ -27,7 +28,7 @@ namespace API.Models.Upstream.Request
         /// The Project Status Code. Mandatory.
         /// </summary>
         [Required]
-        public ProjectStatusEnum ProjectStatus { get; set; }
+        public Enums.ProjectStatusEnum ProjectStatus { get; set; }
 
         /// <summary>
         /// An array of outbound academies identified for the project. Optional.

--- a/TRAMS-API/Repositories/Interfaces/IProjectsRepository.cs
+++ b/TRAMS-API/Repositories/Interfaces/IProjectsRepository.cs
@@ -1,24 +1,25 @@
-﻿using API.Models.D365.Enums;
-using API.Models.Downstream.D365;
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using API.Models.Upstream.Request;
+using API.Models.Upstream.Response;
+using API.Models.Upstream.Enums;
 
 namespace API.Repositories.Interfaces
 {
     public interface IProjectsRepository
     {
-        public Task<RepositoryResult<SearchProjectsD365PageModel>> SearchProject(string searchQuery,
-                                                                                 ProjectStatusEnum status,
+        public Task<RepositoryResult<SearchProjectsPageModel>> SearchProject(string searchQuery,
+                                                                                 ProjectStatusEnum? status,
                                                                                  bool isAscending = true,
                                                                                  uint pageSize = 10,
                                                                                  uint pageNumber = 1);
 
-        public Task<RepositoryResult<GetProjectsD365Model>> GetProjectById(Guid id);
+        public Task<RepositoryResult<GetProjectsResponseModel>> GetProjectById(Guid id);
 
-        public Task<RepositoryResult<Guid?>> InsertProject(PostAcademyTransfersProjectsD365Model project);
+        public Task<RepositoryResult<Guid?>> InsertProject(PostProjectsRequestModel project);
 
-        public Task<RepositoryResult<AcademyTransfersProjectAcademy>> GetProjectAcademyById(Guid id);
+        public Task<RepositoryResult<GetProjectsAcademyResponseModel>> GetProjectAcademyById(Guid id);
 
-        public Task<RepositoryResult<Guid?>> UpdateProjectAcademy(Guid id, PatchProjectAcademiesD365Model model);
+        public Task<RepositoryResult<Guid?>> UpdateProjectAcademy(Guid id, PutProjectAcademiesRequestModel model);
     }
 }

--- a/TRAMS-API/Repositories/Interfaces/ITrustsRepository.cs
+++ b/TRAMS-API/Repositories/Interfaces/ITrustsRepository.cs
@@ -2,13 +2,14 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using API.Models.Upstream.Response;
 
 namespace API.Repositories
 {
     public interface ITrustsRepository
     {
-        public Task<RepositoryResult<GetTrustsD365Model>> GetTrustById(Guid id);
+        public Task<RepositoryResult<GetTrustsModel>> GetTrustById(Guid id);
 
-        public Task<RepositoryResult<List<GetTrustsD365Model>>> SearchTrusts(string searchQuery);
+        public Task<RepositoryResult<List<GetTrustsModel>>> SearchTrusts(string searchQuery);
     }
 }

--- a/TRAMS-API/Repositories/TrustsRepository.cs
+++ b/TRAMS-API/Repositories/TrustsRepository.cs
@@ -1,38 +1,42 @@
 ﻿using API.HttpHelpers;
 using API.Models.Downstream.D365;
-
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using API.Mapping;
+using API.Models.Upstream.Response;
 using static API.Constants.D365Constants;
 
 namespace API.Repositories
 {
     public class TrustsRepository : ITrustsRepository
     {
-        private readonly string _route = "accounts";
+        private const string Route = "accounts";
 
         private readonly IOdataUrlBuilder<GetTrustsD365Model> _urlBuilder;
         private readonly IAuthenticatedHttpClient _client;
         private readonly IODataSanitizer _oDataSanitizer;
         private readonly ILogger<TrustsRepository> _logger;
+        private readonly IMapper<GetTrustsD365Model, GetTrustsModel> _getTrustMapper;
 
-        public TrustsRepository(IAuthenticatedHttpClient client, 
-                                IOdataUrlBuilder<GetTrustsD365Model> urlBuilder,
-                                IODataSanitizer oDataSanitizer,
-                                ILogger<TrustsRepository> logger)
+        public TrustsRepository(IAuthenticatedHttpClient client,
+            IOdataUrlBuilder<GetTrustsD365Model> urlBuilder,
+            IODataSanitizer oDataSanitizer,
+            ILogger<TrustsRepository> logger, IMapper<GetTrustsD365Model, GetTrustsModel> getTrustMapper)
         {
             _client = client;
             _urlBuilder = urlBuilder;
             _oDataSanitizer = oDataSanitizer;
             _logger = logger;
+            _getTrustMapper = getTrustMapper;
         }
 
-        public async Task<RepositoryResult<GetTrustsD365Model>> GetTrustById(Guid id)
+        public async Task<RepositoryResult<GetTrustsModel>> GetTrustById(Guid id)
         {
-            var url = _urlBuilder.BuildRetrieveOneUrl(_route, id);
+            var url = _urlBuilder.BuildRetrieveOneUrl(Route, id);
 
             var response = await _client.GetAsync(url);
             var responseContent = await response.Content?.ReadAsStringAsync();
@@ -40,7 +44,7 @@ namespace API.Repositories
 
             if (responseStatusCode == System.Net.HttpStatusCode.NotFound)
             {
-                return new RepositoryResult<GetTrustsD365Model> { Result = null };
+                return new RepositoryResult<GetTrustsModel> {Result = null};
             }
 
             if (response.IsSuccessStatusCode)
@@ -55,18 +59,20 @@ namespace API.Repositories
                     EstablishmentType.TrustGuid
                 };
 
-                if (!allowedEstablishementTypeIds.Contains(castedResult.EstablishmentTypeId.ToString().ToUpperInvariant()))
+                if (!allowedEstablishementTypeIds.Contains(castedResult.EstablishmentTypeId.ToString()
+                    .ToUpperInvariant()))
                 {
-                    return new RepositoryResult<GetTrustsD365Model> { Result = null };
+                    return new RepositoryResult<GetTrustsModel> {Result = null};
                 }
 
-                return new RepositoryResult<GetTrustsD365Model> { Result = castedResult };
+                var mappedResult = _getTrustMapper.Map(castedResult);
+                return new RepositoryResult<GetTrustsModel> {Result = mappedResult};
             }
 
             //At this point, log the error and configure the repository result to inform the caller that the repo failed
             _logger.LogError(RepositoryErrorMessages.RepositoryErrorLogFormat, responseStatusCode, responseContent);
 
-            return new RepositoryResult<GetTrustsD365Model>
+            return new RepositoryResult<GetTrustsModel>
             {
                 Error = new RepositoryResultBase.RepositoryError
                 {
@@ -76,28 +82,29 @@ namespace API.Repositories
             };
         }
 
-        public async Task<RepositoryResult<List<GetTrustsD365Model>>> SearchTrusts(string searchQuery)
+        public async Task<RepositoryResult<List<GetTrustsModel>>> SearchTrusts(string searchQuery)
         {
             var sanitizedQuery = _oDataSanitizer.Sanitize(searchQuery);
             var filters = BuildTrustSearchFilters(sanitizedQuery);
 
-            var url = _urlBuilder.BuildFilterUrl(_route, filters);
+            var url = _urlBuilder.BuildFilterUrl(Route, filters);
 
             var response = await _client.GetAsync(url);
             var responseContent = await response.Content?.ReadAsStringAsync();
             var responseStatusCode = response.StatusCode;
 
             if (response.IsSuccessStatusCode)
-            { 
+            {
                 var castedResults = JsonConvert.DeserializeObject<ResultSet<GetTrustsD365Model>>(responseContent);
+                var mappedResults = castedResults.Items.Select(r => _getTrustMapper.Map(r)).ToList();
 
-                return new RepositoryResult<List<GetTrustsD365Model>> { Result = castedResults.Items };
+                return new RepositoryResult<List<GetTrustsModel>> {Result = mappedResults};
             }
 
             //At this point, log the error and configure the repository result to inform the caller that the repo failed
             _logger.LogError(RepositoryErrorMessages.RepositoryErrorLogFormat, responseStatusCode, responseContent);
 
-            return new RepositoryResult<List<GetTrustsD365Model>>
+            return new RepositoryResult<List<GetTrustsModel>>
             {
                 Error = new RepositoryResultBase.RepositoryError
                 {
@@ -111,10 +118,13 @@ namespace API.Repositories
         {
             var stateCodeFieldName = _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.StateCode));
             var statusCodeFieldName = _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.StatusCode));
-            var establishmentTypeFieldName = _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.EstablishmentType));
+            var establishmentTypeFieldName =
+                _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.EstablishmentType));
             var trustNameFieldName = _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.TrustName));
-            var companiesHouseFieldName = _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.CompaniesHouseNumber));
-            var trustReferenceNumberFieldName = _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.TrustReferenceNumber));
+            var companiesHouseFieldName =
+                _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.CompaniesHouseNumber));
+            var trustReferenceNumberFieldName =
+                _urlBuilder.GetPropertyAnnotation(nameof(GetTrustsD365Model.TrustReferenceNumber));
 
             var allowedEstablishementTypeIds = new List<string>()
             {
@@ -125,8 +135,8 @@ namespace API.Repositories
 
             var allowedStatusCodes = new List<string>()
             {
-                ((int)TrustStatusReason.Open).ToString(),
-                ((int)TrustStatusReason.OpenButProposedToClose).ToString()
+                ((int) TrustStatusReason.Open).ToString(),
+                ((int) TrustStatusReason.OpenButProposedToClose).ToString()
             };
 
             var filters = new List<string>()


### PR DESCRIPTION
### Context

In preparation for swapping away from the TRAMS API, we have refactored any TRAMS domain objects (The ones containing D365) to be contained only within the implementations of the repositories. This means pivoting in the future should be much easier

### Changes proposed in this pull request

- Refactor the project repository
- Refactor the trusts repository

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

