### PR TITLE
Initial word document generation workflow

### DIFF
--- a/DocumentGeneration.Tests/DocumentBuilderHelpersTests.cs
+++ b/DocumentGeneration.Tests/DocumentBuilderHelpersTests.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace DocumentGeneration.Tests
+{
+    public class DocumentBuilderHelpersTests
+    {
+        public class AddTextToElementTests
+        {
+            [Fact]
+            public void GivenSimpleTest_AddsTextToElement()
+            {
+                var run = new Run();
+                DocumentBuilderHelpers.AddTextToElement(run, "Example text");
+
+                var textElements = run.Descendants<Text>().ToList();
+
+                Assert.Single(textElements);
+                Assert.Equal("Example text", textElements[0].InnerText);
+            }
+
+            [Fact]
+            public void GivenTextWithNewLine_AddsTwoTextElementsSeparatedByBreak()
+            {
+                var run = new Run();
+                DocumentBuilderHelpers.AddTextToElement(run, "Example text\nWith a new line");
+
+                var textElements = run.Descendants<Text>().ToList();
+                var descendents = run.Descendants().ToList();
+
+                Assert.Equal(2, textElements.Count);
+                Assert.IsType<Break>(descendents[1]);
+                Assert.Equal("Example text", textElements[0].InnerText);
+                Assert.Equal("With a new line", textElements[1].InnerText);
+            }
+
+            [Fact]
+            public void GivenTextWithSeveralNewLines_AddsTheCorrectNumberOfTextElementsAndBreaks()
+            {
+                var run = new Run();
+                DocumentBuilderHelpers.AddTextToElement(run, "Example text\nWith a new line\n3\n4\n5");
+
+                var textElements = run.Descendants<Text>().ToList();
+                var breakElements = run.Descendants<Break>().ToList();
+
+                Assert.Equal(5, textElements.Count);
+                Assert.Equal(4, breakElements.Count);
+            }
+
+            [Fact]
+            public void GivenTextWithCarriageReturn_AddsTwoTextElementsSeparatedByBreak()
+            {
+                var run = new Run();
+                DocumentBuilderHelpers.AddTextToElement(run, "Example text\rWith a new line");
+
+                var textElements = run.Descendants<Text>().ToList();
+                var descendents = run.Descendants().ToList();
+
+                Assert.Equal(2, textElements.Count);
+                Assert.IsType<Break>(descendents[1]);
+                Assert.Equal("Example text", textElements[0].InnerText);
+                Assert.Equal("With a new line", textElements[1].InnerText);
+            }
+
+            [Fact]
+            public void GivenTextWithNewLineCarriageReturn_AddsTwoTextElementsSeparatedByBreak()
+            {
+                var run = new Run();
+                DocumentBuilderHelpers.AddTextToElement(run, "Example text\r\nWith a new line");
+
+                var textElements = run.Descendants<Text>().ToList();
+                var descendents = run.Descendants().ToList();
+
+                Assert.Equal(2, textElements.Count);
+                Assert.IsType<Break>(descendents[1]);
+                Assert.Equal("Example text", textElements[0].InnerText);
+                Assert.Equal("With a new line", textElements[1].InnerText);
+            }
+        }
+    }
+}

--- a/DocumentGeneration.Tests/DocumentBuilderTests.cs
+++ b/DocumentGeneration.Tests/DocumentBuilderTests.cs
@@ -39,6 +39,23 @@ namespace DocumentGeneration.Tests
         }
 
         [Fact]
+        public void GivenHeadingAdded_CreatesADocumentWithTheTextAddedCorrectly()
+        {
+            var documentBody = GenerateDocument(builder =>
+            {
+                builder.AddHeading("Heading 1", DocumentHeadingBuilder.HeadingLevelOptions.Heading1);
+                builder.AddHeading("Heading 2", DocumentHeadingBuilder.HeadingLevelOptions.Heading2);
+                builder.AddHeading("Heading 3", DocumentHeadingBuilder.HeadingLevelOptions.Heading3);
+            });
+
+            var textDescendents = documentBody.Descendants<Text>().ToList();
+            Assert.Equal(3, textDescendents.Count);
+            Assert.Equal("Heading 1", textDescendents[0].InnerText);
+            Assert.Equal("Heading 2", textDescendents[1].InnerText);
+            Assert.Equal("Heading 3", textDescendents[2].InnerText);
+        }
+
+        [Fact]
         public void GivenTableAdded_CreatesADocumentWithATable()
         {
             var documentBody = GenerateDocument(builder =>

--- a/DocumentGeneration.Tests/DocumentBuilderTests.cs
+++ b/DocumentGeneration.Tests/DocumentBuilderTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace DocumentGeneration.Tests
+{
+    public class DocumentBuilderTests
+    {
+        [Fact]
+        public void GivenTextForParagraph_CreatesADocumentWithAParagraph()
+        {
+            var documentBody = GenerateDocument(builder => builder.AddParagraph("This is an example paragraph"));
+            var textDescendents = documentBody.Descendants<Text>().ToList();
+
+            Assert.Single(textDescendents);
+            Assert.Equal("This is an example paragraph", textDescendents.First().InnerText);
+        }
+
+        [Fact]
+        public void GivenMultipleParagraphsAdded_CreatesADocumentWithMultipleParagraphs()
+        {
+            var documentBody = GenerateDocument(builder =>
+            {
+                builder.AddParagraph("Paragraph one");
+                builder.AddParagraph("Paragraph two");
+                builder.AddParagraph("Paragraph three");
+            });
+
+            var textDescendents = documentBody.Descendants<Text>().ToList();
+
+            Assert.Equal(3, textDescendents.Count);
+            Assert.Equal("Paragraph one", textDescendents[0].InnerText);
+            Assert.Equal("Paragraph two", textDescendents[1].InnerText);
+            Assert.Equal("Paragraph three", textDescendents[2].InnerText);
+        }
+
+        [Fact]
+        public void GivenTableAdded_CreatesADocumentWithATable()
+        {
+            var documentBody = GenerateDocument(builder =>
+            {
+                builder.AddTable(new List<List<string>> {new List<string> {"Meow"}});
+            });
+
+            var tableDescendents = documentBody.Descendants<Table>().ToList();
+            Assert.Single(tableDescendents);
+            Assert.Equal("Meow", tableDescendents[0].InnerText);
+        }
+
+        [Fact]
+        public void GivenMultipleTablesAdded_CreatesADocumentWithMultipleTables()
+        {
+            var documentBody = GenerateDocument(builder =>
+            {
+                builder.AddTable(new List<List<string>> {new List<string> {"Meow"}});
+                builder.AddTable(new List<List<string>> {new List<string> {"Woof"}});
+                builder.AddTable(new List<List<string>> {new List<string> {"Quack"}});
+            });
+
+            var tableDescendents = documentBody.Descendants<Table>().ToList();
+            Assert.Equal(3, tableDescendents.Count);
+            Assert.Equal("Meow", tableDescendents[0].InnerText);
+            Assert.Equal("Woof", tableDescendents[1].InnerText);
+            Assert.Equal("Quack", tableDescendents[2].InnerText);
+        }
+
+        #region Helpers
+
+        private static Body GenerateDocument(Action<DocumentBuilder> documentFunction)
+        {
+            MemoryStream memoryStream;
+            Body documentBody;
+
+            using (memoryStream = new MemoryStream())
+            {
+                var builder = new DocumentBuilder(memoryStream);
+
+                documentFunction(builder);
+
+                builder.Build();
+                using (var doc = WordprocessingDocument.Open(memoryStream, false))
+                {
+                    documentBody = doc.MainDocumentPart.Document.Body;
+                }
+            }
+
+            return documentBody;
+        }
+
+        #endregion
+    }
+}

--- a/DocumentGeneration.Tests/DocumentGeneration.Tests.csproj
+++ b/DocumentGeneration.Tests/DocumentGeneration.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\DocumentGeneration\DocumentGeneration.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/DocumentGeneration.Tests/DocumentHeadingBuilderTests.cs
+++ b/DocumentGeneration.Tests/DocumentHeadingBuilderTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace DocumentGeneration.Tests
+{
+    public class DocumentHeadingBuilderTests
+    {
+        [Fact]
+        public void GivenHeadingOne_CreatesARunWithTheExpectedRunProperties()
+        {
+            var body = new Body();
+            DocumentHeadingBuilder.AddHeadingToElement(body, "Heading 1",
+                DocumentHeadingBuilder.HeadingLevelOptions.Heading1);
+
+            var createdRuns = body.Descendants<Run>().ToList();
+            Assert.Equal("60", createdRuns[0].RunProperties.FontSize.Val);
+            Assert.Equal("Heading 1", createdRuns[0].InnerText);
+        }
+
+        [Fact]
+        public void GivenHeadingTwo_CreatesARunWithTheExpectedRunProperties()
+        {
+            var body = new Body();
+            DocumentHeadingBuilder.AddHeadingToElement(body, "Heading 2",
+                DocumentHeadingBuilder.HeadingLevelOptions.Heading2);
+
+            var createdRuns = body.Descendants<Run>().ToList();
+            Assert.Equal("40", createdRuns[0].RunProperties.FontSize.Val);
+            Assert.Equal("Heading 2", createdRuns[0].InnerText);
+        }
+
+        [Fact]
+        public void GivenHeadingThree_CreatesARunWithTheExpectedRunProperties()
+        {
+            var body = new Body();
+            DocumentHeadingBuilder.AddHeadingToElement(body, "Heading 3",
+                DocumentHeadingBuilder.HeadingLevelOptions.Heading3);
+
+            var createdRuns = body.Descendants<Run>().ToList();
+            Assert.Equal("30", createdRuns[0].RunProperties.FontSize.Val);
+            Assert.Equal("Heading 3", createdRuns[0].InnerText);
+        }
+    }
+}

--- a/DocumentGeneration.Tests/DocumentTableBuilderTests.cs
+++ b/DocumentGeneration.Tests/DocumentTableBuilderTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace DocumentGeneration.Tests
+{
+    public class DocumentTableBuilderTests
+    {
+        [Fact]
+        public void GivenSingleTableCell_AppendsATableWithASingleCell()
+        {
+            var body = new Body();
+            var builder = new DocumentTableBuilder(body);
+            builder.AddTableRow(new List<string> {"Meow"});
+            builder.Build();
+
+            var createdTableCells = body.Descendants<TableCell>().ToList();
+            var cellContents = createdTableCells.Select(cell => cell.InnerText).ToList();
+
+            Assert.Single(createdTableCells);
+            Assert.Equal("Meow", cellContents[0]);
+        }
+
+        [Fact]
+        public void GivenMultipleCellsInOneRow_AppendsATableWithAMultiCellRow()
+        {
+            var body = new Body();
+            var builder = new DocumentTableBuilder(body);
+            var cellData = new List<string> {"Meow", "Woof", "Quack", "Moo"};
+
+            builder.AddTableRow(cellData);
+            builder.Build();
+
+            var createdTableCells = body.Descendants<TableCell>().ToList();
+            var cellContents = createdTableCells.Select(cell => cell.InnerText).ToList();
+
+            Assert.Equal(4, createdTableCells.Count);
+            Assert.Equal(cellData, cellContents);
+        }
+
+        [Fact]
+        public void GivenMultipleRows_AppendsASingleTableWithAMultipleRows()
+        {
+            var body = new Body();
+            var builder = new DocumentTableBuilder(body);
+            var rowOneData = new List<string> {"Meow", "Woof", "Quack", "Moo"};
+            var rowTwoData = new List<string> {"Cluck", "Howl", "Purr", "Tweet"};
+
+            builder.AddTableRow(rowOneData);
+            builder.AddTableRow(rowTwoData);
+            builder.Build();
+
+            var createdTables = body.Descendants<Table>().ToList();
+            var createdTableRows = createdTables.First().Descendants<TableRow>().ToList();
+            var rowContents = createdTableRows
+                .Select(row =>
+                    row.Descendants<TableCell>().Select(cell => cell.InnerText).ToList()
+                ).ToList();
+
+            Assert.Single(createdTables);
+            Assert.Equal(2, createdTableRows.Count);
+            Assert.Equal(rowOneData, rowContents[0]);
+            Assert.Equal(rowTwoData, rowContents[1]);
+        }
+    }
+}

--- a/DocumentGeneration/DocumentBuilder.cs
+++ b/DocumentGeneration/DocumentBuilder.cs
@@ -19,6 +19,11 @@ namespace DocumentGeneration
             _body = _document.MainDocumentPart.Document.Body;
         }
 
+        public void AddHeading(string text, DocumentHeadingBuilder.HeadingLevelOptions headingLevel)
+        {
+            DocumentHeadingBuilder.AddHeadingToElement(_body, text, headingLevel);
+        }
+        
         public void AddParagraph(string text)
         {
             var paragraph = new Paragraph();

--- a/DocumentGeneration/DocumentBuilder.cs
+++ b/DocumentGeneration/DocumentBuilder.cs
@@ -8,14 +8,12 @@ namespace DocumentGeneration
 {
     public class DocumentBuilder
     {
-        private readonly MemoryStream _memoryStream;
         private readonly WordprocessingDocument _document;
         private readonly Body _body;
 
-        public DocumentBuilder(MemoryStream memoryStream)
+        public DocumentBuilder(Stream stream)
         {
-            _memoryStream = memoryStream;
-            _document = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
+            _document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
             _document.AddMainDocumentPart();
             _document.MainDocumentPart.Document = new Document(new Body());
             _body = _document.MainDocumentPart.Document.Body;
@@ -24,11 +22,9 @@ namespace DocumentGeneration
         public void AddParagraph(string text)
         {
             var paragraph = new Paragraph();
-            var run = new Run() {RunProperties = new RunProperties()};
-            var runProperties = run.RunProperties;
-            var runText = new Text(text);
+            var run = new Run {RunProperties = new RunProperties()};
+            DocumentBuilderHelpers.AddTextToElement(run, text);
 
-            run.AppendChild(runText);
             paragraph.AppendChild(run);
             _body.AppendChild(paragraph);
         }

--- a/DocumentGeneration/DocumentBuilder.cs
+++ b/DocumentGeneration/DocumentBuilder.cs
@@ -6,7 +6,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace DocumentGeneration
 {
-    public class DocumentBuilder
+    public class DocumentBuilder : IDocumentBuilder
     {
         private readonly WordprocessingDocument _document;
         private readonly Body _body;

--- a/DocumentGeneration/DocumentBuilder.cs
+++ b/DocumentGeneration/DocumentBuilder.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocumentGeneration
+{
+    public class DocumentBuilder
+    {
+        private readonly MemoryStream _memoryStream;
+        private readonly WordprocessingDocument _document;
+        private readonly Body _body;
+
+        public DocumentBuilder(MemoryStream memoryStream)
+        {
+            _memoryStream = memoryStream;
+            _document = WordprocessingDocument.Create(memoryStream, WordprocessingDocumentType.Document);
+            _document.AddMainDocumentPart();
+            _document.MainDocumentPart.Document = new Document(new Body());
+            _body = _document.MainDocumentPart.Document.Body;
+        }
+
+        public void AddParagraph(string text)
+        {
+            var paragraph = new Paragraph();
+            var run = new Run() {RunProperties = new RunProperties()};
+            var runProperties = run.RunProperties;
+            var runText = new Text(text);
+
+            run.AppendChild(runText);
+            paragraph.AppendChild(run);
+            _body.AppendChild(paragraph);
+        }
+
+        public void AddTable(List<List<string>> tableData)
+        {
+            var tableBuilder = new DocumentTableBuilder(_body);
+            tableData.ForEach(row => tableBuilder.AddTableRow(row));
+            tableBuilder.Build();
+        }
+
+        public void Build()
+        {
+            _document.Save();
+            _document.Close();
+        }
+    }
+}

--- a/DocumentGeneration/DocumentBuilderHelpers.cs
+++ b/DocumentGeneration/DocumentBuilderHelpers.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocumentGeneration
+{
+    public static class DocumentBuilderHelpers
+    {
+        public static void AddTextToElement(OpenXmlElement element, string text)
+        {
+            var splitText = text.Split(new[] {"\r\n", "\n", "\r"}, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in splitText)
+            {
+                element.AppendChild(new Text(line));
+                if (line != splitText.Last())
+                {
+                    element.AppendChild(new Break());
+                }
+            }
+        }
+    }
+}

--- a/DocumentGeneration/DocumentBuilderTextOptions.cs
+++ b/DocumentGeneration/DocumentBuilderTextOptions.cs
@@ -1,0 +1,7 @@
+namespace DocumentGeneration
+{
+    public class TextOptions
+    {
+        public bool Bold = false;
+    }
+}

--- a/DocumentGeneration/DocumentGeneration.csproj
+++ b/DocumentGeneration/DocumentGeneration.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Open-XML-SDK" Version="2.9.1" />
+    </ItemGroup>
+
+</Project>

--- a/DocumentGeneration/DocumentHeadingBuilder.cs
+++ b/DocumentGeneration/DocumentHeadingBuilder.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocumentGeneration
+{
+    public static class DocumentHeadingBuilder
+    {
+        public enum HeadingLevelOptions
+        {
+            Heading1,
+            Heading2,
+            Heading3
+        }
+
+        public static void AddHeadingToElement(OpenXmlElement parentElement, string text,
+            HeadingLevelOptions headingLevel)
+        {
+            var run = new Run(new Text(text)) {RunProperties = new RunProperties()};
+            var runProperties = run.RunProperties;
+            var headingLevelValues = new Dictionary<HeadingLevelOptions, string>
+            {
+                {HeadingLevelOptions.Heading1, "60"},
+                {HeadingLevelOptions.Heading2, "40"},
+                {HeadingLevelOptions.Heading3, "30"}
+            };
+            runProperties.FontSize = new FontSize {Val = headingLevelValues[headingLevel]};
+            var para = new Paragraph(run);
+                
+            parentElement.AppendChild(para);
+        }
+    }
+}

--- a/DocumentGeneration/DocumentTableBuilder.cs
+++ b/DocumentGeneration/DocumentTableBuilder.cs
@@ -50,7 +50,8 @@ namespace DocumentGeneration
                 var tableCell = new TableCell();
 
                 var paragraph = new Paragraph();
-                var run = new Run(new Text(cellText));
+                var run = new Run();
+                DocumentBuilderHelpers.AddTextToElement(run, cellText);
 
                 paragraph.AppendChild(run);
                 tableCell.AppendChild(paragraph);

--- a/DocumentGeneration/DocumentTableBuilder.cs
+++ b/DocumentGeneration/DocumentTableBuilder.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocumentGeneration
+{
+    public class DocumentTableBuilder
+    {
+        private readonly OpenXmlElement _parentElement;
+        private readonly Table _table;
+
+        public DocumentTableBuilder(OpenXmlElement parentElement)
+        {
+            _parentElement = parentElement;
+            _table = new Table();
+
+            AddTableProperties();
+        }
+
+        private void AddTableProperties()
+        {
+            var tableProperties = new TableProperties
+            {
+                TableBorders = new TableBorders
+                {
+                    TopBorder = new TopBorder
+                        {Color = "000000", Val = BorderValues.Single, Size = 8, Space = 0},
+                    RightBorder = new RightBorder
+                        {Color = "000000", Val = BorderValues.Single, Size = 8, Space = 0},
+                    BottomBorder = new BottomBorder
+                        {Color = "000000", Val = BorderValues.Single, Size = 8, Space = 0},
+                    LeftBorder = new LeftBorder
+                        {Color = "000000", Val = BorderValues.Single, Size = 8, Space = 0},
+                    InsideVerticalBorder = new InsideVerticalBorder
+                        {Color = "000000", Val = BorderValues.Single, Size = 8, Space = 0},
+                    InsideHorizontalBorder = new InsideHorizontalBorder
+                        {Color = "000000", Val = BorderValues.Single, Size = 8, Space = 0},
+                }
+            };
+
+            _table.AppendChild(tableProperties);
+        }
+
+        public void AddTableRow(List<string> cellData)
+        {
+            var tableRow = new TableRow();
+
+            cellData.ForEach(cellText =>
+            {
+                var tableCell = new TableCell();
+
+                var paragraph = new Paragraph();
+                var run = new Run(new Text(cellText));
+
+                paragraph.AppendChild(run);
+                tableCell.AppendChild(paragraph);
+                tableRow.AppendChild(tableCell);
+            });
+            
+            _table.AppendChild(tableRow);
+        }
+
+        public void Build()
+        {
+            _parentElement.AppendChild(_table);
+        }
+    }
+}

--- a/DocumentGeneration/IDocumentBuilder.cs
+++ b/DocumentGeneration/IDocumentBuilder.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace DocumentGeneration
+{
+    public interface IDocumentBuilder
+    {
+        public void AddParagraph(string text);
+
+        public void AddHeading(string text, DocumentHeadingBuilder.HeadingLevelOptions headingLevel);
+
+        public void AddTable(List<List<string>> tableData);
+
+        public void Build();
+    }
+}

--- a/Frontend.Tests/ControllerTests/HeadteacherBoardControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/HeadteacherBoardControllerTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using API.Models.Upstream.Response;
+using API.Repositories;
+using API.Repositories.Interfaces;
+using Frontend.Controllers;
+using Frontend.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Frontend.Tests.ControllerTests
+{
+    public class HeadteacherBoardControllerTests
+    {
+        private readonly HeadteacherBoardController _subject;
+        private readonly Mock<IProjectsRepository> _projectsRepository;
+        private readonly Mock<ICreateHtbDocument> _createHtbDocument;
+
+        public HeadteacherBoardControllerTests()
+        {
+            _projectsRepository = new Mock<IProjectsRepository>();
+            _createHtbDocument = new Mock<ICreateHtbDocument>();
+
+            _subject = new HeadteacherBoardController(_projectsRepository.Object, _createHtbDocument.Object);
+        }
+
+        public class PreviewTests : HeadteacherBoardControllerTests
+        {
+            private readonly Guid _projectId;
+
+            public PreviewTests()
+            {
+                _projectId = Guid.NewGuid();
+
+                _projectsRepository.Setup(r => r.GetProjectById(_projectId)).ReturnsAsync(
+                    new RepositoryResult<GetProjectsResponseModel>
+                    {
+                        Result = new GetProjectsResponseModel
+                        {
+                            ProjectId = _projectId,
+                            ProjectAcademies = new List<GetProjectsAcademyResponseModel>
+                            {
+                                new GetProjectsAcademyResponseModel {AcademyName = "Cat Academy"}
+                            }
+                        }
+                    });
+            }
+
+            [Fact]
+            public async void GivenId_GetsTheProjectFromTheProjectRepository()
+            {
+                await _subject.Preview(_projectId);
+                _projectsRepository.Verify(r => r.GetProjectById(_projectId), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenId_PutsTheProjectIdAndAcademyNameInTheViewData()
+            {
+                await _subject.Preview(_projectId);
+
+                Assert.Equal(_projectId, _subject.ViewData["ProjectId"]);
+                Assert.Equal("Cat Academy", _subject.ViewData["AcademyName"]);
+            }
+        }
+
+        public class GenerateDocumentTests : HeadteacherBoardControllerTests
+        {
+            [Fact]
+            public async void GivenId_GeneratesAnHtbDocumentForTheProject()
+            {
+                var projectId = Guid.NewGuid();
+                await _subject.GenerateDocument(projectId);
+
+                _createHtbDocument.Verify(s => s.Execute(projectId), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenId_ReturnsAFileWithTheGeneratedDocument()
+            {
+                var projectId = Guid.NewGuid();
+                var fileContents = new byte[] {1, 2, 3, 4};
+                _createHtbDocument.Setup(s => s.Execute(projectId)).ReturnsAsync(fileContents);
+                var response = await _subject.GenerateDocument(projectId);
+                var fileResponse = Assert.IsType<FileContentResult>(response);
+                
+                Assert.Equal(fileContents, fileResponse.FileContents);
+            }
+        }
+    }
+}

--- a/Frontend.Tests/Frontend.Tests.csproj
+++ b/Frontend.Tests/Frontend.Tests.csproj
@@ -18,4 +18,8 @@
       <ProjectReference Include="..\Frontend\Frontend.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="ServicesTests" />
+    </ItemGroup>
+
 </Project>

--- a/Frontend/Controllers/HeadteacherBoardController.cs
+++ b/Frontend/Controllers/HeadteacherBoardController.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Repositories;
+using API.Repositories.Interfaces;
+using DocumentGeneration;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Frontend.Controllers
+{
+    [Route("project/{id}/headteacher-board")]
+    public class HeadteacherBoardController : Controller
+    {
+        private readonly IProjectsRepository _projectsRepository;
+        private readonly IAcademiesRepository _academiesRepository;
+
+        public HeadteacherBoardController(IProjectsRepository projectsRepository,
+            IAcademiesRepository academiesRepository)
+        {
+            _projectsRepository = projectsRepository;
+            _academiesRepository = academiesRepository;
+        }
+
+        [Route("preview")]
+        public IActionResult Preview([FromRoute] Guid id)
+        {
+            ViewData["ProjectId"] = id;
+            return View();
+        }
+
+        [Route("download")]
+        public IActionResult Download([FromRoute] Guid id)
+        {
+            ViewData["ProjectId"] = id;
+            return View();
+        }
+
+        public async Task<IActionResult> GenerateDocument([FromRoute] Guid id)
+        {
+            var projectResult = await _projectsRepository.GetProjectById(id);
+            var projectAcademy = projectResult.Result.ProjectAcademies.First().AcademyId;
+            var academyResult = await _academiesRepository.GetAcademyById(projectAcademy);
+            var academy = academyResult.Result;
+
+            MemoryStream ms;
+
+            await using (ms = new MemoryStream())
+            {
+                var generator = new DocumentBuilder(ms);
+                
+                generator.AddParagraph($"General and performance information - {academy.AcademyName}");
+                
+                var tableData = new List<List<string>>
+                {
+                    new List<string> {"School phase", "Primary"},
+                    new List<string> {"Age range", "4 to 11"},
+                    new List<string> {"School type", academy.EstablishmentType},
+                    new List<string> {"NOR (%full)", "113 (100%)"},
+                    new List<string> {"Capacity", "113"},
+                    new List<string> {"PAN", "17"},
+                    new List<string> {"PFI", "No"},
+                    new List<string> {"Viability issues?", "No"}
+                };
+                generator.AddTable(tableData);
+
+                generator.Build();
+            }
+
+            return File(ms.ToArray(), "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "Test.docx");
+        }
+    }
+}

--- a/Frontend/Controllers/HeadteacherBoardController.cs
+++ b/Frontend/Controllers/HeadteacherBoardController.cs
@@ -1,32 +1,35 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using API.Repositories;
 using API.Repositories.Interfaces;
-using DocumentGeneration;
+using Frontend.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Frontend.Controllers
 {
+    [Authorize]
     [Route("project/{id}/headteacher-board")]
     public class HeadteacherBoardController : Controller
     {
         private readonly IProjectsRepository _projectsRepository;
-        private readonly IAcademiesRepository _academiesRepository;
+        private readonly ICreateHtbDocument _createHtbDocument;
 
-        public HeadteacherBoardController(IProjectsRepository projectsRepository,
-            IAcademiesRepository academiesRepository)
+        public HeadteacherBoardController(IProjectsRepository projectsRepository, ICreateHtbDocument createHtbDocument)
         {
             _projectsRepository = projectsRepository;
-            _academiesRepository = academiesRepository;
+            _createHtbDocument = createHtbDocument;
         }
 
         [Route("preview")]
-        public IActionResult Preview([FromRoute] Guid id)
+        public async Task<IActionResult> Preview([FromRoute] Guid id)
         {
+            var projectResult = await _projectsRepository.GetProjectById(id);
+            var projectAcademy = projectResult.Result.ProjectAcademies.First();
+
             ViewData["ProjectId"] = id;
+            ViewData["AcademyName"] = projectAcademy.AcademyName;
+
             return View();
         }
 
@@ -39,36 +42,10 @@ namespace Frontend.Controllers
 
         public async Task<IActionResult> GenerateDocument([FromRoute] Guid id)
         {
-            var projectResult = await _projectsRepository.GetProjectById(id);
-            var projectAcademy = projectResult.Result.ProjectAcademies.First().AcademyId;
-            var academyResult = await _academiesRepository.GetAcademyById(projectAcademy);
-            var academy = academyResult.Result;
+            var documentArray = await _createHtbDocument.Execute(id);
 
-            MemoryStream ms;
-
-            await using (ms = new MemoryStream())
-            {
-                var generator = new DocumentBuilder(ms);
-                
-                generator.AddParagraph($"General and performance information - {academy.AcademyName}");
-                
-                var tableData = new List<List<string>>
-                {
-                    new List<string> {"School phase", "Primary"},
-                    new List<string> {"Age range", "4 to 11"},
-                    new List<string> {"School type", academy.EstablishmentType},
-                    new List<string> {"NOR (%full)", "113 (100%)"},
-                    new List<string> {"Capacity", "113"},
-                    new List<string> {"PAN", "17"},
-                    new List<string> {"PFI", "No"},
-                    new List<string> {"Viability issues?", "No"}
-                };
-                generator.AddTable(tableData);
-
-                generator.Build();
-            }
-
-            return File(ms.ToArray(), "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            return File(documentArray.ToArray(),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 "Test.docx");
         }
     }

--- a/Frontend/Controllers/HomeController.cs
+++ b/Frontend/Controllers/HomeController.cs
@@ -2,6 +2,8 @@
 using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using API.Models.Upstream.Enums;
+using API.Models.Upstream.Response;
 using API.Repositories.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -19,7 +21,8 @@ namespace Frontend.Controllers
         private readonly IConfiguration _configuration;
         private readonly IProjectsRepository _projectsRepository;
 
-        public HomeController(ILogger<HomeController> logger, IConfiguration configuration, IProjectsRepository projectsRepository)
+        public HomeController(ILogger<HomeController> logger, IConfiguration configuration,
+            IProjectsRepository projectsRepository)
         {
             _logger = logger;
             _configuration = configuration;
@@ -27,8 +30,16 @@ namespace Frontend.Controllers
         }
 
         [Authorize]
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
+            var projects = await _projectsRepository.SearchProject("", ProjectStatusEnum.InProgress, false);
+            var projectInformation = new Dictionary<string, SearchProjectsModel>() { };
+
+            projects.Result.Projects.ForEach(project =>
+                projectInformation.Add(project.ProjectId.ToString(), project));
+
+            ViewData["ProjectInformation"] = projectInformation;
+
             return View();
         }
 

--- a/Frontend/Controllers/ProjectController.cs
+++ b/Frontend/Controllers/ProjectController.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Threading.Tasks;
 using API.Repositories.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Frontend.Controllers
 {
+    [Authorize]
     [Route("project/{id}")]
     public class ProjectController : Controller
     {

--- a/Frontend/Controllers/ProjectController.cs
+++ b/Frontend/Controllers/ProjectController.cs
@@ -21,6 +21,7 @@ namespace Frontend.Controllers
             
             ViewData["OutgoingTrustName"] = project.Result.ProjectTrusts[0].TrustName;
             ViewData["ProjectName"] = project.Result.ProjectName;
+            ViewData["ProjectId"] = id;
             
             return View();
         }

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -19,6 +19,7 @@
     <None Include="wwwroot\webpack.config.js" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DocumentGeneration\DocumentGeneration.csproj" />
     <ProjectReference Include="..\TRAMS-API\API.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Frontend/Services/CreateHtbDocument.cs
+++ b/Frontend/Services/CreateHtbDocument.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Repositories;
+using API.Repositories.Interfaces;
+using DocumentGeneration;
+
+namespace Frontend.Services
+{
+    public class CreateHtbDocument : ICreateHtbDocument
+    {
+        private readonly IProjectsRepository _projectsRepository;
+        private readonly IAcademiesRepository _academiesRepository;
+
+        public CreateHtbDocument(IProjectsRepository projectsRepository, IAcademiesRepository academiesRepository)
+        {
+            _projectsRepository = projectsRepository;
+            _academiesRepository = academiesRepository;
+        }
+
+        public async Task<byte[]> Execute(Guid projectId)
+        {
+            var projectResult = await _projectsRepository.GetProjectById(projectId);
+            var projectAcademy = projectResult.Result.ProjectAcademies.First().AcademyId;
+            var academyResult = await _academiesRepository.GetAcademyById(projectAcademy);
+            var academy = academyResult.Result;
+
+            MemoryStream ms;
+
+            await using (ms = new MemoryStream())
+            {
+                var generator = new DocumentBuilder(ms);
+
+                generator.AddHeading($"General and performance information - {academy.AcademyName}",
+                    DocumentHeadingBuilder.HeadingLevelOptions.Heading3);
+
+                var tableData = new List<List<string>>
+                {
+                    new List<string> {"School phase", "Primary"},
+                    new List<string> {"Age range", "4 to 11"},
+                    new List<string> {"School type", academy.EstablishmentType},
+                    new List<string> {"NOR (%full)", "113 (100%)"},
+                    new List<string> {"Capacity", "113"},
+                    new List<string> {"PAN", "17"},
+                    new List<string> {"PFI", "No"},
+                    new List<string> {"Viability issues?", "No"}
+                };
+                generator.AddTable(tableData);
+
+                generator.Build();
+            }
+
+            return ms.ToArray();
+        }
+    }
+}

--- a/Frontend/Services/ICreateHtbDocument.cs
+++ b/Frontend/Services/ICreateHtbDocument.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Frontend.Services
+{
+    public interface ICreateHtbDocument
+    {
+        public Task<byte[]> Execute(Guid projectId);
+    }
+}

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -9,6 +9,8 @@ using API.Models.Upstream.Response;
 using API.ODataHelpers;
 using API.Repositories;
 using API.Repositories.Interfaces;
+using DocumentGeneration;
+using Frontend.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -58,6 +60,7 @@ namespace Frontend
             ConfigureRepositories(services);
             ConfigureHelpers(services);
             ConfigureMappers(services);
+            ConfigureServiceClasses(services);
 
             services.AddSession(options =>
             {
@@ -102,9 +105,7 @@ namespace Frontend
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapControllerRoute(
-                    name: "default",
-                    pattern: "{controller=Home}/{action=Index}/");
+                endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/");
             });
         }
 
@@ -157,6 +158,11 @@ namespace Frontend
             services.AddTransient<IEstablishmentNameFormatter, EstablishmentNameFormatter>();
 
             services.AddTransient<IODataSanitizer, ODataSanitizer>();
+        }
+
+        private static void ConfigureServiceClasses(IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddTransient<ICreateHtbDocument, CreateHtbDocument>();
         }
 
         private AuthenticatedHttpClient CreateHttpClient()

--- a/Frontend/Views/HeadteacherBoard/Download.cshtml
+++ b/Frontend/Views/HeadteacherBoard/Download.cshtml
@@ -1,0 +1,30 @@
+@model object
+
+@{
+    ViewBag.Title = "title";
+    Layout = "_Layout";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <div>
+            <h1 class="govuk-heading-xl">Generate headteacher board (HTB) documents</h1>
+        </div>
+        <div class="govuk-inset-text">
+            <p class="govuk-body-m">Save these documents in the school's Sharepoint file</p>
+        </div>
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+                <a aria-hidden="true" class="thumbnail" tabindex="-1" href="#"></a><img alt="" src="https://www.gov.uk/assets/whitehall/pub-cover-html-b0465911e56983d98c70f0e25fba24bc206d37e8c83d4addf6421dcf6022c6cd.png">
+            </div>
+            <div class="govuk-grid-column-three-quarters">
+                <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
+                    <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener" download asp-action="GenerateDocument" asp-route-id="@ViewData["ProjectId"]">
+                        HTBTemplate.docx
+                    </a>
+                </h2>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Frontend/Views/HeadteacherBoard/Download.cshtml
+++ b/Frontend/Views/HeadteacherBoard/Download.cshtml
@@ -5,6 +5,11 @@
     Layout = "_Layout";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-action="Preview" asp-route-id="@ViewData["ProjectId"]">Back</a>
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div>

--- a/Frontend/Views/HeadteacherBoard/Preview.cshtml
+++ b/Frontend/Views/HeadteacherBoard/Preview.cshtml
@@ -5,10 +5,15 @@
     Layout = "_Layout";
 }
 
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@ViewData["ProjectId"]">Back</a>
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-xl">Preview HTB Template</h1>
-        <h2 class="govuk-heading-l">General information - [Outgoing academy]</h2>
+        <h2 class="govuk-heading-l">General information - @ViewData["AcademyName"]</h2>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">

--- a/Frontend/Views/HeadteacherBoard/Preview.cshtml
+++ b/Frontend/Views/HeadteacherBoard/Preview.cshtml
@@ -1,0 +1,82 @@
+@model object
+
+@{
+    ViewBag.Title = "title";
+    Layout = "_Layout";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-xl">Preview HTB Template</h1>
+        <h2 class="govuk-heading-l">General information - [Outgoing academy]</h2>
+        <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    School phase
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    Primary
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Age range
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    4 to 11
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    School type
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    Academy
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    NOR (%full)
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    113 (100%)
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Capacity
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    113
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    PAN
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    17
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    PFI
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    No
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Viability issues?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    No
+                </dd>
+            </div>
+        </dl>
+    </div>
+    <a role="button" draggable="false" class="govuk-button" data-module="govuk-button" asp-action="Download" asp-route-id="@ViewData["ProjectId"]">
+        Download HTB Templates
+    </a>
+</div>

--- a/Frontend/Views/Home/Index.cshtml
+++ b/Frontend/Views/Home/Index.cshtml
@@ -1,6 +1,9 @@
-﻿@{
+﻿@using API.Models.Upstream.Response
+@{
     ViewData["Title"] = "Home Page";
+    var projectInformation = (Dictionary<string, SearchProjectsModel>) ViewData["ProjectInformation"];
 }
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h2 class="govuk-hint">Home</h2>
@@ -9,5 +12,13 @@
         <a asp-controller="Transfers" asp-action="TrustName" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
             Start a new transfer project
         </a>
+        @foreach (var (projectId, project) in projectInformation)
+        {
+            <p class="govuk-body">
+                <a class="govuk-link" asp-controller="Project" asp-action="Index" asp-route-id="@projectId">
+                    @project.ProjectName
+                </a>
+            </p>
+        }
     </div>
 </div>

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -12,7 +12,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-    
+
         <span class="govuk-caption-xl">@ViewData["ProjectName"]</span>
         <h1 class="govuk-heading-xl">
             @ViewData["OutgoingTrustName"]
@@ -139,5 +139,8 @@
                 </ul>
             </li>
         </ol>
+        <a role="button" draggable="false" class="govuk-button" data-module="govuk-button" asp-controller="HeadteacherBoard" asp-action="Preview" asp-route-id="@ViewData["ProjectId"]">
+            Preview HTB Template
+        </a>
     </div>
 </div>

--- a/academy-transfers-api.sln
+++ b/academy-transfers-api.sln
@@ -18,6 +18,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Frontend", "Frontend\Fronte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Frontend.Tests", "Frontend.Tests\Frontend.Tests.csproj", "{6A7EFD6D-24BD-4101-9CD0-F57EAE47BF4F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentGeneration", "DocumentGeneration\DocumentGeneration.csproj", "{B3E5C233-7BB8-49DB-B9BE-6803D0C0B8B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentGeneration.Tests", "DocumentGeneration.Tests\DocumentGeneration.Tests.csproj", "{0EE8EA1E-A952-4671-9613-2D26D2459C16}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +44,14 @@ Global
 		{6A7EFD6D-24BD-4101-9CD0-F57EAE47BF4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A7EFD6D-24BD-4101-9CD0-F57EAE47BF4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A7EFD6D-24BD-4101-9CD0-F57EAE47BF4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3E5C233-7BB8-49DB-B9BE-6803D0C0B8B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3E5C233-7BB8-49DB-B9BE-6803D0C0B8B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3E5C233-7BB8-49DB-B9BE-6803D0C0B8B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3E5C233-7BB8-49DB-B9BE-6803D0C0B8B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EE8EA1E-A952-4671-9613-2D26D2459C16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EE8EA1E-A952-4671-9613-2D26D2459C16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EE8EA1E-A952-4671-9613-2D26D2459C16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EE8EA1E-A952-4671-9613-2D26D2459C16}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Context

We want to support the creation of Word documents for our users to be able to edit further down the line, giving them a good starting point.

In the long run, the desire will be to move the `DocumentGeneration` project out to a separate library to be used across SDD - for the ease
of development now this is just a project internal to this.

### Changes proposed in this pull request

- Add document generator with ability to add tables
- Quick initial workflow for downloading documents
- Support new lines in text
- Support headings in document generation
- Create HTB document download workflow

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

