### PR TITLE
Add error messages to incoming trust search page

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -284,6 +284,7 @@ namespace Frontend.Tests.ControllerTests
                 Assert.Equal("Meow", _subject.ViewData["Query"]);
             }
         }
+
         public class SearchIncomingTrusts : TransfersControllerTests
         {
             [Fact]
@@ -448,6 +449,18 @@ namespace Frontend.Tests.ControllerTests
                     {
                         Result = new List<GetAcademiesModel> {_academyOne, _academyTwo, _academyThree}
                     });
+            }
+
+            [Fact]
+            public async void GivenIncomingTrustNotSelected_RendersTheViewCorrectly()
+            {
+                byte[] incomingTrustIdByteArray = null;
+                _session.Setup(s => s.TryGetValue("IncomingTrustId", out incomingTrustIdByteArray)).Returns(true);
+
+                var response = await _subject.CheckYourAnswers();
+                var viewResponse = Assert.IsType<ViewResult>(response);
+                var viewModel = Assert.IsType<CheckYourAnswers>(viewResponse.Model);
+                Assert.Null(viewModel.IncomingTrust);
             }
 
             [Fact]

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -112,9 +112,10 @@ namespace Frontend.Controllers
             return RedirectToAction(nextAction);
         }
 
-        public IActionResult IncomingTrust()
+        public IActionResult IncomingTrust(string query = "")
         {
             ViewData["Error.Exists"] = false;
+            ViewData["Query"] = query;
 
             if (TempData.Peek("ErrorMessage") == null) return View();
 
@@ -137,7 +138,13 @@ namespace Frontend.Controllers
             if (!result.IsValid)
             {
                 TempData["ErrorMessage"] = result.Error.ErrorMessage;
-                return RedirectToAction("IncomingTrust");
+                return RedirectToAction("IncomingTrust", new {query});
+            }
+
+            if (result.Result.Count == 0)
+            {
+                TempData["ErrorMessage"] = "No search results";
+                return RedirectToAction("IncomingTrust", new {query});
             }
 
             var model = new TrustSearch {Trusts = result.Result};

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.Models.Upstream.Enums;
 using API.Models.Upstream.Request;
+using API.Models.Upstream.Response;
 using API.Repositories;
 using API.Repositories.Interfaces;
 using Frontend.Helpers;
@@ -169,20 +170,27 @@ namespace Frontend.Controllers
         public async Task<IActionResult> CheckYourAnswers()
         {
             var outgoingTrustId = Guid.Parse(HttpContext.Session.GetString("OutgoingTrustId"));
-            var incomingTrustId = Guid.Parse(HttpContext.Session.GetString("IncomingTrustId"));
+            GetTrustsModel incomingTrust = null;
             var academyIds = Session.GetStringListFromSession(HttpContext.Session, "OutgoingAcademyIds")
                 .Select(Guid.Parse);
 
             var outgoingTrustResponse = await _trustRepository.GetTrustById(outgoingTrustId);
 
-            var incomingTrustResponse = await _trustRepository.GetTrustById(incomingTrustId);
+            var incomingTrustIdString = HttpContext.Session.GetString("IncomingTrustId");
+
+            if (incomingTrustIdString != null)
+            {
+                var incomingTrustId = Guid.Parse(incomingTrustIdString);
+                var incomingTrustResponse = await _trustRepository.GetTrustById(incomingTrustId);
+                incomingTrust = incomingTrustResponse.Result;
+            }
 
             var academiesForTrust = await _academiesRepository.GetAcademiesByTrustId(outgoingTrustId);
             var selectedAcademies = academiesForTrust.Result.Where(academy => academyIds.Contains(academy.Id)).ToList();
 
             var model = new CheckYourAnswers
             {
-                IncomingTrust = incomingTrustResponse.Result,
+                IncomingTrust = incomingTrust,
                 OutgoingTrust = outgoingTrustResponse.Result,
                 OutgoingAcademies = selectedAcademies
             };

--- a/Frontend/Views/Transfers/CheckYourAnswers.cshtml
+++ b/Frontend/Views/Transfers/CheckYourAnswers.cshtml
@@ -75,7 +75,14 @@
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Name</dt>
-                <dd class="govuk-summary-list__value">@Model.IncomingTrust.TrustName</dd>
+                @if (Model.IncomingTrust == null)
+                {
+                    <dd class="govuk-summary-list__value">None selected</dd>
+                }
+                else
+                {
+                    <dd class="govuk-summary-list__value">@Model.IncomingTrust.TrustName</dd>
+                }
                 <dd class="govuk-summary-list__actions">
                     <a class="govuk-link" href="#">Change <span class="govuk-visually-hidden">incoming trust</span></a>
                 </dd>

--- a/Frontend/Views/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrust.cshtml
@@ -1,5 +1,3 @@
-@* @model object *@
-
 @{
     ViewBag.Title = "title";
     Layout = "_Layout";
@@ -12,19 +10,36 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        @if (errorExists)
+        {
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+                <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a href="#query" data-qa="error__text">
+                                @ViewData["Error.Message"]
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        }
         <form method="get" asp-action="SearchIncomingTrust">
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" aria-required="true">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">Add the incoming trust name</h1>
                     </legend>
+                    <label class="govuk-hint" for="query" id="query-hint">Search by name, trust reference number or companies house number</label>
                     @if (errorExists)
                     {
                         <span id="query-error" class="govuk-error-message">
                             <span class="govuk-visually-hidden">Error: </span>@ViewData["Error.Message"]
                         </span>
                     }
-                    <label class="govuk-hint" for="query" id="query-hint">Search by name, trust reference number or companies house number</label>
                     <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint"/>
                 </fieldset>
             </div>

--- a/Frontend/Views/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrust.cshtml
@@ -5,18 +5,25 @@
     Layout = "_Layout";
 }
 
+@{
+    var errorExists = (bool) ViewData["Error.Exists"];
+    var formClasses = errorExists ? "govuk-form-group--error" : "";
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        @if ((bool) ViewData["Error.Exists"])
-        {
-            <p class="govuk-body">Error: @ViewData["Error.Message"]</p>
-        }
         <form method="get" asp-action="SearchIncomingTrust">
-            <div class="govuk-form-group">
+            <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" aria-required="true">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">Add the incoming trust name</h1>
                     </legend>
+                    @if (errorExists)
+                    {
+                        <span id="query-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error: </span>@ViewData["Error.Message"]
+                        </span>
+                    }
                     <label class="govuk-hint" for="query" id="query-hint">Search by name, trust reference number or companies house number</label>
                     <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint"/>
                 </fieldset>

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -10,19 +10,36 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        @if (errorExists)
+        {
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+                <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a href="#query" data-qa="error__text">
+                                @ViewData["Error.Message"]
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        }
         <form method="get" asp-action="TrustSearch">
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" aria-required="true">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">Add the outgoing trust name</h1>
                     </legend>
+                    <label class="govuk-hint" for="query" id="query-hint">Search by name, trust reference number or companies house number</label>
                     @if (errorExists)
                     {
                         <span id="query-error" class="govuk-error-message">
                             <span class="govuk-visually-hidden">Error: </span>@ViewData["Error.Message"]
                         </span>
                     }
-                    <label class="govuk-hint" for="query" id="query-hint">Search by name, trust reference number or companies house number</label>
                     <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint" value="@ViewData["Query"]"/>
                 </fieldset>
             </div>


### PR DESCRIPTION
### Context

We need to provide error messages in the case of:
- No search query provided
- No results found

### Changes proposed in this pull request

- Return an error in the case of no results found
- Return an error in the case of no query entered
- Pre-fill the search box with information entered in the case of an error
- Show the error inline with the GOV.UK Design System guidelines
- Support no incoming trust being selected

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

