### PR TITLE
Outgoing Trust page error messages

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -536,7 +536,7 @@ namespace Frontend.Tests.ControllerTests
             var redirectResponse = Assert.IsType<RedirectToActionResult>(response);
             Assert.Equal(actionName, redirectResponse.ActionName);
         }
-        
+
         #endregion
     }
 }

--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -62,6 +62,14 @@ namespace Frontend.Tests.ControllerTests
                 Assert.Equal(true, _subject.ViewData["Error.Exists"]);
                 Assert.Equal("This is an error message", _subject.ViewData["Error.Message"]);
             }
+
+            [Fact]
+            public void GivenExistingQuery_SetQueryInViewData()
+            {
+                _subject.TrustName("Meow");
+
+                Assert.Equal("Meow", _subject.ViewData["Query"]);
+            }
         }
 
         public class TrustSearchTests : TransfersControllerTests
@@ -72,6 +80,18 @@ namespace Frontend.Tests.ControllerTests
                 var response = await _subject.TrustSearch("");
                 AssertRedirectToAction(response, "TrustName");
                 Assert.Equal("Please enter a search term", _subject.TempData["ErrorMessage"]);
+            }
+
+            [Fact]
+            public async void GivenSearchReturnsNoTrusts_RedirectToTrustNamePageWithAnError()
+            {
+                _trustRepository.Setup(r => r.SearchTrusts("Meow"))
+                    .ReturnsAsync(new RepositoryResult<List<GetTrustsModel>> {Result = new List<GetTrustsModel>()});
+                var response = await _subject.TrustSearch("Meow");
+
+                var redirectResponse = AssertRedirectToAction(response, "TrustName");
+                Assert.Equal("Meow", redirectResponse.RouteValues["query"]);
+                Assert.Equal("No results found", _subject.TempData["ErrorMessage"]);
             }
 
             [Fact]
@@ -89,7 +109,8 @@ namespace Frontend.Tests.ControllerTests
                 );
 
                 var response = await _subject.TrustSearch("Trust name");
-                AssertRedirectToAction(response, "TrustName");
+                var redirectResponse = AssertRedirectToAction(response, "TrustName");
+                Assert.Equal("Trust name", redirectResponse.RouteValues["query"]);
                 Assert.Equal("TRAMS error message", _subject.TempData["ErrorMessage"]);
             }
 
@@ -531,10 +552,11 @@ namespace Frontend.Tests.ControllerTests
             Assert.Equal(trustTwoId, viewModel.Trusts[1].Id);
         }
 
-        private static void AssertRedirectToAction(IActionResult response, string actionName)
+        private static RedirectToActionResult AssertRedirectToAction(IActionResult response, string actionName)
         {
             var redirectResponse = Assert.IsType<RedirectToActionResult>(response);
             Assert.Equal(actionName, redirectResponse.ActionName);
+            return redirectResponse;
         }
 
         #endregion

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -29,9 +29,10 @@ namespace Frontend.Controllers
             _projectsRepository = projectsRepository;
         }
 
-        public IActionResult TrustName()
+        public IActionResult TrustName(string query = "")
         {
             ViewData["Error.Exists"] = false;
+            ViewData["Query"] = query;
 
             if (TempData.Peek("ErrorMessage") == null) return View();
 
@@ -53,7 +54,13 @@ namespace Frontend.Controllers
             if (!result.IsValid)
             {
                 TempData["ErrorMessage"] = result.Error.ErrorMessage;
-                return RedirectToAction("TrustName");
+                return RedirectToAction("TrustName", new {query});
+            }
+
+            if (result.Result.Count == 0)
+            {
+                TempData["ErrorMessage"] = "No results found";
+                return RedirectToAction("TrustName", new {query});
             }
 
             var model = new TrustSearch {Trusts = result.Result};

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -23,7 +23,7 @@
                         </span>
                     }
                     <label class="govuk-hint" for="query" id="query-hint">Search by name, trust reference number or companies house number</label>
-                    <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint"/>
+                    <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint" value="@ViewData["Query"]"/>
                 </fieldset>
             </div>
             <button class="govuk-button" type="submit">Submit</button>

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -1,22 +1,27 @@
-@* @model object *@
-
 @{
     ViewBag.Title = "Add the outgoing trust name";
     Layout = "_Layout";
 }
+@{
+    var errorExists = (bool) ViewData["Error.Exists"];
+    var formClasses = errorExists ? "govuk-form-group--error" : "";
+}
+
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        @if ((bool) ViewData["Error.Exists"])
-        {
-            <p class="govuk-body">Error: @ViewData["Error.Message"]</p>
-        }
         <form method="get" asp-action="TrustSearch">
-            <div class="govuk-form-group">
+            <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" aria-required="true">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">Add the outgoing trust name</h1>
                     </legend>
+                    @if (errorExists)
+                    {
+                        <span id="query-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error: </span>@ViewData["Error.Message"]
+                        </span>
+                    }
                     <label class="govuk-hint" for="query" id="query-hint">Search by name, trust reference number or companies house number</label>
                     <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint"/>
                 </fieldset>

--- a/TRAMS-API/Repositories/Interfaces/ITrustsRepository.cs
+++ b/TRAMS-API/Repositories/Interfaces/ITrustsRepository.cs
@@ -1,10 +1,9 @@
-﻿using API.Models.Downstream.D365;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using API.Models.Upstream.Response;
 
-namespace API.Repositories
+namespace API.Repositories.Interfaces
 {
     public interface ITrustsRepository
     {

--- a/TRAMS-API/Repositories/TrustsRepository.cs
+++ b/TRAMS-API/Repositories/TrustsRepository.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.Mapping;
 using API.Models.Upstream.Response;
+using API.Repositories.Interfaces;
 using static API.Constants.D365Constants;
 
 namespace API.Repositories


### PR DESCRIPTION

### Context

Users need to be able to search for the outgoing trust and have a consistent experience with error messages to prevent them going to an empty search page.

### Changes proposed in this pull request

- Add error message for no search query entered
- Add error message for no results found
- Support pre-filling the query box from the URL

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

