### PR TITLE
Skip the incoming trust identified stage

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -360,7 +360,7 @@ namespace Frontend.Tests.ControllerTests
                 var result = _subject.SubmitOutgoingTrustAcademies(idOne);
 
                 var resultRedirect = Assert.IsType<RedirectToActionResult>(result);
-                Assert.Equal("IncomingTrustIdentified", resultRedirect.ActionName);
+                Assert.Equal("IncomingTrust", resultRedirect.ActionName);
 
                 _session.Verify(s => s.Set(
                     "OutgoingAcademyIds",

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -134,7 +134,7 @@ namespace Frontend.Controllers
             var academyIdsString = string.Join(",", academyIds.Select(id => id.ToString()).ToList());
             HttpContext.Session.SetString(OutgoingAcademyIdSessionKey, academyIdsString);
 
-            return RedirectToAction(change ? "CheckYourAnswers" : "IncomingTrustIdentified");
+            return RedirectToAction(change ? "CheckYourAnswers" : "IncomingTrust");
         }
 
         public IActionResult IncomingTrustIdentified()

--- a/Frontend/Views/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrust.cshtml
@@ -16,7 +16,7 @@
     }
     else
     {
-        <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrustIdentified">Back</a>
+        <a class="govuk-back-link" asp-controller="Transfers" asp-action="OutgoingTrustAcademies">Back</a>
     }
 }
 


### PR DESCRIPTION
### Context

For our MVP we are only allowing the creation of projects where the incoming trust is identified. As such, we are skipping the step in the creation process that lets you pick if an incoming trust is identified or not.

### Changes proposed in this pull request

- Skip the incoming trust identified page

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

