### PR TITLE
Implement change link functionality for outgoing trusts

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -70,6 +70,14 @@ namespace Frontend.Tests.ControllerTests
 
                 Assert.Equal("Meow", _subject.ViewData["Query"]);
             }
+
+            [Fact]
+            public void GivenChangeLink_SetChangeLinkinViewData()
+            {
+                _subject.TrustName("Meow", true);
+                
+                Assert.Equal(true, _subject.ViewData["ChangeLink"]);
+            }
         }
 
         public class TrustSearchTests : TransfersControllerTests
@@ -157,6 +165,28 @@ namespace Frontend.Tests.ControllerTests
                 await _subject.TrustSearch("Trust name");
                 Assert.Equal("Trust name", _subject.ViewData["Query"]);
             }
+            
+            [Fact]
+            public async void GivenChangeLink_SetChangeLinkinViewData()
+            {
+                var trustId = Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9");
+                var trustTwoId = Guid.Parse("a16e9020-9123-4420-8055-851d1b672faf");
+
+                _trustRepository.Setup(r => r.SearchTrusts("Trust name")).ReturnsAsync(
+                    new RepositoryResult<List<GetTrustsModel>>
+                    {
+                        Result = new List<GetTrustsModel>
+                        {
+                            new GetTrustsModel {Id = trustId},
+                            new GetTrustsModel {Id = trustTwoId}
+                        }
+                    }
+                );
+
+                await _subject.TrustSearch("Trust name", true);
+                
+                Assert.Equal(true, _subject.ViewData["ChangeLink"]);
+            }
         }
 
         public class OutgoingTrustDetailsTests : TransfersControllerTests
@@ -203,6 +233,13 @@ namespace Frontend.Tests.ControllerTests
                 await _subject.OutgoingTrustDetails(_trustId, "Trust name");
                 Assert.Equal("Trust name", _subject.ViewData["Query"]);
             }
+            
+            [Fact]
+            public async void GivenChangeLink_AssignChangeLinkToTheView()
+            {
+                await _subject.OutgoingTrustDetails(_trustId, "Trust name", true);
+                Assert.Equal(true, _subject.ViewData["ChangeLink"]);
+            }
         }
 
         public class ConfirmOutgoingTrustTests : TransfersControllerTests
@@ -220,6 +257,16 @@ namespace Frontend.Tests.ControllerTests
                     )));
 
                 AssertRedirectToAction(response, "OutgoingTrustAcademies");
+            }
+            
+            [Fact]
+            public void GivenTrustGuid_ClearExistingInformationInTheSession()
+            {
+                var trustId = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
+                _subject.ConfirmOutgoingTrust(trustId);
+                
+                _session.Verify(s => s.Remove("IncomingTrustId"));
+                _session.Verify(s => s.Remove("OutgoingAcademyIds"));
             }
         }
 

--- a/Frontend/Views/Transfers/CheckYourAnswers.cshtml
+++ b/Frontend/Views/Transfers/CheckYourAnswers.cshtml
@@ -19,7 +19,9 @@
                 <dt class="govuk-summary-list__key">Name</dt>
                 <dd class="govuk-summary-list__value">@Model.OutgoingTrust.TrustName</dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">Change <span class="govuk-visually-hidden">outgoing trust</span></a>
+                    <a class="govuk-link" asp-action="TrustName", asp-route-change="true">
+                        Change <span class="govuk-visually-hidden">outgoing trust</span>
+                    </a>
                 </dd>
             </div>
             <div class="govuk-summary-list__row">

--- a/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustDetails.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="TrustName" asp-route-query="@ViewData["Query"]">Back</a>
+    <a class="govuk-back-link" asp-action="TrustName" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"].ToString()">Back</a>
 }
 
 <div class="govuk-grid-row">

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -3,11 +3,19 @@
     Layout = "_Layout";
     var errorExists = (bool) ViewData["Error.Exists"];
     var formClasses = errorExists ? "govuk-form-group--error" : "";
+    var changeLinkClicked = (bool) ViewData["ChangeLink"];
 }
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-controller="Home" asp-action="Index">Back</a>
+    @if (changeLinkClicked)
+    {
+        <a class="govuk-back-link" asp-controller="Transfers" asp-action="CheckYourAnswers">Back</a>
+    }
+    else
+    {
+        <a class="govuk-back-link" asp-controller="Home" asp-action="Index">Back</a>
+    }
 }
 
 
@@ -44,6 +52,7 @@
                         </span>
                     }
                     <input class="govuk-input" name="query" id="query" type="text" aria-describedby="query-hint" value="@ViewData["Query"]"/>
+                    <input hidden name="change" type="text" value="@changeLinkClicked.ToString()" />
                 </fieldset>
             </div>
             <button class="govuk-button" type="submit">Submit</button>

--- a/Frontend/Views/Transfers/TrustSearch.cshtml
+++ b/Frontend/Views/Transfers/TrustSearch.cshtml
@@ -7,7 +7,7 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-controller="Transfers" asp-action="TrustName" asp-route-query="@ViewData["Query"]">Back</a>
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="TrustName" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"]">Back</a>
 }
 
 <h1 class="govuk-heading-l">Select and outgoing trust</h1>
@@ -16,7 +16,7 @@
         @foreach (var trust in Model.Trusts)
         {
             <h2 class="govuk-heading-s">
-                <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Id" asp-route-query="@ViewData["Query"]">
+                <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Id" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"]">
                     @trust.TrustName (@trust.TrustReferenceNumber)
                 </a>
             </h2>


### PR DESCRIPTION
### Context

Following the GOV.UK Design system - we have implemented change links on our "Check your answers page", as such we need to support these and handle the user navigation between them.

When changing an outgoing trust, we also want the user to go through the process again, and changing the outgoing trust is a fundamental change to the transfer.

### Changes proposed in this pull request

- Update pages to support navigation from the change link page
- Clear the session when outgoing trusts are selected

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

