### PR TITLE
Create TRAMS API Classes

### DIFF
--- a/API.Tests/MappersTests/GetProjectsModelMapperTests.cs
+++ b/API.Tests/MappersTests/GetProjectsModelMapperTests.cs
@@ -10,12 +10,12 @@ namespace API.Tests.MapperTests
 {
     public class GetProjectsModelMapperTests
     {
-        private readonly GetProjectsResponseMapper _mapper;
+        private readonly GetProjectsResponseDynamicsMapper _dynamicsMapper;
 
         public GetProjectsModelMapperTests()
         {
             var establishmentNameFormatter = new EstablishmentNameFormatter();
-            _mapper = new GetProjectsResponseMapper(new GetProjectAcademiesResponseMapper(establishmentNameFormatter), establishmentNameFormatter);
+            _dynamicsMapper = new GetProjectsResponseDynamicsMapper(new GetProjectAcademiesResponseDynamicsMapper(establishmentNameFormatter), establishmentNameFormatter);
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace API.Tests.MapperTests
         {
             var model = (GetProjectsD365Model)null;
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Null(result);
         }
@@ -36,7 +36,7 @@ namespace API.Tests.MapperTests
                 ProjectId = Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9")
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectId);
         }
@@ -49,7 +49,7 @@ namespace API.Tests.MapperTests
                 ProjectName = "Some name"
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal("Some name", result.ProjectName);
         }
@@ -62,7 +62,7 @@ namespace API.Tests.MapperTests
                 ProjectStatus = Models.D365.Enums.ProjectStatusEnum.Completed
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.ProjectStatusEnum.Completed, result.ProjectStatus);
         }
@@ -76,7 +76,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorUid = "joe.bloggs@email.com"
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal("Joe Bloggs", result.ProjectInitiatorFullName);
             Assert.Equal("joe.bloggs@email.com", result.ProjectInitiatorUid);
@@ -98,7 +98,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectAcademies[0].ProjectAcademyId);
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1"), result.ProjectAcademies[0].AcademyId);
@@ -133,7 +133,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectAcademies[0].ProjectAcademyId);
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1"), result.ProjectAcademies[0].AcademyId);
@@ -162,7 +162,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].EsfaInterventionReasons);
         }
@@ -181,7 +181,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].EsfaInterventionReasons);
         }
@@ -200,7 +200,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.GovernanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[0]);
             Assert.Single(result.ProjectAcademies[0].EsfaInterventionReasons);
@@ -220,7 +220,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.GovernanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[0]);
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.FinanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[1]);
@@ -251,7 +251,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.GovernanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[0]);
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.FinanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[1]);
@@ -278,7 +278,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].RddOrRscInterventionReasons);
         }
@@ -297,7 +297,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].RddOrRscInterventionReasons);
         }
@@ -316,7 +316,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(RddOrRscInterventionReasonEnum.TerminationWarningNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[0]);
             Assert.Single(result.ProjectAcademies[0].RddOrRscInterventionReasons);
@@ -336,7 +336,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(RddOrRscInterventionReasonEnum.TerminationWarningNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[0]);
             Assert.Equal(RddOrRscInterventionReasonEnum.RSCMindedToTerminateNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[1]);
@@ -367,7 +367,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(RddOrRscInterventionReasonEnum.TerminationWarningNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[0]);
             Assert.Equal(RddOrRscInterventionReasonEnum.RSCMindedToTerminateNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[1]);
@@ -407,7 +407,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal("RDD Explanation", result.ProjectAcademies[0].RddOrRscInterventionReasonsExplained);
             Assert.Equal("ESFA Explanation", result.ProjectAcademies[0].EsfaInterventionReasonsExplained);
@@ -430,7 +430,7 @@ namespace API.Tests.MapperTests
                 Academies = null
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies);
         }
@@ -443,7 +443,7 @@ namespace API.Tests.MapperTests
                 Academies = new List<AcademyTransfersProjectAcademy>()
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies);
         }
@@ -456,7 +456,7 @@ namespace API.Tests.MapperTests
                 Trusts = null
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectTrusts);
         }
@@ -469,7 +469,7 @@ namespace API.Tests.MapperTests
                 Trusts = new List<ProjectTrust>()
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectTrusts);
         }
@@ -490,7 +490,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Single(result.ProjectTrusts);
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectTrusts[0].ProjectTrustId);
@@ -526,7 +526,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(3, result.ProjectTrusts.Count);
 

--- a/API.Tests/MappersTests/ModelMappingTests.cs
+++ b/API.Tests/MappersTests/ModelMappingTests.cs
@@ -32,7 +32,7 @@ namespace API.Tests.MapperTests
                 Urn = "4242"
             };
 
-            var mapper = new GetAcademiesResponseMapper(new EstablishmentNameFormatter());
+            var mapper = new GetAcademiesResponseDynamicsMapper(new EstablishmentNameFormatter());
 
             var result = mapper.Map(academiesD365Model);
 
@@ -69,7 +69,7 @@ namespace API.Tests.MapperTests
                 Upin = "42424",
             };
 
-            var mapper = new GetTrustsReponseMapper(new EstablishmentNameFormatter());
+            var mapper = new GetTrustsReponseDynamicsMapper(new EstablishmentNameFormatter());
 
             var result = mapper.Map(d365Model);
 

--- a/API.Tests/MappersTests/PostProjectsRequestMapperTests.cs
+++ b/API.Tests/MappersTests/PostProjectsRequestMapperTests.cs
@@ -9,11 +9,11 @@ namespace API.Tests.MapperTests
 {
     public class PostProjectsRequestMapperTests
     {
-        private readonly PostProjectsRequestMapper _mapper;
+        private readonly PostProjectsRequestDynamicsMapper _dynamicsMapper;
 
         public PostProjectsRequestMapperTests()
         {
-            _mapper = new PostProjectsRequestMapper(new PostProjectAcademiesRequestMapper());
+            _dynamicsMapper = new PostProjectsRequestDynamicsMapper(new PostProjectAcademiesRequestDynamicsMapper());
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].AcademyId);
         }
@@ -44,7 +44,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorUid = "joebloggs@email.com"
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Joe Bloggs", result.ProjectInitiatorFullName);
             Assert.Equal("joebloggs@email.com", result.ProjectInitiatorUid);
@@ -58,7 +58,7 @@ namespace API.Tests.MapperTests
                 ProjectStatus = Models.Upstream.Enums.ProjectStatusEnum.Completed
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal(Models.D365.Enums.ProjectStatusEnum.Completed, result.ProjectStatus);
         }
@@ -85,7 +85,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].AcademyId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Academies[1].AcademyId);
@@ -106,7 +106,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.Academies[0].EsfaInterventionReasons));
         }
@@ -128,7 +128,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001", result.Academies[0].EsfaInterventionReasons);
         }
@@ -152,7 +152,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001,596500002,596500003", result.Academies[0].EsfaInterventionReasons);
         }
@@ -187,7 +187,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Null(result.Academies[0].EsfaInterventionReasons);
             Assert.Equal("596500001", result.Academies[1].EsfaInterventionReasons);
@@ -208,7 +208,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.Academies[0].EsfaInterventionReasonsExplained));
         }
@@ -227,7 +227,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Some explanation", result.Academies[0].EsfaInterventionReasonsExplained);
         }
@@ -254,7 +254,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Some explanation", result.Academies[0].EsfaInterventionReasonsExplained);
             Assert.True(string.IsNullOrEmpty(result.Academies[1].EsfaInterventionReasonsExplained));
@@ -275,7 +275,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.Academies[0].RddOrRscInterventionReasons));
         }
@@ -297,7 +297,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002", result.Academies[0].RddOrRscInterventionReasons);
         }
@@ -321,7 +321,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002,596500001,596500000", result.Academies[0].RddOrRscInterventionReasons);
         }
@@ -356,7 +356,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002,596500001,596500000", result.Academies[0].RddOrRscInterventionReasons);
             Assert.Equal("596500002", result.Academies[1].RddOrRscInterventionReasons);
@@ -374,7 +374,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Empty(result.Academies[0].Trusts);
         }
@@ -399,7 +399,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].Trusts[0].TrustId);
         }
@@ -432,7 +432,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].Trusts[0].TrustId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Academies[0].Trusts[1].TrustId);
@@ -477,7 +477,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].Trusts[0].TrustId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Academies[1].Trusts[0].TrustId);
@@ -493,7 +493,7 @@ namespace API.Tests.MapperTests
                 ProjectTrusts = null
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Empty(result.Trusts);
         }
@@ -512,7 +512,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Trusts[0].TrustId);
         }
@@ -539,7 +539,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Trusts[0].TrustId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672ff2)", result.Trusts[1].TrustId);

--- a/API.Tests/MappersTests/PutProjectAcademyMapperTests.cs
+++ b/API.Tests/MappersTests/PutProjectAcademyMapperTests.cs
@@ -10,11 +10,11 @@ namespace API.Tests.MapperTests
 {
     public class PutProjectAcademyMapperTests
     {
-        private readonly PutProjectAcademiesRequestMapper _mapper; 
+        private readonly PutProjectAcademiesRequestDynamicsMapper _dynamicsMapper; 
 
         public PutProjectAcademyMapperTests()
         {
-            _mapper = new PutProjectAcademiesRequestMapper();
+            _dynamicsMapper = new PutProjectAcademiesRequestDynamicsMapper();
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace API.Tests.MapperTests
                 AcademyId = Guid.Parse("81014326-5d51-e911-a82e-000d3a385a17")
             };
                 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.AcademyId);
         }
@@ -38,7 +38,7 @@ namespace API.Tests.MapperTests
                 EsfaInterventionReasons = null
             };
                 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.EsfaInterventionReasons));
         }
@@ -54,7 +54,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001", result.EsfaInterventionReasons);
         }
@@ -72,7 +72,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001,596500002,596500003", result.EsfaInterventionReasons);
         }
@@ -86,7 +86,7 @@ namespace API.Tests.MapperTests
                 EsfaInterventionReasonsExplained = null
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.EsfaInterventionReasonsExplained));
         }
@@ -99,7 +99,7 @@ namespace API.Tests.MapperTests
                 EsfaInterventionReasonsExplained = "Some explanation"
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Some explanation", result.EsfaInterventionReasonsExplained);
         }
@@ -112,7 +112,7 @@ namespace API.Tests.MapperTests
                 RddOrRscInterventionReasons = null
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.RddOrRscInterventionReasons));
         }
@@ -128,7 +128,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002", result.RddOrRscInterventionReasons);
         }
@@ -146,7 +146,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002,596500001,596500000", result.RddOrRscInterventionReasons);
         }

--- a/API.Tests/MappersTests/SearchProjectsMapperTests.cs
+++ b/API.Tests/MappersTests/SearchProjectsMapperTests.cs
@@ -9,17 +9,17 @@ namespace API.Tests.MapperTests
 {
     public class SearchProjectsMapperTests
     {
-        private readonly SearchProjectsItemMapper _mapper;
+        private readonly SearchProjectsItemDynamicsMapper _dynamicsMapper;
 
         public SearchProjectsMapperTests()
         {
-            _mapper = new SearchProjectsItemMapper();
+            _dynamicsMapper = new SearchProjectsItemDynamicsMapper();
         }
 
         [Fact]
         public void NullInput_Returns_Null()
         {
-            var result = _mapper.Map(null);
+            var result = _dynamicsMapper.Map(null);
 
             Assert.Null(result);
         }
@@ -29,7 +29,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal((Guid)default, result.ProjectId);
         }
@@ -42,7 +42,7 @@ namespace API.Tests.MapperTests
                 ProjectId = Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1")
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1"), result.ProjectId);
         }
@@ -52,7 +52,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Null(result.ProjectInitiatorUid);
         }
@@ -68,7 +68,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorUid = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectInitiatorUid);
         }
@@ -78,7 +78,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Null(result.ProjectName);
         }
@@ -95,7 +95,7 @@ namespace API.Tests.MapperTests
                 ProjectName = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectName);
         }
@@ -105,7 +105,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Null(result.ProjectInitiatorFullName);
         }
@@ -122,7 +122,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorFullName = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectInitiatorFullName);
         }
@@ -132,7 +132,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
             
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(default, result.ProjectStatus);
         }
@@ -147,7 +147,7 @@ namespace API.Tests.MapperTests
                 ProjectStatus = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectStatus);
         }

--- a/API.Tests/MappersTests/SearchProjectsPageResponseMapperTests.cs
+++ b/API.Tests/MappersTests/SearchProjectsPageResponseMapperTests.cs
@@ -9,18 +9,18 @@ namespace API.Tests.MapperTests
 {
     public class SearchProjectsPageResponseMapperTests
     {
-        private readonly Mapping.SearchProjectsPageResponseMapper _mapper;
+        private readonly Mapping.SearchProjectsPageResponseDynamicsMapper _dynamicsMapper;
 
         public SearchProjectsPageResponseMapperTests()
         {
-            var itemMapper = new SearchProjectsItemMapper();
-            _mapper = new Mapping.SearchProjectsPageResponseMapper(itemMapper);
+            var itemMapper = new SearchProjectsItemDynamicsMapper();
+            _dynamicsMapper = new Mapping.SearchProjectsPageResponseDynamicsMapper(itemMapper);
         }
 
         [Fact]
         public void NullInput_Returns_NullValue()
         {
-            var result = _mapper.Map(null);
+            var result = _dynamicsMapper.Map(null);
 
             Assert.Null(result);
         }
@@ -36,7 +36,7 @@ namespace API.Tests.MapperTests
                 TotalPages = input
             };
 
-            var result = _mapper.Map(inputPageModel);
+            var result = _dynamicsMapper.Map(inputPageModel);
 
             Assert.Equal(expected, result.TotalPages);
         }
@@ -52,7 +52,7 @@ namespace API.Tests.MapperTests
                 CurrentPage = input
             };
 
-            var result = _mapper.Map(inputPageModel);
+            var result = _dynamicsMapper.Map(inputPageModel);
 
             Assert.Equal(expected, result.CurrentPage);
         }
@@ -60,12 +60,12 @@ namespace API.Tests.MapperTests
         [Fact]
         public void ItemMapper_CallTest()
         {
-            var itemMapper = new Mock<IMapper<SearchProjectsD365Model, SearchProjectsModel>>();
+            var itemMapper = new Mock<IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel>>();
 
             itemMapper.Setup(m => m.Map(It.IsAny<SearchProjectsD365Model>()))
                       .Verifiable();
 
-            var pageMapper = new SearchProjectsPageResponseMapper(itemMapper.Object);
+            var pageMapper = new SearchProjectsPageResponseDynamicsMapper(itemMapper.Object);
 
             var inputModel = new SearchProjectsD365PageModel
             {

--- a/API.Tests/RepositoriesTests/AcademiesRepositoryTests.cs
+++ b/API.Tests/RepositoriesTests/AcademiesRepositoryTests.cs
@@ -20,13 +20,13 @@ namespace API.Tests.RepositoriesTests
         private readonly Mock<IAuthenticatedHttpClient> _mockClient;
         private readonly Mock<IOdataUrlBuilder<GetAcademiesD365Model>> _mockUrlBuilder;
         private readonly AcademiesDynamicsRepository _subject;
-        private readonly Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>> _365AcademiesMapper;
+        private readonly Mock<IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>> _365AcademiesMapper;
 
         public AcademiesRepositoryTests()
         {
             _mockClient = new Mock<IAuthenticatedHttpClient>();
             _mockUrlBuilder = new Mock<IOdataUrlBuilder<GetAcademiesD365Model>>();
-            _365AcademiesMapper = new Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>>();
+            _365AcademiesMapper = new Mock<IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>>();
             var mockedLogger = new Mock<ILogger<AcademiesDynamicsRepository>>();
             _subject = new AcademiesDynamicsRepository(_mockClient.Object, _mockUrlBuilder.Object, mockedLogger.Object,
                 _365AcademiesMapper.Object);

--- a/API.Tests/RepositoriesTests/TrustsRepositoryTests.cs
+++ b/API.Tests/RepositoriesTests/TrustsRepositoryTests.cs
@@ -20,13 +20,13 @@ namespace API.Tests.RepositoriesTests
         private readonly TrustsDynamicsRepository _subject;
         private readonly Mock<IOdataUrlBuilder<GetTrustsD365Model>> _mockUrlBuilder;
         private readonly Mock<IAuthenticatedHttpClient> _mockClient;
-        private readonly Mock<IMapper<GetTrustsD365Model, GetTrustsModel>> _getTrustMapper;
+        private readonly Mock<IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>> _getTrustMapper;
 
         public TrustsRepositoryTests()
         {
             _mockClient = new Mock<IAuthenticatedHttpClient>();
             _mockUrlBuilder = new Mock<IOdataUrlBuilder<GetTrustsD365Model>>();
-            _getTrustMapper = new Mock<IMapper<GetTrustsD365Model, GetTrustsModel>>();
+            _getTrustMapper = new Mock<IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>>();
             var mockedLogger = new Mock<ILogger<TrustsDynamicsRepository>>();
             var mockSanitizer = new Mock<IODataSanitizer>();
 

--- a/Data.Mock/MockAcademyRepository.cs
+++ b/Data.Mock/MockAcademyRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Data.Models;
+using Data.Models.Academies;
 
 namespace Data.Mock
 {

--- a/Data.Mock/MockTrustsRepository.cs
+++ b/Data.Mock/MockTrustsRepository.cs
@@ -1,0 +1,7 @@
+namespace Data.Mock
+{
+    public class MockTrustsRepository
+    {
+        
+    }
+}

--- a/Data.Mock/MockTrustsRepository.cs
+++ b/Data.Mock/MockTrustsRepository.cs
@@ -1,7 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Data.Models;
+
 namespace Data.Mock
 {
-    public class MockTrustsRepository
+    public class MockTrustsRepository : ITrusts
     {
-        
+        public Task<RepositoryResult<List<TrustSearchResult>>> SearchTrusts(string searchQuery = "")
+        {
+            var result = new RepositoryResult<List<TrustSearchResult>>
+            {
+                Result = new List<TrustSearchResult>
+                {
+                    new TrustSearchResult
+                    {
+                        Ukprn = "0001",
+                        TrustName = "Example trust",
+                        CompaniesHouseNumber = "00001",
+                        Academies = new List<TrustSearchAcademies>
+                        {
+                            new TrustSearchAcademies {Ukprn = "0002", Name = "Example Academy"}
+                        }
+                    }
+                }
+            };
+
+            return Task.FromResult(result);
+        }
     }
 }

--- a/Data.Mock/MockTrustsRepository.cs
+++ b/Data.Mock/MockTrustsRepository.cs
@@ -27,5 +27,10 @@ namespace Data.Mock
 
             return Task.FromResult(result);
         }
+
+        public Task<RepositoryResult<Trust>> GetByUkprn(string ukprn)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/Data.Mock/MockTrustsRepository.cs
+++ b/Data.Mock/MockTrustsRepository.cs
@@ -17,9 +17,9 @@ namespace Data.Mock
                         Ukprn = "0001",
                         TrustName = "Example trust",
                         CompaniesHouseNumber = "00001",
-                        Academies = new List<TrustSearchAcademies>
+                        Academies = new List<TrustSearchAcademy>
                         {
-                            new TrustSearchAcademies {Ukprn = "0002", Name = "Example Academy"}
+                            new TrustSearchAcademy {Ukprn = "0002", Name = "Example Academy"}
                         }
                     }
                 }

--- a/Data.TRAMS.Tests/Data.TRAMS.Tests.csproj
+++ b/Data.TRAMS.Tests/Data.TRAMS.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Moq" Version="4.15.2" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Data.TRAMS\Data.TRAMS.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Data.TRAMS.Tests/Mappers/Response/TramsAcademyMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsAcademyMapperTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Data.Models;
+using Data.TRAMS.Mappers.Response;
+using Data.TRAMS.Models;
+using Xunit;
+
+namespace Data.TRAMS.Tests.Mappers.Response
+{
+    public class TramsAcademyMapperTests
+    {
+        private readonly TramsAcademyMapper _subject;
+
+        public TramsAcademyMapperTests()
+        {
+            _subject = new TramsAcademyMapper();
+        }
+
+        [Fact]
+        public void GivenTramsAcademy_MapsToInternalAcademySuccessfully()
+        {
+            var academyToMap = new TramsAcademy()
+            {
+                Ukprn = "Ukprn",
+                EstablishmentName = "Fake Academy",
+                Address = new Address()
+                {
+                    Street = "Example street",
+                    Town = "Town",
+                    County = "Fakeshire",
+                    Postcode = "FA11 1KE"
+                },
+                StatutoryLowAge = "4",
+                StatutoryHighAge = "11"
+            };
+
+            var result = _subject.Map(academyToMap);
+            var expectedAddress = new List<string> {"Example street", "Town", "Fakeshire", "FA11 1KE"};
+
+            Assert.Equal(academyToMap.Ukprn, result.Ukprn);
+            Assert.Equal(academyToMap.EstablishmentName, result.Name);
+            Assert.Equal(expectedAddress, result.Address);
+            AssertAcademyPerformanceCorrect(result, academyToMap);
+        }
+
+        private static void AssertAcademyPerformanceCorrect(Academy result, TramsAcademy academyToMap)
+        {
+            var expectedAgeRange = $"{academyToMap.StatutoryLowAge} to {academyToMap.StatutoryHighAge}";
+            var performance = result.Performance;
+            Assert.Equal(expectedAgeRange, performance.AgeRange);
+            Assert.Equal(academyToMap.SchoolCapacity, performance.Capacity);
+        }
+    }
+}

--- a/Data.TRAMS.Tests/Mappers/Response/TramsSearchResultMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsSearchResultMapperTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Data.TRAMS.Mappers.Response;
+using Data.TRAMS.Models;
+using Xunit;
+
+namespace Data.TRAMS.Tests.Mappers.Response
+{
+    public class TramsSearchResultMapperTests
+    {
+        [Fact]
+        public void GivenSearchResult_MapsCorrectly()
+        {
+            var subject = new TramsSearchResultMapper();
+
+            var resultToMap = new TramsTrustSearchResult()
+            {
+                Urn = "1234",
+                GroupName = "Group name",
+                CompaniesHouseNumber = "12345",
+                Academies = new List<TramsTrustSearchAcademy>()
+                {
+                    new TramsTrustSearchAcademy() {Name = "Academy 1 name", Urn = "0001"},
+                    new TramsTrustSearchAcademy() {Name = "Academy 2 name", Urn = "0002"}
+                }
+            };
+
+            var result = subject.Map(resultToMap);
+
+            Assert.Equal(resultToMap.Urn, result.Ukprn);
+            Assert.Equal(resultToMap.GroupName, result.TrustName);
+            Assert.Equal(resultToMap.CompaniesHouseNumber, result.CompaniesHouseNumber);
+
+            AssertAcademyMappedCorrectly(resultToMap.Academies[0], result.Academies[0]);
+            AssertAcademyMappedCorrectly(resultToMap.Academies[1], result.Academies[1]);
+        }
+
+        private static void AssertAcademyMappedCorrectly(TramsTrustSearchAcademy academyToMap, Data.Models.TrustSearchAcademy mappedAcademy)
+        {
+            Assert.Equal(academyToMap.Name, mappedAcademy.Name);
+            Assert.Equal(academyToMap.Urn, mappedAcademy.Ukprn);
+        }
+    }
+}

--- a/Data.TRAMS.Tests/TestFixtures/Academies.cs
+++ b/Data.TRAMS.Tests/TestFixtures/Academies.cs
@@ -1,0 +1,16 @@
+using Data.TRAMS.Models;
+
+namespace Data.TRAMS.Tests.TestFixtures
+{
+    public class Academies
+    {
+        public static TramsAcademy SingleAcademy()
+        {
+            return new TramsAcademy
+            {
+                Ukprn = "12345",
+                EstablishmentName = "Academy name"
+            };
+        }
+    }
+}

--- a/Data.TRAMS.Tests/TestFixtures/Projects.cs
+++ b/Data.TRAMS.Tests/TestFixtures/Projects.cs
@@ -1,0 +1,15 @@
+using Data.TRAMS.Models;
+
+namespace Data.TRAMS.Tests.TestFixtures
+{
+    public static class Projects
+    {
+        public static TramsProject GetSingleProject()
+        {
+            return new TramsProject
+            {
+                ProjectUrn = "001"
+            };
+        }
+    }
+}

--- a/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
+++ b/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
@@ -14,9 +14,9 @@ namespace Data.TRAMS.Tests.TestFixtures
             for (var i = 0; i < numberOfResults; i++)
             {
                 searchResults.Add(
-                    new TramsTrustSearchResult()
+                    new TramsTrustSearchResult
                     {
-                        Academies = new List<TrustSearchAcademies>(),
+                        Academies = new List<TramsTrustSearchAcademy>(),
                         CompaniesHouseNumber = counter.ToString(),
                         GroupName = $"Trust {counter}",
                         Urn = counter.ToString()

--- a/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
+++ b/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS.Tests.TestFixtures
+{
+    public class TrustSearchResults
+    {
+        
+    }
+}

--- a/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
+++ b/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
@@ -1,7 +1,31 @@
+using System.Collections.Generic;
+using Data.TRAMS.Models;
+
 namespace Data.TRAMS.Tests.TestFixtures
 {
-    public class TrustSearchResults
+    public static class TrustSearchResults
     {
-        
+        public static List<TramsTrustSearchResult> GetTrustSearchResults(int numberOfResults = 1)
+        {
+            var counter = 1;
+
+            var searchResults = new List<TramsTrustSearchResult>();
+
+            for (var i = 0; i < numberOfResults; i++)
+            {
+                searchResults.Add(
+                    new TramsTrustSearchResult()
+                    {
+                        Academies = new List<TrustSearchAcademies>(),
+                        CompaniesHouseNumber = counter.ToString(),
+                        GroupName = $"Trust {counter}",
+                        Urn = counter.ToString()
+                    }
+                );
+                counter++;
+            }
+
+            return searchResults;
+        }
     }
 }

--- a/Data.TRAMS.Tests/TestFixtures/Trusts.cs
+++ b/Data.TRAMS.Tests/TestFixtures/Trusts.cs
@@ -1,7 +1,24 @@
+using System.Collections.Generic;
+using Data.TRAMS.Models;
+
 namespace Data.TRAMS.Tests.TestFixtures
 {
     public class Trusts
     {
-        
+        public static TramsTrust GetSingleTrust()
+        {
+            return new TramsTrust
+            {
+                Academies = new List<TramsAcademy>(),
+                GiasData = new TramsTrustGiasData
+                {
+                    Ukprn = "00001",
+                    CompaniesHouseNumber = "1234567",
+                    GroupContactAddress = new GroupContactAddress(),
+                    GroupId = "123",
+                    GroupName = "Group Name"
+                }
+            };
+        }
     }
 }

--- a/Data.TRAMS.Tests/TestFixtures/Trusts.cs
+++ b/Data.TRAMS.Tests/TestFixtures/Trusts.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS.Tests.TestFixtures
+{
+    public class Trusts
+    {
+        
+    }
+}

--- a/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
@@ -1,0 +1,71 @@
+using System.Net.Http;
+using Data.Models;
+using Data.TRAMS.Models;
+using Data.TRAMS.Tests.TestFixtures;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Data.TRAMS.Tests
+{
+    public class TramsAcademiesRepositoryTests
+    {
+        private readonly Mock<ITramsHttpClient> _client;
+        private readonly Mock<IMapper<TramsAcademy, Academy>> _mapper;
+        private readonly TramsAcademiesRepository _subject;
+
+        public TramsAcademiesRepositoryTests()
+        {
+            _client = new Mock<ITramsHttpClient>();
+            _mapper = new Mock<IMapper<TramsAcademy, Academy>>();
+            _subject = new TramsAcademiesRepository(_client.Object, _mapper.Object);
+        }
+
+        [Fact]
+        public async void GivenUkprn_GetsAcademyWithGivenUkprn()
+        {
+            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(Academies.SingleAcademy()))
+            });
+
+            await _subject.GetAcademyByUkprn("12345");
+
+            _client.Verify(c => c.GetAsync("academy/12345"), Times.Once);
+        }
+
+        [Fact]
+        public async void GivenUkprn_MapFoundAcademy()
+        {
+            var academy = Academies.SingleAcademy();
+            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(academy))
+            });
+
+            await _subject.GetAcademyByUkprn("12345");
+
+            _mapper.Verify(m => m.Map(It.Is<TramsAcademy>(mappedAcademy => mappedAcademy.Ukprn == academy.Ukprn)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async void GivenUkprn_ReturnsMappedAcademy()
+        {
+            var academy = Academies.SingleAcademy();
+            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(academy))
+            });
+
+            _mapper.Setup(m => m.Map(It.IsAny<TramsAcademy>())).Returns<TramsAcademy>(input => new Academy
+            {
+                Ukprn = $"Mapped {academy.Ukprn}"
+            });
+
+            var response = await _subject.GetAcademyByUkprn("12345");
+
+            Assert.Equal("Mapped 12345", response.Result.Ukprn);
+        }
+    }
+}

--- a/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
@@ -21,51 +21,54 @@ namespace Data.TRAMS.Tests
             _subject = new TramsAcademiesRepository(_client.Object, _mapper.Object);
         }
 
-        [Fact]
-        public async void GivenUkprn_GetsAcademyWithGivenUkprn()
+        public class GetAcademyByUkprnTests : TramsAcademiesRepositoryTests
         {
-            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            [Fact]
+            public async void GivenUkprn_GetsAcademyWithGivenUkprn()
             {
-                Content = new StringContent(JsonConvert.SerializeObject(Academies.SingleAcademy()))
-            });
+                _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(Academies.SingleAcademy()))
+                });
 
-            await _subject.GetAcademyByUkprn("12345");
+                await _subject.GetAcademyByUkprn("12345");
 
-            _client.Verify(c => c.GetAsync("academy/12345"), Times.Once);
-        }
+                _client.Verify(c => c.GetAsync("academy/12345"), Times.Once);
+            }
 
-        [Fact]
-        public async void GivenUkprn_MapFoundAcademy()
-        {
-            var academy = Academies.SingleAcademy();
-            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            [Fact]
+            public async void GivenUkprn_MapFoundAcademy()
             {
-                Content = new StringContent(JsonConvert.SerializeObject(academy))
-            });
+                var academy = Academies.SingleAcademy();
+                _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(academy))
+                });
 
-            await _subject.GetAcademyByUkprn("12345");
+                await _subject.GetAcademyByUkprn("12345");
 
-            _mapper.Verify(m => m.Map(It.Is<TramsAcademy>(mappedAcademy => mappedAcademy.Ukprn == academy.Ukprn)),
-                Times.Once);
-        }
+                _mapper.Verify(m => m.Map(It.Is<TramsAcademy>(mappedAcademy => mappedAcademy.Ukprn == academy.Ukprn)),
+                    Times.Once);
+            }
 
-        [Fact]
-        public async void GivenUkprn_ReturnsMappedAcademy()
-        {
-            var academy = Academies.SingleAcademy();
-            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            [Fact]
+            public async void GivenUkprn_ReturnsMappedAcademy()
             {
-                Content = new StringContent(JsonConvert.SerializeObject(academy))
-            });
+                var academy = Academies.SingleAcademy();
+                _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(academy))
+                });
 
-            _mapper.Setup(m => m.Map(It.IsAny<TramsAcademy>())).Returns<TramsAcademy>(input => new Academy
-            {
-                Ukprn = $"Mapped {academy.Ukprn}"
-            });
+                _mapper.Setup(m => m.Map(It.IsAny<TramsAcademy>())).Returns<TramsAcademy>(input => new Academy
+                {
+                    Ukprn = $"Mapped {academy.Ukprn}"
+                });
 
-            var response = await _subject.GetAcademyByUkprn("12345");
+                var response = await _subject.GetAcademyByUkprn("12345");
 
-            Assert.Equal("Mapped 12345", response.Result.Ukprn);
+                Assert.Equal("Mapped 12345", response.Result.Ukprn);
+            }
         }
     }
 }

--- a/Data.TRAMS.Tests/TramsProjectsRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsProjectsRepositoryTests.cs
@@ -1,0 +1,206 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Data.Models;
+using Data.TRAMS.Models;
+using Data.TRAMS.Tests.TestFixtures;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Data.TRAMS.Tests
+{
+    public class TramsProjectsRepositoryTests
+    {
+        private readonly TramsProjectsRepository _subject;
+        private readonly Mock<ITramsHttpClient> _httpClient;
+        private readonly Mock<IMapper<TramsProject, Project>> _externalToInternalMapper;
+        private readonly Mock<IMapper<Project, TramsProject>> _internalToExternalMapper;
+
+        public TramsProjectsRepositoryTests()
+        {
+            _httpClient = new Mock<ITramsHttpClient>();
+            _externalToInternalMapper = new Mock<IMapper<TramsProject, Project>>();
+            _internalToExternalMapper = new Mock<IMapper<Project, TramsProject>>();
+            _subject = new TramsProjectsRepository(_httpClient.Object, _externalToInternalMapper.Object,
+                _internalToExternalMapper.Object);
+        }
+
+        public class GetByUrnTests : TramsProjectsRepositoryTests
+        {
+            private readonly TramsProject _foundProject;
+
+            public GetByUrnTests()
+            {
+                _foundProject = Projects.GetSingleProject();
+                _httpClient.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(_foundProject))
+                });
+                _externalToInternalMapper.Setup(m => m.Map(It.IsAny<TramsProject>())).Returns<TramsProject>(
+                    externalProject =>
+                        new Project
+                        {
+                            Urn = $"Mapped {externalProject.ProjectUrn}"
+                        });
+            }
+
+            [Fact]
+            public async void GivenUrn_GetsProjectFromAPI()
+            {
+                await _subject.GetByUrn("12345");
+                _httpClient.Verify(c => c.GetAsync("academyTransferProject/12345"), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenApiReturnsProject_MapProjectToInternalModel()
+            {
+                await _subject.GetByUrn("12345");
+
+                _externalToInternalMapper.Verify(m =>
+                    m.Map(It.Is<TramsProject>(project => _foundProject.ProjectUrn == project.ProjectUrn)), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenApiReturnsProject_ReturnsMappedProject()
+            {
+                var response = await _subject.GetByUrn("12345");
+
+                Assert.Equal($"Mapped {_foundProject.ProjectUrn}", response.Result.Urn);
+            }
+        }
+
+        public class UpdateProjectTests : TramsProjectsRepositoryTests
+        {
+            private readonly Project _projectToUpdate;
+            private readonly TramsProject _mappedProject;
+            private readonly TramsProject _updatedProject;
+
+            public UpdateProjectTests()
+            {
+                _projectToUpdate = new Project {Urn = "12345", Status = "New"};
+                _mappedProject = new TramsProject() {ProjectUrn = "12345"};
+                _updatedProject = new TramsProject() {ProjectUrn = "12345 - Updated"};
+
+                _internalToExternalMapper.Setup(m => m.Map(_projectToUpdate)).Returns(_mappedProject);
+                
+                _httpClient.Setup(c => c.PatchAsync(It.IsAny<string>(), It.IsAny<HttpContent>())).ReturnsAsync(
+                    new HttpResponseMessage()
+                    {
+                        Content = new StringContent(JsonConvert.SerializeObject(_updatedProject))
+                    });
+                
+                _externalToInternalMapper.Setup(m => m.Map(It.IsAny<TramsProject>())).Returns<TramsProject>((input) =>
+                    new Project
+                    {
+                        Urn = $"Mapped {input.ProjectUrn}"
+                    });
+            }
+
+            [Fact]
+            public async void GivenProject_MapsToExternalProject()
+            {
+                await _subject.Update(_projectToUpdate);
+
+                _internalToExternalMapper.Verify(m => m.Map(_projectToUpdate), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenProjectGetsMapped_PostsMappedProjectToTheApi()
+            {
+                await _subject.Update(_projectToUpdate);
+                var expectedPostedContent = JsonConvert.SerializeObject(_mappedProject);
+
+                _httpClient.Verify(c => c.PatchAsync(
+                    "academyTransferProject/12345",
+                    It.Is<StringContent>(content => AssertStringContentMatches(expectedPostedContent, content).Result)
+                ), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenProjectCreated_MapsCreatedProject()
+            {
+                await _subject.Update(_projectToUpdate);
+
+                _externalToInternalMapper.Verify(m =>
+                    m.Map(It.Is<TramsProject>(project => project.ProjectUrn == _updatedProject.ProjectUrn)));
+            }
+
+            [Fact]
+            public async void GivenProjectCreated_ReturnsMappedCreatedProject()
+            {
+                var response = await _subject.Update(_projectToUpdate);
+
+                Assert.Equal($"Mapped {_updatedProject.ProjectUrn}", response.Result.Urn);
+            }
+        }
+
+        public class CreateProjectTests : TramsProjectsRepositoryTests
+        {
+            private readonly Project _projectToCreate;
+            private readonly TramsProject _mappedProject;
+            private readonly TramsProject _createdProject;
+
+            public CreateProjectTests()
+            {
+                _projectToCreate = new Project {Status = "New"};
+                _mappedProject = new TramsProject() {Status = "Mapped new"};
+                _createdProject = new TramsProject() {ProjectUrn = "12345", Status = "Mapped new"};
+
+                _internalToExternalMapper.Setup(m => m.Map(_projectToCreate)).Returns(_mappedProject);
+                _httpClient.Setup(c => c.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>())).ReturnsAsync(
+                    new HttpResponseMessage()
+                    {
+                        Content = new StringContent(JsonConvert.SerializeObject(_createdProject))
+                    });
+                _externalToInternalMapper.Setup(m => m.Map(It.IsAny<TramsProject>())).Returns<TramsProject>((input) =>
+                    new Project
+                    {
+                        Urn = $"Mapped {input.ProjectUrn}"
+                    });
+            }
+
+            [Fact]
+            public async void GivenProject_MapsToExternalProject()
+            {
+                await _subject.Create(_projectToCreate);
+
+                _internalToExternalMapper.Verify(m => m.Map(_projectToCreate), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenProjectGetsMapped_PostsMappedProjectToTheApi()
+            {
+                await _subject.Create(_projectToCreate);
+                var expectedPostedContent = JsonConvert.SerializeObject(_mappedProject);
+
+                _httpClient.Verify(c => c.PostAsync(
+                    "academyTransferProject",
+                    It.Is<StringContent>(content => AssertStringContentMatches(expectedPostedContent, content).Result)
+                ), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenProjectCreated_MapsCreatedProject()
+            {
+                await _subject.Create(_projectToCreate);
+
+                _externalToInternalMapper.Verify(m =>
+                    m.Map(It.Is<TramsProject>(project => project.ProjectUrn == _createdProject.ProjectUrn)));
+            }
+
+            [Fact]
+            public async void GivenProjectCreated_ReturnsMappedCreatedProject()
+            {
+                var response = await _subject.Create(_projectToCreate);
+
+                Assert.Equal($"Mapped {_createdProject.ProjectUrn}", response.Result.Urn);
+            }
+        }
+
+        private static async Task<bool> AssertStringContentMatches(string expectedContent, StringContent actualContent)
+        {
+            var actualContentString = await actualContent.ReadAsStringAsync();
+            return expectedContent.Equals(actualContentString);
+        }
+    }
+}

--- a/Data.TRAMS.Tests/TramsTrustsRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsTrustsRepositoryTests.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
 using System.Net.Http;
 using Data.Models;
 using Data.TRAMS.Models;
+using Data.TRAMS.Tests.TestFixtures;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -11,14 +11,16 @@ namespace Data.TRAMS.Tests
     public class TramsTrustsRepositoryTests
     {
         private readonly Mock<ITramsHttpClient> _client;
-        private readonly Mock<IMapper<TramsTrustSearchResult, TrustSearchResult>> _mapper;
+        private readonly Mock<IMapper<TramsTrustSearchResult, TrustSearchResult>> _trustSearchResultsMapper;
+        private readonly Mock<IMapper<TramsTrust, Trust>> _trustMapper;
         private readonly TramsTrustsRepository _subject;
 
         public TramsTrustsRepositoryTests()
         {
             _client = new Mock<ITramsHttpClient>();
-            _mapper = new Mock<IMapper<TramsTrustSearchResult, TrustSearchResult>>();
-            _subject = new TramsTrustsRepository(_client.Object, _mapper.Object);
+            _trustSearchResultsMapper = new Mock<IMapper<TramsTrustSearchResult, TrustSearchResult>>();
+            _trustMapper = new Mock<IMapper<TramsTrust, Trust>>();
+            _subject = new TramsTrustsRepository(_client.Object, _trustSearchResultsMapper.Object, _trustMapper.Object);
         }
 
         public class SearchTrustsTests : TramsTrustsRepositoryTests
@@ -29,7 +31,7 @@ namespace Data.TRAMS.Tests
                 _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(
-                        JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
+                        JsonConvert.SerializeObject(TrustSearchResults.GetTrustSearchResults()))
                 });
 
                 await _subject.SearchTrusts("Cats");
@@ -44,15 +46,16 @@ namespace Data.TRAMS.Tests
                 _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(
-                        JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
+                        JsonConvert.SerializeObject(TrustSearchResults.GetTrustSearchResults()))
                 });
 
-                _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
-                    new TrustSearchResult
-                    {
-                        Ukprn = $"Mapped {result.Urn}",
-                        TrustName = $"Mapped {result.GroupName}"
-                    });
+                _trustSearchResultsMapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>()))
+                    .Returns<TramsTrustSearchResult>(result =>
+                        new TrustSearchResult
+                        {
+                            Ukprn = $"Mapped {result.Urn}",
+                            TrustName = $"Mapped {result.GroupName}"
+                        });
 
                 var response = await _subject.SearchTrusts();
 
@@ -65,20 +68,66 @@ namespace Data.TRAMS.Tests
                 _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(
-                        JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults(2)))
+                        JsonConvert.SerializeObject(TrustSearchResults.GetTrustSearchResults(2)))
                 });
 
-                _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
-                    new TrustSearchResult
-                    {
-                        Ukprn = $"Mapped {result.Urn}",
-                        TrustName = $"Mapped {result.GroupName}"
-                    });
+                _trustSearchResultsMapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>()))
+                    .Returns<TramsTrustSearchResult>(result =>
+                        new TrustSearchResult
+                        {
+                            Ukprn = $"Mapped {result.Urn}",
+                            TrustName = $"Mapped {result.GroupName}"
+                        });
 
                 var response = await _subject.SearchTrusts();
 
                 Assert.Equal("Mapped 1", response.Result[0].Ukprn);
                 Assert.Equal("Mapped 2", response.Result[1].Ukprn);
+            }
+        }
+
+        public class GetTrustByUkprnTests : TramsTrustsRepositoryTests
+        {
+            private readonly TramsTrust _foundTrust;
+
+            public GetTrustByUkprnTests()
+            {
+                _foundTrust = Trusts.GetSingleTrust();
+                _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(_foundTrust))
+                });
+                
+                _trustMapper.Setup(m => m.Map(It.IsAny<TramsTrust>())).Returns<TramsTrust>((input) => new Trust()
+                {
+                    Name = $"Mapped {input.GiasData.GroupName}",
+                    Ukprn = $"Mapped {input.GiasData.Ukprn}"
+                });
+            }
+
+            [Fact]
+            public async void GivenUkprn_SearchesForTrustOnTheApi()
+            {
+                await _subject.GetByUkprn("12345");
+
+                _client.Verify(c => c.GetAsync("trust/12345"), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenResultFromApi_MapsResult()
+            {
+                await _subject.GetByUkprn("12345");
+
+                _trustMapper.Verify(m =>
+                    m.Map(It.Is<TramsTrust>(trust => trust.GiasData.Ukprn == _foundTrust.GiasData.Ukprn)), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenResultFromApi_ReturnsMappedResult()
+            {
+                var response = await _subject.GetByUkprn("12345");
+
+                Assert.Equal($"Mapped {_foundTrust.GiasData.Ukprn}", response.Result.Ukprn);
             }
         }
     }

--- a/Data.TRAMS.Tests/TramsTrustsRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsTrustsRepositoryTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using Data.Models;
+using Data.TRAMS.Models;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Data.TRAMS.Tests
+{
+    public class TramsTrustsRepositoryTests
+    {
+        private readonly Mock<ITramsHttpClient> _client;
+        private readonly Mock<IMapper<TramsTrustSearchResult, TrustSearchResult>> _mapper;
+        private readonly TramsTrustsRepository _subject;
+
+        public TramsTrustsRepositoryTests()
+        {
+            _client = new Mock<ITramsHttpClient>();
+            _mapper = new Mock<IMapper<TramsTrustSearchResult, TrustSearchResult>>();
+            _subject = new TramsTrustsRepository(_client.Object, _mapper.Object);
+        }
+
+        [Fact]
+        public async void GivenSearchTerm_QueriesTheApiWithTheSearchTerm()
+        {
+            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            {
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
+            });
+
+            await _subject.SearchTrusts("Cats");
+
+            _client.Verify(c => c.GetAsync("trusts?group_name=Cats&urn=Cats&companies_house_number=Cats"), Times.Once);
+        }
+
+        [Fact]
+        public async void GivenASingleSearchResult_ReturnsTheMappedResult()
+        {
+            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            {
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
+            });
+
+            _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
+                new TrustSearchResult
+                {
+                    Ukprn = $"Mapped {result.Urn}",
+                    TrustName = $"Mapped {result.GroupName}"
+                });
+
+            var response = await _subject.SearchTrusts();
+
+            Assert.Equal("Mapped 1", response.Result[0].Ukprn);
+        }
+
+        [Fact]
+        public async void GivenMultipleSearchResults_ReturnsTheMappedResult()
+        {
+            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            {
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults(2)))
+            });
+
+            _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
+                new TrustSearchResult
+                {
+                    Ukprn = $"Mapped {result.Urn}",
+                    TrustName = $"Mapped {result.GroupName}"
+                });
+
+            var response = await _subject.SearchTrusts();
+
+            Assert.Equal("Mapped 1", response.Result[0].Ukprn);
+            Assert.Equal("Mapped 2", response.Result[1].Ukprn);
+        }
+    }
+}

--- a/Data.TRAMS.Tests/TramsTrustsRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsTrustsRepositoryTests.cs
@@ -21,61 +21,65 @@ namespace Data.TRAMS.Tests
             _subject = new TramsTrustsRepository(_client.Object, _mapper.Object);
         }
 
-        [Fact]
-        public async void GivenSearchTerm_QueriesTheApiWithTheSearchTerm()
+        public class SearchTrustsTests : TramsTrustsRepositoryTests
         {
-            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            [Fact]
+            public async void GivenSearchTerm_QueriesTheApiWithTheSearchTerm()
             {
-                Content = new StringContent(
-                    JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
-            });
-
-            await _subject.SearchTrusts("Cats");
-
-            _client.Verify(c => c.GetAsync("trusts?group_name=Cats&urn=Cats&companies_house_number=Cats"), Times.Once);
-        }
-
-        [Fact]
-        public async void GivenASingleSearchResult_ReturnsTheMappedResult()
-        {
-            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
-            {
-                Content = new StringContent(
-                    JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
-            });
-
-            _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
-                new TrustSearchResult
+                _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
-                    Ukprn = $"Mapped {result.Urn}",
-                    TrustName = $"Mapped {result.GroupName}"
+                    Content = new StringContent(
+                        JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
                 });
 
-            var response = await _subject.SearchTrusts();
+                await _subject.SearchTrusts("Cats");
 
-            Assert.Equal("Mapped 1", response.Result[0].Ukprn);
-        }
+                _client.Verify(c => c.GetAsync("trusts?group_name=Cats&urn=Cats&companies_house_number=Cats"),
+                    Times.Once);
+            }
 
-        [Fact]
-        public async void GivenMultipleSearchResults_ReturnsTheMappedResult()
-        {
-            _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+            [Fact]
+            public async void GivenASingleSearchResult_ReturnsTheMappedResult()
             {
-                Content = new StringContent(
-                    JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults(2)))
-            });
-
-            _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
-                new TrustSearchResult
+                _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
-                    Ukprn = $"Mapped {result.Urn}",
-                    TrustName = $"Mapped {result.GroupName}"
+                    Content = new StringContent(
+                        JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults()))
                 });
 
-            var response = await _subject.SearchTrusts();
+                _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
+                    new TrustSearchResult
+                    {
+                        Ukprn = $"Mapped {result.Urn}",
+                        TrustName = $"Mapped {result.GroupName}"
+                    });
 
-            Assert.Equal("Mapped 1", response.Result[0].Ukprn);
-            Assert.Equal("Mapped 2", response.Result[1].Ukprn);
+                var response = await _subject.SearchTrusts();
+
+                Assert.Equal("Mapped 1", response.Result[0].Ukprn);
+            }
+
+            [Fact]
+            public async void GivenMultipleSearchResults_ReturnsTheMappedResult()
+            {
+                _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(
+                        JsonConvert.SerializeObject(TestFixtures.TrustSearchResults.GetTrustSearchResults(2)))
+                });
+
+                _mapper.Setup(m => m.Map(It.IsAny<TramsTrustSearchResult>())).Returns<TramsTrustSearchResult>(result =>
+                    new TrustSearchResult
+                    {
+                        Ukprn = $"Mapped {result.Urn}",
+                        TrustName = $"Mapped {result.GroupName}"
+                    });
+
+                var response = await _subject.SearchTrusts();
+
+                Assert.Equal("Mapped 1", response.Result[0].Ukprn);
+                Assert.Equal("Mapped 2", response.Result[1].Ukprn);
+            }
         }
     }
 }

--- a/Data.TRAMS/Data.TRAMS.csproj
+++ b/Data.TRAMS/Data.TRAMS.csproj
@@ -12,4 +12,8 @@
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Mappers\Request" />
+    </ItemGroup>
+
 </Project>

--- a/Data.TRAMS/IMapper.cs
+++ b/Data.TRAMS/IMapper.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS
+{
+    public interface IMapper<T, V>
+    {
+        V Map(T input);
+    }
+}

--- a/Data.TRAMS/ITramsHttpClient.cs
+++ b/Data.TRAMS/ITramsHttpClient.cs
@@ -1,9 +1,10 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Data.TRAMS.Tests
+namespace Data.TRAMS
 {
     public interface ITramsHttpClient
     {
-        public Task<string>
+        public Task<HttpResponseMessage> GetAsync(string url);
     }
 }

--- a/Data.TRAMS/ITramsHttpClient.cs
+++ b/Data.TRAMS/ITramsHttpClient.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Data.TRAMS.Tests
+{
+    public interface ITramsHttpClient
+    {
+        public Task<string>
+    }
+}

--- a/Data.TRAMS/ITramsHttpClient.cs
+++ b/Data.TRAMS/ITramsHttpClient.cs
@@ -6,5 +6,9 @@ namespace Data.TRAMS
     public interface ITramsHttpClient
     {
         public Task<HttpResponseMessage> GetAsync(string url);
+
+        public Task<HttpResponseMessage> PostAsync(string url, HttpContent content);
+
+        public Task<HttpResponseMessage> PatchAsync(string url, HttpContent content);
     }
 }

--- a/Data.TRAMS/Mappers/Response/TramsAcademyMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsAcademyMapper.cs
@@ -1,4 +1,5 @@
 using Data.Models;
+using Data.Models.Academies;
 using Data.TRAMS.Models;
 
 namespace Data.TRAMS.Mappers.Response

--- a/Data.TRAMS/Mappers/Response/TramsAcademyMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsAcademyMapper.cs
@@ -1,0 +1,22 @@
+using Data.Models;
+using Data.TRAMS.Models;
+
+namespace Data.TRAMS.Mappers.Response
+{
+    public class TramsAcademyMapper : IMapper<TramsAcademy, Academy>
+    {
+        public Academy Map(TramsAcademy input)
+        {
+            return new Academy
+            {
+                Ukprn = input.Ukprn,
+                Name = input.EstablishmentName,
+                Performance = new AcademyPerformance
+                {
+                    AgeRange = $"{input.StatutoryLowAge} to {input.StatutoryHighAge}",
+                    Capacity = input.SchoolCapacity
+                }
+            };
+        }
+    }
+}

--- a/Data.TRAMS/Mappers/Response/TramsAcademyMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsAcademyMapper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Data.Models;
 using Data.Models.Academies;
 using Data.TRAMS.Models;
@@ -12,6 +13,8 @@ namespace Data.TRAMS.Mappers.Response
             {
                 Ukprn = input.Ukprn,
                 Name = input.EstablishmentName,
+                Address = new List<string>
+                    {input.Address.Street, input.Address.Town, input.Address.County, input.Address.Postcode},
                 Performance = new AcademyPerformance
                 {
                     AgeRange = $"{input.StatutoryLowAge} to {input.StatutoryHighAge}",

--- a/Data.TRAMS/Mappers/Response/TramsSearchResultMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsSearchResultMapper.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Data.Models;
 using Data.TRAMS.Models;
 
@@ -7,7 +8,16 @@ namespace Data.TRAMS.Mappers.Response
     {
         public TrustSearchResult Map(TramsTrustSearchResult input)
         {
-            throw new System.NotImplementedException();
+            return new TrustSearchResult
+            {
+                Ukprn = input.Urn,
+                TrustName = input.GroupName,
+                CompaniesHouseNumber = input.CompaniesHouseNumber,
+                Academies = input.Academies.Select(academy => new TrustSearchAcademy
+                {
+                    Name = academy.Name, Ukprn = academy.Urn
+                }).ToList()
+            };
         }
     }
 }

--- a/Data.TRAMS/Mappers/Response/TramsSearchResultMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsSearchResultMapper.cs
@@ -1,0 +1,13 @@
+using Data.Models;
+using Data.TRAMS.Models;
+
+namespace Data.TRAMS.Mappers.Response
+{
+    public class TramsSearchResultMapper : IMapper<TramsTrustSearchResult, TrustSearchResult>
+    {
+        public TrustSearchResult Map(TramsTrustSearchResult input)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Data.TRAMS/Mappers/Response/TramsTrustMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsTrustMapper.cs
@@ -1,0 +1,17 @@
+using Data.Models;
+using Data.TRAMS.Models;
+
+namespace Data.TRAMS.Mappers.Response
+{
+    public class TramsTrustMapper : IMapper<TramsTrust, Trust>
+    {
+        public Trust Map(TramsTrust input)
+        {
+            return new Trust
+            {
+                Ukprn = input.GiasData.Ukprn,
+                Name = input.GiasData.GroupName
+            };
+        }
+    }
+}

--- a/Data.TRAMS/Models/TramsProject.cs
+++ b/Data.TRAMS/Models/TramsProject.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+
+namespace Data.TRAMS.Models
+{
+    public class TramsProject
+    {
+        [JsonProperty("project_urn")] public string ProjectUrn { get; set; }
+        [JsonProperty("outgoing_trust_urn")] public string OutgoingTrustUrn { get; set; }
+
+        [JsonProperty("transferring_academies")]
+        public TransferringAcademy TransferringAcademies { get; set; }
+
+        [JsonProperty("features")] public AcademyTransferProjectFeatures Features { get; set; }
+        [JsonProperty("state")] public string State { get; set; }
+        [JsonProperty("status")] public string Status { get; set; }
+    }
+
+    public class AcademyTransferProjectFeatures
+    {
+        [JsonProperty("who_initiated_the_transfer")]
+        public string WhoInitiatedTheTransfer { get; set; }
+
+        [JsonProperty("rdd_or_esfa_intervention")]
+        public bool RddOrEsfaIntervention { get; set; }
+
+        [JsonProperty("rdd_or_esfa_intervention_detail")]
+        public string RddOrEsfaInterventionDetail { get; set; }
+
+        [JsonProperty("type_of_transfer")] public string TypeOfTransfer { get; set; }
+    }
+
+    public class TransferringAcademy
+    {
+        [JsonProperty("outgoing_academy_urn")] public string OutgoingAcademyUrn { get; set; }
+        [JsonProperty("incoming_trust_urn")] public string IncomingTrustUrn { get; set; }
+    }
+}

--- a/Data.TRAMS/Models/TramsTrustSearchResult.cs
+++ b/Data.TRAMS/Models/TramsTrustSearchResult.cs
@@ -11,10 +11,10 @@ namespace Data.TRAMS.Models
         [JsonProperty("companies_house_number")]
         public string CompaniesHouseNumber { get; set; }
 
-        [JsonProperty("academies")] public List<TrustSearchAcademies> Academies { get; set; }
+        [JsonProperty("academies")] public List<TramsTrustSearchAcademy> Academies { get; set; }
     }
 
-    public class TrustSearchAcademies
+    public class TramsTrustSearchAcademy
     {
         [JsonProperty("urn")] public string Urn { get; set; }
         [JsonProperty("name")] public string Name { get; set; }

--- a/Data.TRAMS/TramsAcademiesRepository.cs
+++ b/Data.TRAMS/TramsAcademiesRepository.cs
@@ -9,11 +9,13 @@ namespace Data.TRAMS
 {
     public class TramsAcademiesRepository : IAcademies
     {
-        private readonly HttpClient _httpClient;
+        private readonly ITramsHttpClient _httpClient;
+        private readonly IMapper<TramsAcademy, Academy> _academyMapper;
 
-        public TramsAcademiesRepository(HttpClient httpClient)
+        public TramsAcademiesRepository(ITramsHttpClient httpClient, IMapper<TramsAcademy, Academy> academyMapper)
         {
             _httpClient = httpClient;
+            _academyMapper = academyMapper;
         }
 
         public async Task<RepositoryResult<Academy>> GetAcademyByUkprn(string ukprn)
@@ -22,20 +24,9 @@ namespace Data.TRAMS
 
             var apiResponse = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<TramsAcademy>(apiResponse);
+            var mappedResult = _academyMapper.Map(result);
 
-            return new RepositoryResult<Academy>
-            {
-                Result = new Academy
-                {
-                    Ukprn = result.Ukprn,
-                    Name = result.EstablishmentName,
-                    Performance = new AcademyPerformance
-                    {
-                        AgeRange = $"{result.StatutoryLowAge} to {result.StatutoryHighAge}",
-                        Capacity = result.SchoolCapacity
-                    }
-                }
-            };
+            return new RepositoryResult<Academy> {Result = mappedResult};
         }
     }
 }

--- a/Data.TRAMS/TramsAcademiesRepository.cs
+++ b/Data.TRAMS/TramsAcademiesRepository.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS
+{
+    public class TramsAcademiesRepository
+    {
+        
+    }
+}

--- a/Data.TRAMS/TramsAcademiesRepository.cs
+++ b/Data.TRAMS/TramsAcademiesRepository.cs
@@ -1,7 +1,41 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Data.Models;
+using Data.TRAMS.Models;
+using Newtonsoft.Json;
+
 namespace Data.TRAMS
 {
-    public class TramsAcademiesRepository
+    public class TramsAcademiesRepository : IAcademies
     {
-        
+        private readonly HttpClient _httpClient;
+
+        public TramsAcademiesRepository(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<RepositoryResult<Academy>> GetAcademyByUkprn(string ukprn)
+        {
+            using var response = await _httpClient.GetAsync($"academy/{ukprn}");
+
+            var apiResponse = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<TramsAcademy>(apiResponse);
+
+            return new RepositoryResult<Academy>
+            {
+                Result = new Academy
+                {
+                    Ukprn = result.Ukprn,
+                    Name = result.EstablishmentName,
+                    Performance = new AcademyPerformance
+                    {
+                        AgeRange = $"{result.StatutoryLowAge} to {result.StatutoryHighAge}",
+                        Capacity = result.SchoolCapacity
+                    }
+                }
+            };
+        }
     }
 }

--- a/Data.TRAMS/TramsHttpClient.cs
+++ b/Data.TRAMS/TramsHttpClient.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS
+{
+    public class TramsHttpClient
+    {
+        
+    }
+}

--- a/Data.TRAMS/TramsHttpClient.cs
+++ b/Data.TRAMS/TramsHttpClient.cs
@@ -6,9 +6,10 @@ namespace Data.TRAMS
 {
     public class TramsHttpClient : HttpClient, ITramsHttpClient
     {
-        public TramsHttpClient(string url)
+        public TramsHttpClient(string url, string apiKey)
         {
             BaseAddress = new Uri(url);
+            DefaultRequestHeaders.Add("ApiKey", apiKey);
         }
 
         public new async Task<HttpResponseMessage> GetAsync(string url)

--- a/Data.TRAMS/TramsHttpClient.cs
+++ b/Data.TRAMS/TramsHttpClient.cs
@@ -1,7 +1,20 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
 namespace Data.TRAMS
 {
-    public class TramsHttpClient
+    public class TramsHttpClient : HttpClient, ITramsHttpClient
     {
+        public TramsHttpClient(string url)
+        {
+            BaseAddress = new Uri(url);
+        }
         
+        public new async Task<HttpResponseMessage> GetAsync(string url)
+        {
+            var response = await base.GetAsync(url);
+            return response;
+        }
     }
 }

--- a/Data.TRAMS/TramsHttpClient.cs
+++ b/Data.TRAMS/TramsHttpClient.cs
@@ -10,10 +10,22 @@ namespace Data.TRAMS
         {
             BaseAddress = new Uri(url);
         }
-        
+
         public new async Task<HttpResponseMessage> GetAsync(string url)
         {
             var response = await base.GetAsync(url);
+            return response;
+        }
+
+        public new async Task<HttpResponseMessage> PostAsync(string url, HttpContent content)
+        {
+            var response = await base.PostAsync(url, content);
+            return response;
+        }
+
+        public new async Task<HttpResponseMessage> PatchAsync(string url, HttpContent content)
+        {
+            var response = await base.PatchAsync(url, content);
             return response;
         }
     }

--- a/Data.TRAMS/TramsProjectsRepository.cs
+++ b/Data.TRAMS/TramsProjectsRepository.cs
@@ -1,0 +1,66 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Data.Models;
+using Data.TRAMS.Models;
+using Newtonsoft.Json;
+
+namespace Data.TRAMS
+{
+    public class TramsProjectsRepository : IProjects
+    {
+        private readonly ITramsHttpClient _httpClient;
+        private readonly IMapper<TramsProject, Project> _externalToInternalProjectMapper;
+        private readonly IMapper<Project, TramsProject> _internalToExternalProjectMapper;
+
+        public TramsProjectsRepository(ITramsHttpClient httpClient,
+            IMapper<TramsProject, Project> externalToInternalProjectMapper,
+            IMapper<Project, TramsProject> internalToExternalProjectMapper)
+        {
+            _httpClient = httpClient;
+            _externalToInternalProjectMapper = externalToInternalProjectMapper;
+            _internalToExternalProjectMapper = internalToExternalProjectMapper;
+        }
+
+        public async Task<RepositoryResult<Project>> GetByUrn(string urn)
+        {
+            var response = await _httpClient.GetAsync($"academyTransferProject/{urn}");
+            var apiResponse = await response.Content.ReadAsStringAsync();
+            var project = JsonConvert.DeserializeObject<TramsProject>(apiResponse);
+
+            var mappedProject = _externalToInternalProjectMapper.Map(project);
+
+            return new RepositoryResult<Project>
+            {
+                Result = mappedProject
+            };
+        }
+
+        public async Task<RepositoryResult<Project>> Update(Project project)
+        {
+            var externalProject = _internalToExternalProjectMapper.Map(project);
+            var content = new StringContent(JsonConvert.SerializeObject(externalProject));
+            var response = await _httpClient.PatchAsync($"academyTransferProject/{project.Urn}", content);
+            var apiResponse = await response.Content.ReadAsStringAsync();
+            var createdProject = JsonConvert.DeserializeObject<TramsProject>(apiResponse);
+
+            return new RepositoryResult<Project>()
+            {
+                Result = _externalToInternalProjectMapper.Map(createdProject)
+            };
+        }
+
+        public async Task<RepositoryResult<Project>> Create(Project project)
+        {
+            var externalProject = _internalToExternalProjectMapper.Map(project);
+            var content = new StringContent(JsonConvert.SerializeObject(externalProject));
+            var response = await _httpClient.PostAsync("academyTransferProject", content);
+            var apiResponse = await response.Content.ReadAsStringAsync();
+            var createdProject = JsonConvert.DeserializeObject<TramsProject>(apiResponse);
+
+            return new RepositoryResult<Project>()
+            {
+                Result = _externalToInternalProjectMapper.Map(createdProject)
+            };
+        }
+    }
+}

--- a/Data.TRAMS/TramsTrustsRepository.cs
+++ b/Data.TRAMS/TramsTrustsRepository.cs
@@ -12,12 +12,15 @@ namespace Data.TRAMS
     {
         private readonly ITramsHttpClient _httpClient;
         private readonly IMapper<TramsTrustSearchResult, TrustSearchResult> _searchResultMapper;
+        private readonly IMapper<TramsTrust, Trust> _trustMapper;
 
         public TramsTrustsRepository(ITramsHttpClient httpClient,
-            IMapper<TramsTrustSearchResult, TrustSearchResult> searchResultMapper)
+            IMapper<TramsTrustSearchResult, TrustSearchResult> searchResultMapper,
+            IMapper<TramsTrust, Trust> trustMapper)
         {
             _httpClient = httpClient;
             _searchResultMapper = searchResultMapper;
+            _trustMapper = trustMapper;
         }
 
         public async Task<RepositoryResult<List<TrustSearchResult>>> SearchTrusts(string searchQuery = "")
@@ -33,6 +36,19 @@ namespace Data.TRAMS
             return new RepositoryResult<List<TrustSearchResult>>
             {
                 Result = mappedResult
+            };
+        }
+
+        public async Task<RepositoryResult<Trust>> GetByUkprn(string ukprn)
+        {
+            var url = $"trust/{ukprn}";
+            using var response = await _httpClient.GetAsync(url);
+            var apiResponse = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<TramsTrust>(apiResponse);
+
+            return new RepositoryResult<Trust>
+            {
+                Result = _trustMapper.Map(result)
             };
         }
     }

--- a/Data.TRAMS/TramsTrustsRepository.cs
+++ b/Data.TRAMS/TramsTrustsRepository.cs
@@ -5,30 +5,35 @@ using System.Threading.Tasks;
 using Data.Models;
 using Data.TRAMS.Models;
 using Newtonsoft.Json;
-using TrustSearchAcademies = Data.Models.TrustSearchAcademies;
 
 namespace Data.TRAMS
 {
     public class TramsTrustsRepository : ITrusts
     {
-        public async Task<List<TrustSearchResult>> SearchTrusts()
+        private readonly ITramsHttpClient _httpClient;
+        private readonly IMapper<TramsTrustSearchResult, TrustSearchResult> _searchResultMapper;
+
+        public TramsTrustsRepository(ITramsHttpClient httpClient,
+            IMapper<TramsTrustSearchResult, TrustSearchResult> searchResultMapper)
         {
-            using var httpClient = new HttpClient();
-            using var response = await httpClient.GetAsync("http://localhost:3000/trusts");
+            _httpClient = httpClient;
+            _searchResultMapper = searchResultMapper;
+        }
+
+        public async Task<RepositoryResult<List<TrustSearchResult>>> SearchTrusts(string searchQuery = "")
+        {
+            var url = $"trusts?group_name={searchQuery}&urn={searchQuery}&companies_house_number={searchQuery}";
+            using var response = await _httpClient.GetAsync(url);
 
             var apiResponse = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<List<TramsTrustSearchResult>>(apiResponse);
 
-            var mappedResult = result.Select(r => new TrustSearchResult
+            var mappedResult = result.Select(r => _searchResultMapper.Map(r)).ToList();
+
+            return new RepositoryResult<List<TrustSearchResult>>
             {
-                Ukprn = r.Urn,
-                TrustName = r.GroupName,
-                CompaniesHouseNumber = r.CompaniesHouseNumber,
-                Academies = r.Academies.Select(a => new TrustSearchAcademies {Name = a.Name, Ukprn = a.Urn}).ToList()
-            }).ToList();
-
-
-            return mappedResult;
+                Result = mappedResult
+            };
         }
     }
 }

--- a/Data/IProjects.cs
+++ b/Data/IProjects.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Data.Models;
+
+namespace Data
+{
+    public interface IProjects
+    {
+        public Task<RepositoryResult<Project>> GetByUrn(string urn);
+        public Task<RepositoryResult<Project>> Update(Project project);
+        public Task<RepositoryResult<Project>> Create(Project project);
+    }
+}

--- a/Data/ITrusts.cs
+++ b/Data/ITrusts.cs
@@ -6,6 +6,6 @@ namespace Data
 {
     public interface ITrusts
     {
-        public Task<List<TrustSearchResult>> SearchTrusts();
+        public Task<RepositoryResult<List<TrustSearchResult>>> SearchTrusts(string searchQuery);
     }
 }

--- a/Data/ITrusts.cs
+++ b/Data/ITrusts.cs
@@ -7,5 +7,7 @@ namespace Data
     public interface ITrusts
     {
         public Task<RepositoryResult<List<TrustSearchResult>>> SearchTrusts(string searchQuery);
+
+        public Task<RepositoryResult<Trust>> GetByUkprn(string ukprn);
     }
 }

--- a/Data/Models/Academies/AcademyPerformance.cs
+++ b/Data/Models/Academies/AcademyPerformance.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Data.Models
+namespace Data.Models.Academies
 {
     public class AcademyPerformance
     {

--- a/Data/Models/Academies/LatestOfstedJudgement.cs
+++ b/Data/Models/Academies/LatestOfstedJudgement.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Data.Models
+namespace Data.Models.Academies
 {
     public class LatestOfstedJudgement
     {

--- a/Data/Models/Academies/PupilNumbers.cs
+++ b/Data/Models/Academies/PupilNumbers.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Data.Models
+namespace Data.Models.Academies
 {
     public class PupilNumbers
     {

--- a/Data/Models/Academy.cs
+++ b/Data/Models/Academy.cs
@@ -6,9 +6,10 @@ namespace Data.Models
     {
         public Guid DynamicsId { get; set; }
         public string Ukprn { get; set; }
+        public string Name { get; set; }
         public AcademyPerformance Performance { get; set; }
         public PupilNumbers PupilNumbers { get; set; }
-        
+
         public LatestOfstedJudgement LatestOfstedJudgement { get; set; }
     }
 }

--- a/Data/Models/Academy.cs
+++ b/Data/Models/Academy.cs
@@ -1,4 +1,5 @@
 using System;
+using Data.Models.Academies;
 
 namespace Data.Models
 {

--- a/Data/Models/Academy.cs
+++ b/Data/Models/Academy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Data.Models.Academies;
 
 namespace Data.Models
@@ -12,5 +13,6 @@ namespace Data.Models
         public PupilNumbers PupilNumbers { get; set; }
 
         public LatestOfstedJudgement LatestOfstedJudgement { get; set; }
+        public List<string> Address { get; set; }
     }
 }

--- a/Data/Models/Project.cs
+++ b/Data/Models/Project.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Data.Models.Projects;
+
+namespace Data.Models
+{
+    public class Project
+    {
+        public string Urn { get; set; }
+        public string OutgoingTrustUkprn { get; set; }
+        public string State { get; set; }
+        public string Status { get; set; }
+        public List<TransferringAcademies> TransferringAcademies { get; set; }
+        public TransferFeatures Features { get; set; }
+    }
+}

--- a/Data/Models/Projects/TransferFeatures.cs
+++ b/Data/Models/Projects/TransferFeatures.cs
@@ -1,0 +1,10 @@
+namespace Data.Models.Projects
+{
+    public class TransferFeatures
+    {
+        public string WhoInitiatedTheTransfer { get; set; }
+        public bool IsSubjectToRddOrEsfaIntervention { get; set; }
+        public string InterventionDetails { get; set; }
+        public string ReasonForTransfer { get; set; }
+    }
+}

--- a/Data/Models/Projects/TransferringAcademies.cs
+++ b/Data/Models/Projects/TransferringAcademies.cs
@@ -1,0 +1,8 @@
+namespace Data.Models.Projects
+{
+    public class TransferringAcademies
+    {
+        public string OutgoingAcademyUkprn { get; set; }
+        public string IncomingTrustUkprn { get; set; }
+    }
+}

--- a/Data/Models/Trust.cs
+++ b/Data/Models/Trust.cs
@@ -1,0 +1,8 @@
+namespace Data.Models
+{
+    public class Trust
+    {
+        public string Name { get; set; }
+        public string Ukprn { get; set; }
+    }
+}

--- a/Data/Models/TrustSearchResult.cs
+++ b/Data/Models/TrustSearchResult.cs
@@ -10,10 +10,10 @@ namespace Data.Models
 
         public string CompaniesHouseNumber { get; set; }
 
-        public List<TrustSearchAcademies> Academies { get; set; }
+        public List<TrustSearchAcademy> Academies { get; set; }
     }
 
-    public class TrustSearchAcademies
+    public class TrustSearchAcademy
     {
         public string Ukprn { get; set; }
         public string Name { get; set; }

--- a/Frontend.Tests/ControllerTests/Projects/AcademyPerformanceControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/AcademyPerformanceControllerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using API.Models.Upstream.Response;
 using Data.Models;
+using Data.Models.Academies;
 using Frontend.Controllers.Projects;
 using Frontend.Models.AcademyPerformance;
 using Frontend.Services.Interfaces;

--- a/Frontend.Tests/ControllerTests/Projects/LatestOfstedJudgementControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/LatestOfstedJudgementControllerTests.cs
@@ -5,6 +5,7 @@ using API.Repositories;
 using API.Repositories.Interfaces;
 using Data;
 using Data.Models;
+using Data.Models.Academies;
 using Frontend.Controllers.Projects;
 using Frontend.Models;
 using Frontend.Models.AcademyPerformance;

--- a/Frontend.Tests/ControllerTests/Projects/PupilNumbersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/PupilNumbersControllerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using API.Models.Upstream.Response;
 using Data.Models;
+using Data.Models.Academies;
 using Frontend.Controllers.Projects;
 using Frontend.Models;
 using Frontend.Services.Interfaces;

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Data.Mock\Data.Mock.csproj" />
+    <ProjectReference Include="..\Data.TRAMS\Data.TRAMS.csproj" />
     <ProjectReference Include="..\Data\Data.csproj" />
     <ProjectReference Include="..\DocumentGeneration\DocumentGeneration.csproj" />
     <ProjectReference Include="..\TRAMS-API\API.csproj" />
@@ -27,8 +28,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="App_Code" />
   </ItemGroup>
 </Project>

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -11,7 +11,7 @@ using API.Repositories;
 using API.Repositories.Interfaces;
 using Data;
 using Data.Mock;
-using DocumentGeneration;
+using Data.TRAMS;
 using Frontend.Services;
 using Frontend.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -58,10 +58,10 @@ namespace Frontend
 
             services.AddSingleton(CreateHttpClient());
             services.AddSingleton<IAuthenticatedHttpClient>(r => CreateHttpClient());
-            services.AddTransient<IMapper<GetTrustsD365Model, GetTrustsModel>, GetTrustsReponseMapper>();
+
 
             ConfigureDynamicsRepositories(services);
-            ConfigureRepositories(services);
+            ConfigureRepositories(services, Configuration);
             ConfigureHelpers(services);
             ConfigureMappers(services);
             ConfigureServiceClasses(services);
@@ -120,39 +120,52 @@ namespace Frontend
             services.AddTransient<IProjectsRepository, ProjectsDynamicsRepository>();
         }
 
-        private static void ConfigureRepositories(IServiceCollection services)
+        private static void ConfigureRepositories(IServiceCollection services, IConfiguration configuration)
         {
-            services.AddTransient<IAcademies, MockAcademyRepository>();
+            var tramsApiBase = configuration["TRAMS_API_BASE"];
+            if (string.IsNullOrEmpty(tramsApiBase))
+            {
+                services.AddTransient<IAcademies, MockAcademyRepository>();
+                services.AddTransient<ITrusts, MockTrustsRepository>();
+            }
+            else
+            {
+                services.AddHttpClient("trams",
+                    client => { client.BaseAddress = new Uri(tramsApiBase); });
+                services.AddHttpClient<ITrusts, TramsTrustsRepository>("trams");
+                services.AddHttpClient<IAcademies, TramsAcademiesRepository>("trams");
+            }
         }
 
         private static void ConfigureMappers(IServiceCollection services)
         {
-            services.AddTransient<IMapper<GetTrustsD365Model, GetTrustsModel>,
-                GetTrustsReponseMapper>();
+            services.AddTransient<IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>,
+                GetTrustsReponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<GetAcademiesD365Model, GetAcademiesModel>,
-                GetAcademiesResponseMapper>();
+            services.AddTransient<IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>,
+                GetAcademiesResponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>,
-                PutProjectAcademiesRequestMapper>();
+            services.AddTransient<IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>,
+                PutProjectAcademiesRequestDynamicsMapper>();
 
-            services.AddTransient<IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>,
-                PostProjectAcademiesRequestMapper>();
+            services
+                .AddTransient<IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>,
+                    PostProjectAcademiesRequestDynamicsMapper>();
 
-            services.AddTransient<IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>,
-                PostProjectsRequestMapper>();
+            services.AddTransient<IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>,
+                PostProjectsRequestDynamicsMapper>();
 
-            services.AddTransient<IMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>,
-                GetProjectAcademiesResponseMapper>();
+            services.AddTransient<IDynamicsMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>,
+                GetProjectAcademiesResponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<GetProjectsD365Model, GetProjectsResponseModel>,
-                GetProjectsResponseMapper>();
+            services.AddTransient<IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel>,
+                GetProjectsResponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<SearchProjectsD365Model, SearchProjectsModel>,
-                SearchProjectsItemMapper>();
+            services.AddTransient<IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel>,
+                SearchProjectsItemDynamicsMapper>();
 
-            services.AddTransient<IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>,
-                SearchProjectsPageResponseMapper>();
+            services.AddTransient<IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>,
+                SearchProjectsPageResponseDynamicsMapper>();
         }
 
         private static void ConfigureHelpers(IServiceCollection services)

--- a/TRAMS-API/Mapping/IDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/IDynamicsMapper.cs
@@ -1,6 +1,6 @@
 ﻿namespace API.Mapping
 {
-    public interface IMapper<T, V>
+    public interface IDynamicsMapper<T, V>
     {
         V Map(T input);
     }

--- a/TRAMS-API/Mapping/Request/PostProjectAcademiesRequestDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Request/PostProjectAcademiesRequestDynamicsMapper.cs
@@ -5,11 +5,11 @@ using System.Linq;
 
 namespace API.Mapping.Request
 {
-    public class PutProjectAcademiesRequestMapper : IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
+    public class PostProjectAcademiesRequestDynamicsMapper : IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>
     {
-        public PatchProjectAcademiesD365Model Map(PutProjectAcademiesRequestModel input)
+        public PostAcademyTransfersProjectAcademyD365Model Map(PostProjectsAcademiesModel input)
         {
-            return new PatchProjectAcademiesD365Model
+            return new PostAcademyTransfersProjectAcademyD365Model
             {
                 AcademyId = $"/accounts({input.AcademyId})",
                 EsfaInterventionReasons = input.EsfaInterventionReasons != null && input.EsfaInterventionReasons.Any()
@@ -21,7 +21,11 @@ namespace API.Mapping.Request
                                               ? input.RddOrRscInterventionReasons.Select(r => ((int)MappingDictionaries.RddOrRscInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                  .ToDelimitedString()
                                               : null,
-                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained
+                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained,
+                Trusts = input.Trusts != null
+                         ? input.Trusts.Select(t => new PostAcademyTransfersProjectAcademyTrustD365Model { TrustId = $"/accounts({t.TrustId})" })
+                                       .ToList()
+                         : new List<PostAcademyTransfersProjectAcademyTrustD365Model>()
             };
         }
     }

--- a/TRAMS-API/Mapping/Request/PostProjectsRequestDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Request/PostProjectsRequestDynamicsMapper.cs
@@ -5,13 +5,13 @@ using System.Linq;
 
 namespace API.Mapping.Request
 {
-    public class PostProjectsRequestMapper : IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>
+    public class PostProjectsRequestDynamicsMapper : IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>
     {
-        private readonly IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> _projectAcademiesMapper;
+        private readonly IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> _projectAcademiesDynamicsMapper;
 
-        public PostProjectsRequestMapper(IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> projectAcademiesMapper)
+        public PostProjectsRequestDynamicsMapper(IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> projectAcademiesDynamicsMapper)
         {
-            _projectAcademiesMapper = projectAcademiesMapper;
+            _projectAcademiesDynamicsMapper = projectAcademiesDynamicsMapper;
         }
 
         public PostAcademyTransfersProjectsD365Model Map(PostProjectsRequestModel input)
@@ -21,7 +21,7 @@ namespace API.Mapping.Request
                 return null;
             }
 
-            var academies = input.ProjectAcademies?.Select(p => _projectAcademiesMapper.Map(p)).ToList();
+            var academies = input.ProjectAcademies?.Select(p => _projectAcademiesDynamicsMapper.Map(p)).ToList();
 
 
             var output = new PostAcademyTransfersProjectsD365Model

--- a/TRAMS-API/Mapping/Request/PutProjectAcademiesRequestDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Request/PutProjectAcademiesRequestDynamicsMapper.cs
@@ -5,11 +5,11 @@ using System.Linq;
 
 namespace API.Mapping.Request
 {
-    public class PostProjectAcademiesRequestMapper : IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>
+    public class PutProjectAcademiesRequestDynamicsMapper : IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
     {
-        public PostAcademyTransfersProjectAcademyD365Model Map(PostProjectsAcademiesModel input)
+        public PatchProjectAcademiesD365Model Map(PutProjectAcademiesRequestModel input)
         {
-            return new PostAcademyTransfersProjectAcademyD365Model
+            return new PatchProjectAcademiesD365Model
             {
                 AcademyId = $"/accounts({input.AcademyId})",
                 EsfaInterventionReasons = input.EsfaInterventionReasons != null && input.EsfaInterventionReasons.Any()
@@ -21,11 +21,7 @@ namespace API.Mapping.Request
                                               ? input.RddOrRscInterventionReasons.Select(r => ((int)MappingDictionaries.RddOrRscInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                  .ToDelimitedString()
                                               : null,
-                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained,
-                Trusts = input.Trusts != null
-                         ? input.Trusts.Select(t => new PostAcademyTransfersProjectAcademyTrustD365Model { TrustId = $"/accounts({t.TrustId})" })
-                                       .ToList()
-                         : new List<PostAcademyTransfersProjectAcademyTrustD365Model>()
+                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained
             };
         }
     }

--- a/TRAMS-API/Mapping/Response/GetAcademiesResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetAcademiesResponseDynamicsMapper.cs
@@ -3,11 +3,11 @@ using API.Models.Upstream.Response;
 
 namespace API.Mapping.Response
 {
-    public class GetAcademiesResponseMapper : IMapper<GetAcademiesD365Model, GetAcademiesModel>
+    public class GetAcademiesResponseDynamicsMapper : IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>
     {
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetAcademiesResponseMapper(IEstablishmentNameFormatter establishmentNameFormatter)
+        public GetAcademiesResponseDynamicsMapper(IEstablishmentNameFormatter establishmentNameFormatter)
         {
             _establishmentNameFormatter = establishmentNameFormatter;
         }

--- a/TRAMS-API/Mapping/Response/GetProjectAcademiesResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetProjectAcademiesResponseDynamicsMapper.cs
@@ -7,12 +7,12 @@ using System.Linq;
 
 namespace API.Mapping.Response
 {
-    public class GetProjectAcademiesResponseMapper : IMapper<AcademyTransfersProjectAcademy,
+    public class GetProjectAcademiesResponseDynamicsMapper : IDynamicsMapper<AcademyTransfersProjectAcademy,
                                                              GetProjectsAcademyResponseModel>
     {
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetProjectAcademiesResponseMapper(IEstablishmentNameFormatter establishmentNameFormatter)
+        public GetProjectAcademiesResponseDynamicsMapper(IEstablishmentNameFormatter establishmentNameFormatter)
         {
             _establishmentNameFormatter = establishmentNameFormatter;
         }

--- a/TRAMS-API/Mapping/Response/GetProjectsResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetProjectsResponseDynamicsMapper.cs
@@ -6,17 +6,17 @@ using System.Linq;
 
 namespace API.Mapping.Response
 {
-    public class GetProjectsResponseMapper : IMapper<GetProjectsD365Model, GetProjectsResponseModel>
+    public class GetProjectsResponseDynamicsMapper : IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel>
     {
-        private readonly IMapper<AcademyTransfersProjectAcademy,
-                                 GetProjectsAcademyResponseModel> _academyMapper;
+        private readonly IDynamicsMapper<AcademyTransfersProjectAcademy,
+                                 GetProjectsAcademyResponseModel> _academyDynamicsMapper;
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetProjectsResponseMapper(IMapper<AcademyTransfersProjectAcademy,
-                                                 GetProjectsAcademyResponseModel> academyMapper,
+        public GetProjectsResponseDynamicsMapper(IDynamicsMapper<AcademyTransfersProjectAcademy,
+                                                 GetProjectsAcademyResponseModel> academyDynamicsMapper,
                                          IEstablishmentNameFormatter establishmentNameFormatter)
         {
-            _academyMapper = academyMapper;
+            _academyDynamicsMapper = academyDynamicsMapper;
             _establishmentNameFormatter = establishmentNameFormatter;
         }
 
@@ -71,7 +71,7 @@ namespace API.Mapping.Response
         {
             return input.Academies == null || input.Academies.Count == 0
                    ? new List<GetProjectsAcademyResponseModel>()
-                   : input.Academies?.Select(a => _academyMapper.Map(a))
+                   : input.Academies?.Select(a => _academyDynamicsMapper.Map(a))
                                      .ToList();
         }
     }

--- a/TRAMS-API/Mapping/Response/GetTrustsReponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetTrustsReponseDynamicsMapper.cs
@@ -3,11 +3,11 @@ using API.Models.Upstream.Response;
 
 namespace API.Mapping.Response
 {
-    public class GetTrustsReponseMapper : IMapper<GetTrustsD365Model, GetTrustsModel>
+    public class GetTrustsReponseDynamicsMapper : IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>
     {
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetTrustsReponseMapper(IEstablishmentNameFormatter establishmentNameFormatter)
+        public GetTrustsReponseDynamicsMapper(IEstablishmentNameFormatter establishmentNameFormatter)
         {
             _establishmentNameFormatter = establishmentNameFormatter;
         }

--- a/TRAMS-API/Mapping/SearchProjectsItemDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/SearchProjectsItemDynamicsMapper.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace API.Mapping
 {
-    public class SearchProjectsItemMapper : IMapper<SearchProjectsD365Model, SearchProjectsModel>
+    public class SearchProjectsItemDynamicsMapper : IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel>
     {
         public SearchProjectsModel Map(SearchProjectsD365Model input)
         {

--- a/TRAMS-API/Mapping/SearchProjectsPageResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/SearchProjectsPageResponseDynamicsMapper.cs
@@ -5,13 +5,13 @@ using System.Linq;
 
 namespace API.Mapping
 {
-    public class SearchProjectsPageResponseMapper : IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>
+    public class SearchProjectsPageResponseDynamicsMapper : IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>
     {
-        private readonly IMapper<SearchProjectsD365Model, SearchProjectsModel> _itemMapper;
+        private readonly IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel> _itemDynamicsMapper;
 
-        public SearchProjectsPageResponseMapper(IMapper<SearchProjectsD365Model, SearchProjectsModel> itemMapper)
+        public SearchProjectsPageResponseDynamicsMapper(IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel> itemDynamicsMapper)
         {
-            _itemMapper = itemMapper;
+            _itemDynamicsMapper = itemDynamicsMapper;
         }
 
         public SearchProjectsPageModel Map(SearchProjectsD365PageModel input)
@@ -21,7 +21,7 @@ namespace API.Mapping
                 return null;
             }
 
-            var items = input.Projects?.Select(p => _itemMapper.Map(p))
+            var items = input.Projects?.Select(p => _itemDynamicsMapper.Map(p))
                                        .ToList();
 
             return new SearchProjectsPageModel

--- a/TRAMS-API/Repositories/AcademiesDynamicsRepository.cs
+++ b/TRAMS-API/Repositories/AcademiesDynamicsRepository.cs
@@ -19,17 +19,17 @@ namespace API.Repositories
         private readonly IAuthenticatedHttpClient _client;
         private readonly IOdataUrlBuilder<GetAcademiesD365Model> _urlBuilder;
         private readonly ILogger<AcademiesDynamicsRepository> _logger;
-        private readonly IMapper<GetAcademiesD365Model, GetAcademiesModel> _getAcademies365Mapper;
+        private readonly IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel> _getAcademies365DynamicsMapper;
 
         public AcademiesDynamicsRepository(IAuthenticatedHttpClient client,
             IOdataUrlBuilder<GetAcademiesD365Model> urlBuilder,
             ILogger<AcademiesDynamicsRepository> logger,
-            IMapper<GetAcademiesD365Model, GetAcademiesModel> getAcademies365Mapper)
+            IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel> getAcademies365DynamicsMapper)
         {
             _client = client;
             _urlBuilder = urlBuilder;
             _logger = logger;
-            _getAcademies365Mapper = getAcademies365Mapper;
+            _getAcademies365DynamicsMapper = getAcademies365DynamicsMapper;
         }
 
         public async Task<RepositoryResult<GetAcademiesModel>> GetAcademyById(Guid id)
@@ -54,7 +54,7 @@ namespace API.Repositories
                     return new RepositoryResult<GetAcademiesModel> {Result = null};
                 }
 
-                var mappedResult = _getAcademies365Mapper.Map(castedResult);
+                var mappedResult = _getAcademies365DynamicsMapper.Map(castedResult);
                 return new RepositoryResult<GetAcademiesModel> {Result = mappedResult};
             }
 
@@ -89,7 +89,7 @@ namespace API.Repositories
             if (response.IsSuccessStatusCode)
             {
                 var castedResults = JsonConvert.DeserializeObject<ResultSet<GetAcademiesD365Model>>(responseContent);
-                var mappedResults = castedResults.Items.Select(item => _getAcademies365Mapper.Map(item)).ToList();
+                var mappedResults = castedResults.Items.Select(item => _getAcademies365DynamicsMapper.Map(item)).ToList();
 
                 return new RepositoryResult<List<GetAcademiesModel>> {Result = mappedResults};
             }

--- a/TRAMS-API/Repositories/ProjectsDynamicsRepository.cs
+++ b/TRAMS-API/Repositories/ProjectsDynamicsRepository.cs
@@ -27,39 +27,39 @@ namespace API.Repositories
         private readonly ILogger<ProjectsDynamicsRepository> _logger;
         private readonly IOdataUrlBuilder<AcademyTransfersProjectAcademy> _projectAcademyUrlBuilder;
         private readonly IFetchXmlSanitizer _fetchXmlSanitizer;
-        private readonly IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> _postProjectsMapper;
+        private readonly IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> _postProjectsDynamicsMapper;
 
-        private readonly IMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>
-            _getProjectAcademyMapper;
+        private readonly IDynamicsMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>
+            _getProjectAcademyDynamicsMapper;
 
-        private readonly IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
-            _putProjectAcademiesMapper;
+        private readonly IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
+            _putProjectAcademiesDynamicsMapper;
 
-        private readonly IMapper<GetProjectsD365Model, GetProjectsResponseModel> _getProjectsMapper;
+        private readonly IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel> _getProjectsDynamicsMapper;
 
-        private readonly IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> _searchProjectsMapper;
+        private readonly IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> _searchProjectsDynamicsMapper;
 
         public ProjectsDynamicsRepository(IAuthenticatedHttpClient client,
             IOdataUrlBuilder<GetProjectsD365Model> urlBuilder,
             IOdataUrlBuilder<AcademyTransfersProjectAcademy> projectAcademyUrlBuilder,
             IFetchXmlSanitizer fetchXmlSanitizer,
             ILogger<ProjectsDynamicsRepository> logger,
-            IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> postProjectsMapper,
-            IMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel> getProjectAcademyMapper,
-            IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model> putProjectAcademiesMapper,
-            IMapper<GetProjectsD365Model, GetProjectsResponseModel> getProjectsMapper,
-            IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> searchProjectsMapper)
+            IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> postProjectsDynamicsMapper,
+            IDynamicsMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel> getProjectAcademyDynamicsMapper,
+            IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model> putProjectAcademiesDynamicsMapper,
+            IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel> getProjectsDynamicsMapper,
+            IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> searchProjectsDynamicsMapper)
         {
             _client = client;
             _urlBuilder = urlBuilder;
             _projectAcademyUrlBuilder = projectAcademyUrlBuilder;
             _fetchXmlSanitizer = fetchXmlSanitizer;
             _logger = logger;
-            _postProjectsMapper = postProjectsMapper;
-            _getProjectAcademyMapper = getProjectAcademyMapper;
-            _putProjectAcademiesMapper = putProjectAcademiesMapper;
-            _getProjectsMapper = getProjectsMapper;
-            _searchProjectsMapper = searchProjectsMapper;
+            _postProjectsDynamicsMapper = postProjectsDynamicsMapper;
+            _getProjectAcademyDynamicsMapper = getProjectAcademyDynamicsMapper;
+            _putProjectAcademiesDynamicsMapper = putProjectAcademiesDynamicsMapper;
+            _getProjectsDynamicsMapper = getProjectsDynamicsMapper;
+            _searchProjectsDynamicsMapper = searchProjectsDynamicsMapper;
         }
 
         public async Task<RepositoryResult<SearchProjectsPageModel>> SearchProject(string search,
@@ -119,7 +119,7 @@ namespace API.Repositories
                     Projects = pageResults
                 };
 
-                var mappedPageResult = _searchProjectsMapper.Map(pageResult);
+                var mappedPageResult = _searchProjectsDynamicsMapper.Map(pageResult);
                 return new RepositoryResult<SearchProjectsPageModel> {Result = mappedPageResult};
             }
 
@@ -152,7 +152,7 @@ namespace API.Repositories
             if (response.IsSuccessStatusCode)
             {
                 var castedResults = JsonConvert.DeserializeObject<AcademyTransfersProjectAcademy>(responseContent);
-                var mappedResults = _getProjectAcademyMapper.Map(castedResults);
+                var mappedResults = _getProjectAcademyDynamicsMapper.Map(castedResults);
 
                 return new RepositoryResult<GetProjectsAcademyResponseModel> {Result = mappedResults};
             }
@@ -187,7 +187,7 @@ namespace API.Repositories
             {
                 var castedResults = JsonConvert.DeserializeObject<GetProjectsD365Model>(responseContent);
 
-                return new RepositoryResult<GetProjectsResponseModel> {Result = _getProjectsMapper.Map(castedResults)};
+                return new RepositoryResult<GetProjectsResponseModel> {Result = _getProjectsDynamicsMapper.Map(castedResults)};
             }
 
             //At this point, log the error and configure the repository result to inform the caller that the repo failed
@@ -205,7 +205,7 @@ namespace API.Repositories
 
         public async Task<RepositoryResult<Guid?>> InsertProject(PostProjectsRequestModel project)
         {
-            var mappedProject = _postProjectsMapper.Map(project);
+            var mappedProject = _postProjectsDynamicsMapper.Map(project);
             var jsonBody = JsonConvert.SerializeObject(mappedProject);
 
             var buffer = System.Text.Encoding.UTF8.GetBytes(jsonBody);
@@ -245,7 +245,7 @@ namespace API.Repositories
         public async Task<RepositoryResult<Guid?>> UpdateProjectAcademy(Guid id, PutProjectAcademiesRequestModel model)
         {
             var url = _projectAcademyUrlBuilder.BuildRetrieveOneUrl("sip_academytransfersprojectacademies", id);
-            var mappedModel = _putProjectAcademiesMapper.Map(model);
+            var mappedModel = _putProjectAcademiesDynamicsMapper.Map(model);
             var jsonContent = JsonConvert.SerializeObject(mappedModel);
             var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 

--- a/TRAMS-API/Repositories/TrustsDynamicsRepository.cs
+++ b/TRAMS-API/Repositories/TrustsDynamicsRepository.cs
@@ -22,18 +22,18 @@ namespace API.Repositories
         private readonly IAuthenticatedHttpClient _client;
         private readonly IODataSanitizer _oDataSanitizer;
         private readonly ILogger<TrustsDynamicsRepository> _logger;
-        private readonly IMapper<GetTrustsD365Model, GetTrustsModel> _getTrustMapper;
+        private readonly IDynamicsMapper<GetTrustsD365Model, GetTrustsModel> _getTrustDynamicsMapper;
 
         public TrustsDynamicsRepository(IAuthenticatedHttpClient client,
             IOdataUrlBuilder<GetTrustsD365Model> urlBuilder,
             IODataSanitizer oDataSanitizer,
-            ILogger<TrustsDynamicsRepository> logger, IMapper<GetTrustsD365Model, GetTrustsModel> getTrustMapper)
+            ILogger<TrustsDynamicsRepository> logger, IDynamicsMapper<GetTrustsD365Model, GetTrustsModel> getTrustDynamicsMapper)
         {
             _client = client;
             _urlBuilder = urlBuilder;
             _oDataSanitizer = oDataSanitizer;
             _logger = logger;
-            _getTrustMapper = getTrustMapper;
+            _getTrustDynamicsMapper = getTrustDynamicsMapper;
         }
 
         public async Task<RepositoryResult<GetTrustsModel>> GetTrustById(Guid id)
@@ -67,7 +67,7 @@ namespace API.Repositories
                     return new RepositoryResult<GetTrustsModel> {Result = null};
                 }
 
-                var mappedResult = _getTrustMapper.Map(castedResult);
+                var mappedResult = _getTrustDynamicsMapper.Map(castedResult);
                 return new RepositoryResult<GetTrustsModel> {Result = mappedResult};
             }
 
@@ -98,7 +98,7 @@ namespace API.Repositories
             if (response.IsSuccessStatusCode)
             {
                 var castedResults = JsonConvert.DeserializeObject<ResultSet<GetTrustsD365Model>>(responseContent);
-                var mappedResults = castedResults.Items.Select(r => _getTrustMapper.Map(r)).ToList();
+                var mappedResults = castedResults.Items.Select(r => _getTrustDynamicsMapper.Map(r)).ToList();
 
                 return new RepositoryResult<List<GetTrustsModel>> {Result = mappedResults};
             }

--- a/academy-transfers-api.sln
+++ b/academy-transfers-api.sln
@@ -26,6 +26,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data", "Data\Data.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data.Mock", "Data.Mock\Data.Mock.csproj", "{B438E250-451B-4435-B689-E64D702AED13}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data.TRAMS", "Data.TRAMS\Data.TRAMS.csproj", "{AB12AC97-D04C-4525-B615-EE0BD1E21229}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data.TRAMS.Tests", "Data.TRAMS.Tests\Data.TRAMS.Tests.csproj", "{98D82005-DF8A-43F5-960A-8FDD77EE693E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,6 +68,14 @@ Global
 		{B438E250-451B-4435-B689-E64D702AED13}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B438E250-451B-4435-B689-E64D702AED13}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B438E250-451B-4435-B689-E64D702AED13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB12AC97-D04C-4525-B615-EE0BD1E21229}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB12AC97-D04C-4525-B615-EE0BD1E21229}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB12AC97-D04C-4525-B615-EE0BD1E21229}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB12AC97-D04C-4525-B615-EE0BD1E21229}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98D82005-DF8A-43F5-960A-8FDD77EE693E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98D82005-DF8A-43F5-960A-8FDD77EE693E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98D82005-DF8A-43F5-960A-8FDD77EE693E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98D82005-DF8A-43F5-960A-8FDD77EE693E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Context

In preparation to integrate with the upcoming TRAMS API, classes to interact with the API have to be created.

This PR seeks to create the models and repositories required to integrate with the API, as well as a few initial mappers used with a local mock API

### Changes proposed in this pull request

- Rename dynamics mapper
- Add Tests for Trust repository
- Add academies repository tests
- Restructure tests
- Get trust by Ukprn
- Add Projects interface and models
- Add trams project repository
- Add initial mapper examples
- Add api key header to default headers
- Add initial trams trust mapper
- Create first mappings of trams repositories

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

