### PR TITLE
Select a single academy

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -224,15 +224,12 @@ namespace Frontend.Tests.ControllerTests
         public class SubmitOutgoingTrustAcademiesTests : TransfersControllerTests
         {
             [Fact]
-            public void GivenAcademyGuids_StoresTheThemInTheSessionAndRedirects()
+            public void GivenAcademyGuid_StoresItInTheSessionAndRedirects()
             {
                 var idOne = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
-                var idTwo = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3854af");
-                var idThree = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3854af");
-                var academyIds = new List<Guid> {idOne, idTwo, idThree}.ToArray();
-                var academyIdString = string.Join(",", academyIds.Select(id => id.ToString()).ToList());
+                var academyIdString = string.Join(",", new [] {idOne}.Select(id => id.ToString()).ToList());
 
-                var result = _subject.SubmitOutgoingTrustAcademies(academyIds);
+                var result = _subject.SubmitOutgoingTrustAcademies(idOne);
 
                 var resultRedirect = Assert.IsType<RedirectToActionResult>(result);
                 Assert.Equal("IncomingTrustIdentified", resultRedirect.ActionName);

--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -191,11 +191,11 @@ namespace Frontend.Tests.ControllerTests
 
         public class OutgoingTrustAcademiesTests : TransfersControllerTests
         {
-            [Fact]
-            public async void GivenTrustGuidInSession_FetchesTheAcademiesForThatTrust()
+            private const string AcademyName = "Academy 001";
+            private const string AcademyNameTwo = "Academy 002";
+
+            public OutgoingTrustAcademiesTests()
             {
-                const string academyName = "Academy 001";
-                const string academyNameTwo = "Academy 002";
                 var trustId = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
                 var trustIdByteArray = Encoding.UTF8.GetBytes(trustId.ToString());
 
@@ -206,18 +206,42 @@ namespace Frontend.Tests.ControllerTests
                     {
                         Result = new List<GetAcademiesModel>
                         {
-                            new GetAcademiesModel {AcademyName = academyName},
-                            new GetAcademiesModel {AcademyName = academyNameTwo},
+                            new GetAcademiesModel {AcademyName = AcademyName},
+                            new GetAcademiesModel {AcademyName = AcademyNameTwo},
                         }
                     }
                 );
+            }
 
+            [Fact]
+            public async void GivenTrustGuidInSession_FetchesTheAcademiesForThatTrust()
+            {
                 var response = await _subject.OutgoingTrustAcademies();
                 var viewResponse = Assert.IsType<ViewResult>(response);
                 var viewModel = Assert.IsType<OutgoingTrustAcademies>(viewResponse.Model);
 
-                Assert.Equal("Academy 001", viewModel.Academies[0].AcademyName);
-                Assert.Equal("Academy 002", viewModel.Academies[1].AcademyName);
+                Assert.Equal(AcademyName, viewModel.Academies[0].AcademyName);
+                Assert.Equal(AcademyNameTwo, viewModel.Academies[1].AcademyName);
+            }
+            
+            [Fact]
+            public async void GivenNoErrorMessage_SetsErrorExistsToFalse()
+            {
+                var response = await _subject.OutgoingTrustAcademies();
+                var viewResponse = Assert.IsType<ViewResult>(response);
+                Assert.Equal(false, viewResponse.ViewData["Error.Exists"]);
+            }
+
+            [Fact]
+            public async void GivenErrorMessage_PutsTheErrorIntoTheViewData()
+            {
+                _subject.TempData["ErrorMessage"] = "Error message";
+                
+                var response = await _subject.OutgoingTrustAcademies();
+                var viewResponse = Assert.IsType<ViewResult>(response);
+                
+                Assert.Equal(true, viewResponse.ViewData["Error.Exists"]);
+                Assert.Equal("Error message", viewResponse.ViewData["Error.Message"]);
             }
         }
 
@@ -227,7 +251,7 @@ namespace Frontend.Tests.ControllerTests
             public void GivenAcademyGuid_StoresItInTheSessionAndRedirects()
             {
                 var idOne = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
-                var academyIdString = string.Join(",", new [] {idOne}.Select(id => id.ToString()).ToList());
+                var academyIdString = string.Join(",", new[] {idOne}.Select(id => id.ToString()).ToList());
 
                 var result = _subject.SubmitOutgoingTrustAcademies(idOne);
 
@@ -239,6 +263,16 @@ namespace Frontend.Tests.ControllerTests
                     It.Is<byte[]>(input =>
                         Encoding.UTF8.GetString(input) == academyIdString
                     )));
+            }
+
+            [Fact]
+            public void GivenNoAcademyGuid_RedirectBackToOutgoingTrustAcademiesWithError()
+            {
+                var result = _subject.SubmitOutgoingTrustAcademies(null);
+
+                var resultRedirect = Assert.IsType<RedirectToActionResult>(result);
+                Assert.Equal("OutgoingTrustAcademies", resultRedirect.ActionName);
+                Assert.Equal("Please select an academy", _subject.TempData["ErrorMessage"]);
             }
         }
 

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -89,13 +89,25 @@ namespace Frontend.Controllers
             var outgoingTrustId = Guid.Parse(sessionGuid);
             var academiesRepoResult = await _academiesRepository.GetAcademiesByTrustId(outgoingTrustId);
             var academies = academiesRepoResult.Result;
-
             var model = new OutgoingTrustAcademies {Academies = academies};
+            
+            ViewData["Error.Exists"] = false;
+            if (TempData.Peek("ErrorMessage") == null) return View(model);
+            
+            ViewData["Error.Exists"] = true;
+            ViewData["Error.Message"] = TempData["ErrorMessage"];
+
             return View(model);
         }
 
-        public IActionResult SubmitOutgoingTrustAcademies(Guid academyId)
+        public IActionResult SubmitOutgoingTrustAcademies(Guid? academyId)
         {
+            if (!academyId.HasValue)
+            {
+                TempData["ErrorMessage"] = "Please select an academy";
+                return RedirectToAction("OutgoingTrustAcademies");
+            }
+
             var academyIds = new[] {academyId};
             var academyIdsString = string.Join(",", academyIds.Select(id => id.ToString()).ToList());
             HttpContext.Session.SetString("OutgoingAcademyIds", academyIdsString);

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -94,8 +94,9 @@ namespace Frontend.Controllers
             return View(model);
         }
 
-        public IActionResult SubmitOutgoingTrustAcademies(Guid[] academyIds)
+        public IActionResult SubmitOutgoingTrustAcademies(Guid academyId)
         {
+            var academyIds = new[] {academyId};
             var academyIdsString = string.Join(",", academyIds.Select(id => id.ToString()).ToList());
             HttpContext.Session.SetString("OutgoingAcademyIds", academyIdsString);
 

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -17,12 +17,12 @@
                     <div id="add-academies-hint" class="govuk-hint">
                         Select all the academies that are transferring.
                     </div>
-                    <div class="govuk-checkboxes">
+                    <div class="govuk-radios govuk-radios">
                         @foreach (var academy in Model.Academies)
                         {
-                            <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="@academy.Id" name="academyIds" type="checkbox" value="@academy.Id">
-                                <label class="govuk-label govuk-checkboxes__label" for="@academy.Id">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="@academy.Id" name="academyId" type="radio" value="@academy.Id">
+                                <label class="govuk-label govuk-radios__label" for="@academy.Id">
                                     @academy.AcademyName (URN @academy.Urn)
                                 </label>
                             </div>

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -3,13 +3,33 @@
 @{
     ViewBag.Title = "title";
     Layout = "_Layout";
+    var errorExists = (bool) ViewData["Error.Exists"];
+    var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
+
 <h1 class="govuk-heading-xl"></h1>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+        @if (errorExists)
+        {
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+                <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a href="#@Model.Academies[0].Id" data-qa="error__text">
+                                @ViewData["Error.Message"]
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        }
+        
         <form class="govuk-form" asp-action="SubmitOutgoingTrustAcademies" method="get">
-            <div class="govuk-form-group">
-
+            <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" aria-describedby="add-academies-hint">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">Add the transferring academies</h1>
@@ -17,6 +37,14 @@
                     <div id="add-academies-hint" class="govuk-hint">
                         Select all the academies that are transferring.
                     </div>
+
+                    @if (errorExists)
+                    {
+                        <span id="academyId-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> @ViewData["Error.Message"]
+                        </span>
+                    }
+
                     <div class="govuk-radios govuk-radios">
                         @foreach (var academy in Model.Academies)
                         {

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -1,8 +1,6 @@
 @{
     ViewBag.Title = "Add the outgoing trust name";
     Layout = "_Layout";
-}
-@{
     var errorExists = (bool) ViewData["Error.Exists"];
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }


### PR DESCRIPTION
### Context

For our MVP we're only going to work on transfers that contain a single academy - to prevent users from selecting more than one academy we've changed the page for academy selection from checkboxes to radio buttons. 

Additionally, we need to prevent users from selecting _no_ academy, so this also adds validation.

### Changes proposed in this pull request

- Change from checkboxes to radio buttons for academies
- Perform presence checking for academy selection

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

