### PR TITLE
Update display of search results when searching for trusts

### DIFF
--- a/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
@@ -7,14 +7,16 @@
 
 <h1 class="govuk-heading-xl">Select an incoming trust</h1>
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <ul class="govuk-list govuk-list--bullet">
-            @foreach (var trust in Model.Trusts)
-            {
-                <li>
-                    <a class="govuk-link" asp-action="IncomingTrustDetails" asp-route-trustId="@trust.Id">@trust.TrustName</a>
-                </li>
-            }
-        </ul>
+    <div class="govuk-grid-column-two-thirds">
+        @foreach (var trust in Model.Trusts)
+        {
+            <h2 class="govuk-heading-s">
+                <a class="govuk-link" asp-action="IncomingTrustDetails" asp-route-trustId="@trust.Id">
+                    @trust.TrustName (@trust.TrustReferenceNumber)
+                </a>
+            </h2>
+            <p class="govuk-body">Companies House number: @trust.CompaniesHouseNumber</p>
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
+        }
     </div>
 </div>

--- a/Frontend/Views/Transfers/TrustSearch.cshtml
+++ b/Frontend/Views/Transfers/TrustSearch.cshtml
@@ -5,12 +5,18 @@
     Layout = "_Layout";
 }
 
-<h1 class="govuk-heading-xl">Trust search</h1>
-<ul class="govuk-list govuk-list--bullet">
-    @foreach (var trust in Model.Trusts)
-    {
-        <li>
-            <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Id">@trust.TrustName</a>
-        </li>
-    }
-</ul>
+<h1 class="govuk-heading-l">Select and outgoing trust</h1>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        @foreach (var trust in Model.Trusts)
+        {
+            <h2 class="govuk-heading-s">
+                <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Id">
+                    @trust.TrustName (@trust.TrustReferenceNumber)
+                </a>
+            </h2>
+            <p class="govuk-body">Companies House number: @trust.CompaniesHouseNumber</p>
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
+        }
+    </div>
+</div>


### PR DESCRIPTION
### Context

We want to make the search results page slightly more clear in the information displayed

### Changes proposed in this pull request

- Update the layout for search results pages

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

