### PR TITLE
Add back links for transfer creation process

### DIFF
--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -65,14 +65,16 @@ namespace Frontend.Controllers
             }
 
             var model = new TrustSearch {Trusts = result.Result};
+            ViewData["Query"] = query;
 
             return View(model);
         }
 
-        public async Task<IActionResult> OutgoingTrustDetails(Guid trustId)
+        public async Task<IActionResult> OutgoingTrustDetails(Guid trustId, string query = "")
         {
             var result = await _trustRepository.GetTrustById(trustId);
             var model = new OutgoingTrustDetails {Trust = result.Result};
+            ViewData["Query"] = query;
             return View(model);
         }
 
@@ -87,6 +89,8 @@ namespace Frontend.Controllers
         {
             var sessionGuid = HttpContext.Session.GetString("OutgoingTrustId");
             var outgoingTrustId = Guid.Parse(sessionGuid);
+            ViewData["OutgoingTrustId"] = outgoingTrustId.ToString();
+            
             var academiesRepoResult = await _academiesRepository.GetAcademiesByTrustId(outgoingTrustId);
             var academies = academiesRepoResult.Result;
             var model = new OutgoingTrustAcademies {Academies = academies};
@@ -141,6 +145,7 @@ namespace Frontend.Controllers
 
         public async Task<IActionResult> SearchIncomingTrust(string query)
         {
+            ViewData["Query"] = query;
             if (string.IsNullOrEmpty(query))
             {
                 TempData["ErrorMessage"] = "Please enter a search term";
@@ -166,10 +171,11 @@ namespace Frontend.Controllers
             return View(model);
         }
 
-        public async Task<IActionResult> IncomingTrustDetails(Guid trustId)
+        public async Task<IActionResult> IncomingTrustDetails(Guid trustId, string query = "")
         {
             var result = await _trustRepository.GetTrustById(trustId);
             var model = new OutgoingTrustDetails {Trust = result.Result};
+            ViewData["Query"] = query;
             return View(model);
         }
 

--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -49,6 +49,7 @@
 </header>
 
 <div class="govuk-width-container ">
+    @await RenderSectionAsync("BeforeMain", required: false)
     <main class="govuk-main-wrapper " id="main-content" role="main">
         @RenderBody()
     </main>

--- a/Frontend/Views/Transfers/CheckYourAnswers.cshtml
+++ b/Frontend/Views/Transfers/CheckYourAnswers.cshtml
@@ -5,6 +5,11 @@
     Layout = "_Layout";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrustDetails" asp-route-trustId="@Model.IncomingTrust.Id">Back</a>
+}
+
 <h1 class="govuk-heading-xl">Check trust and academy details</h1>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/Frontend/Views/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrust.cshtml
@@ -8,6 +8,11 @@
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrustIdentified">Back</a>
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @if (errorExists)
@@ -40,7 +45,7 @@
                             <span class="govuk-visually-hidden">Error: </span>@ViewData["Error.Message"]
                         </span>
                     }
-                    <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint"/>
+                    <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint" value="@ViewData["Query"]"/>
                 </fieldset>
             </div>
             <button class="govuk-button" type="submit">Submit</button>

--- a/Frontend/Views/Transfers/IncomingTrustDetails.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrustDetails.cshtml
@@ -6,6 +6,11 @@
     Layout = "_Layout";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrust" asp-route-query="@ViewData["Query"]">Back</a>
+}
+
 <h1 class="govuk-heading-xl">Incoming trust details</h1>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/Frontend/Views/Transfers/IncomingTrustIdentified.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrustIdentified.cshtml
@@ -1,11 +1,13 @@
-@* @model  *@
-
 @{
     ViewBag.Title = "title";
     Layout = "_Layout";
 }
 
-<h1 class="govuk-heading-xl"></h1>
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="OutgoingTrustAcademies">Back</a>
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <form class="govuk-form" asp-action="SubmitIncomingTrustIdentified" method="get">

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -7,6 +7,11 @@
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="OutgoingTrustDetails" asp-route-trustId="@ViewData["OutgoingTrustId"]">Back</a>
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         @if (errorExists)
@@ -26,7 +31,7 @@
                 </div>
             </div>
         }
-        
+
         <form class="govuk-form" asp-action="SubmitOutgoingTrustAcademies" method="get">
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" aria-describedby="add-academies-hint">

--- a/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
@@ -6,6 +6,11 @@
     Layout = "_Layout";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-action="TrustName" asp-route-query="@ViewData["Query"]">Back</a>
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-xl">Outgoing trust details</h1>

--- a/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
@@ -5,13 +5,18 @@
     Layout = "_Layout";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrust" asp-route-query="@ViewData["Query"]">Back</a>
+}
+
 <h1 class="govuk-heading-xl">Select an incoming trust</h1>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @foreach (var trust in Model.Trusts)
         {
             <h2 class="govuk-heading-s">
-                <a class="govuk-link" asp-action="IncomingTrustDetails" asp-route-trustId="@trust.Id">
+                <a class="govuk-link" asp-action="IncomingTrustDetails" asp-route-trustId="@trust.Id" asp-route-query="@ViewData["Query"]">
                     @trust.TrustName (@trust.TrustReferenceNumber)
                 </a>
             </h2>

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -5,6 +5,11 @@
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Home" asp-action="Index">Back</a>
+}
+
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/Frontend/Views/Transfers/TrustSearch.cshtml
+++ b/Frontend/Views/Transfers/TrustSearch.cshtml
@@ -5,13 +5,18 @@
     Layout = "_Layout";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="TrustName" asp-route-query="@ViewData["Query"]">Back</a>
+}
+
 <h1 class="govuk-heading-l">Select and outgoing trust</h1>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @foreach (var trust in Model.Trusts)
         {
             <h2 class="govuk-heading-s">
-                <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Id">
+                <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Id" asp-route-query="@ViewData["Query"]">
                     @trust.TrustName (@trust.TrustReferenceNumber)
                 </a>
             </h2>


### PR DESCRIPTION
### Context

To allow users to navigate backwards through the service, they need to use GOV.UK Back links as per the service standard.

### Changes proposed in this pull request

- Add back links to the service, supporting pre-filling the query where easily possible

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

