### PR TITLE
Rename dynamics mapper

### DIFF
--- a/API.Tests/MappersTests/GetProjectsModelMapperTests.cs
+++ b/API.Tests/MappersTests/GetProjectsModelMapperTests.cs
@@ -10,12 +10,12 @@ namespace API.Tests.MapperTests
 {
     public class GetProjectsModelMapperTests
     {
-        private readonly GetProjectsResponseMapper _mapper;
+        private readonly GetProjectsResponseDynamicsMapper _dynamicsMapper;
 
         public GetProjectsModelMapperTests()
         {
             var establishmentNameFormatter = new EstablishmentNameFormatter();
-            _mapper = new GetProjectsResponseMapper(new GetProjectAcademiesResponseMapper(establishmentNameFormatter), establishmentNameFormatter);
+            _dynamicsMapper = new GetProjectsResponseDynamicsMapper(new GetProjectAcademiesResponseDynamicsMapper(establishmentNameFormatter), establishmentNameFormatter);
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace API.Tests.MapperTests
         {
             var model = (GetProjectsD365Model)null;
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Null(result);
         }
@@ -36,7 +36,7 @@ namespace API.Tests.MapperTests
                 ProjectId = Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9")
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectId);
         }
@@ -49,7 +49,7 @@ namespace API.Tests.MapperTests
                 ProjectName = "Some name"
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal("Some name", result.ProjectName);
         }
@@ -62,7 +62,7 @@ namespace API.Tests.MapperTests
                 ProjectStatus = Models.D365.Enums.ProjectStatusEnum.Completed
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.ProjectStatusEnum.Completed, result.ProjectStatus);
         }
@@ -76,7 +76,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorUid = "joe.bloggs@email.com"
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal("Joe Bloggs", result.ProjectInitiatorFullName);
             Assert.Equal("joe.bloggs@email.com", result.ProjectInitiatorUid);
@@ -98,7 +98,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectAcademies[0].ProjectAcademyId);
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1"), result.ProjectAcademies[0].AcademyId);
@@ -133,7 +133,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectAcademies[0].ProjectAcademyId);
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1"), result.ProjectAcademies[0].AcademyId);
@@ -162,7 +162,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].EsfaInterventionReasons);
         }
@@ -181,7 +181,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].EsfaInterventionReasons);
         }
@@ -200,7 +200,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.GovernanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[0]);
             Assert.Single(result.ProjectAcademies[0].EsfaInterventionReasons);
@@ -220,7 +220,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.GovernanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[0]);
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.FinanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[1]);
@@ -251,7 +251,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.GovernanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[0]);
             Assert.Equal(Models.Upstream.Enums.EsfaInterventionReasonEnum.FinanceConcerns, result.ProjectAcademies[0].EsfaInterventionReasons[1]);
@@ -278,7 +278,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].RddOrRscInterventionReasons);
         }
@@ -297,7 +297,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies[0].RddOrRscInterventionReasons);
         }
@@ -316,7 +316,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(RddOrRscInterventionReasonEnum.TerminationWarningNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[0]);
             Assert.Single(result.ProjectAcademies[0].RddOrRscInterventionReasons);
@@ -336,7 +336,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(RddOrRscInterventionReasonEnum.TerminationWarningNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[0]);
             Assert.Equal(RddOrRscInterventionReasonEnum.RSCMindedToTerminateNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[1]);
@@ -367,7 +367,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(RddOrRscInterventionReasonEnum.TerminationWarningNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[0]);
             Assert.Equal(RddOrRscInterventionReasonEnum.RSCMindedToTerminateNotice, result.ProjectAcademies[0].RddOrRscInterventionReasons[1]);
@@ -407,7 +407,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal("RDD Explanation", result.ProjectAcademies[0].RddOrRscInterventionReasonsExplained);
             Assert.Equal("ESFA Explanation", result.ProjectAcademies[0].EsfaInterventionReasonsExplained);
@@ -430,7 +430,7 @@ namespace API.Tests.MapperTests
                 Academies = null
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies);
         }
@@ -443,7 +443,7 @@ namespace API.Tests.MapperTests
                 Academies = new List<AcademyTransfersProjectAcademy>()
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectAcademies);
         }
@@ -456,7 +456,7 @@ namespace API.Tests.MapperTests
                 Trusts = null
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectTrusts);
         }
@@ -469,7 +469,7 @@ namespace API.Tests.MapperTests
                 Trusts = new List<ProjectTrust>()
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Empty(result.ProjectTrusts);
         }
@@ -490,7 +490,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Single(result.ProjectTrusts);
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fa9"), result.ProjectTrusts[0].ProjectTrustId);
@@ -526,7 +526,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(model);
+            var result = _dynamicsMapper.Map(model);
 
             Assert.Equal(3, result.ProjectTrusts.Count);
 

--- a/API.Tests/MappersTests/ModelMappingTests.cs
+++ b/API.Tests/MappersTests/ModelMappingTests.cs
@@ -32,7 +32,7 @@ namespace API.Tests.MapperTests
                 Urn = "4242"
             };
 
-            var mapper = new GetAcademiesResponseMapper(new EstablishmentNameFormatter());
+            var mapper = new GetAcademiesResponseDynamicsMapper(new EstablishmentNameFormatter());
 
             var result = mapper.Map(academiesD365Model);
 
@@ -69,7 +69,7 @@ namespace API.Tests.MapperTests
                 Upin = "42424",
             };
 
-            var mapper = new GetTrustsReponseMapper(new EstablishmentNameFormatter());
+            var mapper = new GetTrustsReponseDynamicsMapper(new EstablishmentNameFormatter());
 
             var result = mapper.Map(d365Model);
 

--- a/API.Tests/MappersTests/PostProjectsRequestMapperTests.cs
+++ b/API.Tests/MappersTests/PostProjectsRequestMapperTests.cs
@@ -9,11 +9,11 @@ namespace API.Tests.MapperTests
 {
     public class PostProjectsRequestMapperTests
     {
-        private readonly PostProjectsRequestMapper _mapper;
+        private readonly PostProjectsRequestDynamicsMapper _dynamicsMapper;
 
         public PostProjectsRequestMapperTests()
         {
-            _mapper = new PostProjectsRequestMapper(new PostProjectAcademiesRequestMapper());
+            _dynamicsMapper = new PostProjectsRequestDynamicsMapper(new PostProjectAcademiesRequestDynamicsMapper());
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].AcademyId);
         }
@@ -44,7 +44,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorUid = "joebloggs@email.com"
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Joe Bloggs", result.ProjectInitiatorFullName);
             Assert.Equal("joebloggs@email.com", result.ProjectInitiatorUid);
@@ -58,7 +58,7 @@ namespace API.Tests.MapperTests
                 ProjectStatus = Models.Upstream.Enums.ProjectStatusEnum.Completed
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal(Models.D365.Enums.ProjectStatusEnum.Completed, result.ProjectStatus);
         }
@@ -85,7 +85,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].AcademyId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Academies[1].AcademyId);
@@ -106,7 +106,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.Academies[0].EsfaInterventionReasons));
         }
@@ -128,7 +128,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001", result.Academies[0].EsfaInterventionReasons);
         }
@@ -152,7 +152,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001,596500002,596500003", result.Academies[0].EsfaInterventionReasons);
         }
@@ -187,7 +187,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Null(result.Academies[0].EsfaInterventionReasons);
             Assert.Equal("596500001", result.Academies[1].EsfaInterventionReasons);
@@ -208,7 +208,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.Academies[0].EsfaInterventionReasonsExplained));
         }
@@ -227,7 +227,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Some explanation", result.Academies[0].EsfaInterventionReasonsExplained);
         }
@@ -254,7 +254,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Some explanation", result.Academies[0].EsfaInterventionReasonsExplained);
             Assert.True(string.IsNullOrEmpty(result.Academies[1].EsfaInterventionReasonsExplained));
@@ -275,7 +275,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.Academies[0].RddOrRscInterventionReasons));
         }
@@ -297,7 +297,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002", result.Academies[0].RddOrRscInterventionReasons);
         }
@@ -321,7 +321,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002,596500001,596500000", result.Academies[0].RddOrRscInterventionReasons);
         }
@@ -356,7 +356,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002,596500001,596500000", result.Academies[0].RddOrRscInterventionReasons);
             Assert.Equal("596500002", result.Academies[1].RddOrRscInterventionReasons);
@@ -374,7 +374,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Empty(result.Academies[0].Trusts);
         }
@@ -399,7 +399,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].Trusts[0].TrustId);
         }
@@ -432,7 +432,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].Trusts[0].TrustId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Academies[0].Trusts[1].TrustId);
@@ -477,7 +477,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.Academies[0].Trusts[0].TrustId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Academies[1].Trusts[0].TrustId);
@@ -493,7 +493,7 @@ namespace API.Tests.MapperTests
                 ProjectTrusts = null
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Empty(result.Trusts);
         }
@@ -512,7 +512,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Trusts[0].TrustId);
         }
@@ -539,7 +539,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672fe1)", result.Trusts[0].TrustId);
             Assert.Equal("/accounts(a16e9020-9123-4420-8055-851d1b672ff2)", result.Trusts[1].TrustId);

--- a/API.Tests/MappersTests/PutProjectAcademyMapperTests.cs
+++ b/API.Tests/MappersTests/PutProjectAcademyMapperTests.cs
@@ -10,11 +10,11 @@ namespace API.Tests.MapperTests
 {
     public class PutProjectAcademyMapperTests
     {
-        private readonly PutProjectAcademiesRequestMapper _mapper; 
+        private readonly PutProjectAcademiesRequestDynamicsMapper _dynamicsMapper; 
 
         public PutProjectAcademyMapperTests()
         {
-            _mapper = new PutProjectAcademiesRequestMapper();
+            _dynamicsMapper = new PutProjectAcademiesRequestDynamicsMapper();
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace API.Tests.MapperTests
                 AcademyId = Guid.Parse("81014326-5d51-e911-a82e-000d3a385a17")
             };
                 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("/accounts(81014326-5d51-e911-a82e-000d3a385a17)", result.AcademyId);
         }
@@ -38,7 +38,7 @@ namespace API.Tests.MapperTests
                 EsfaInterventionReasons = null
             };
                 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.EsfaInterventionReasons));
         }
@@ -54,7 +54,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001", result.EsfaInterventionReasons);
         }
@@ -72,7 +72,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500001,596500002,596500003", result.EsfaInterventionReasons);
         }
@@ -86,7 +86,7 @@ namespace API.Tests.MapperTests
                 EsfaInterventionReasonsExplained = null
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.EsfaInterventionReasonsExplained));
         }
@@ -99,7 +99,7 @@ namespace API.Tests.MapperTests
                 EsfaInterventionReasonsExplained = "Some explanation"
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("Some explanation", result.EsfaInterventionReasonsExplained);
         }
@@ -112,7 +112,7 @@ namespace API.Tests.MapperTests
                 RddOrRscInterventionReasons = null
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.True(string.IsNullOrEmpty(result.RddOrRscInterventionReasons));
         }
@@ -128,7 +128,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002", result.RddOrRscInterventionReasons);
         }
@@ -146,7 +146,7 @@ namespace API.Tests.MapperTests
                 }
             };
 
-            var result = _mapper.Map(request);
+            var result = _dynamicsMapper.Map(request);
 
             Assert.Equal("596500002,596500001,596500000", result.RddOrRscInterventionReasons);
         }

--- a/API.Tests/MappersTests/SearchProjectsMapperTests.cs
+++ b/API.Tests/MappersTests/SearchProjectsMapperTests.cs
@@ -9,17 +9,17 @@ namespace API.Tests.MapperTests
 {
     public class SearchProjectsMapperTests
     {
-        private readonly SearchProjectsItemMapper _mapper;
+        private readonly SearchProjectsItemDynamicsMapper _dynamicsMapper;
 
         public SearchProjectsMapperTests()
         {
-            _mapper = new SearchProjectsItemMapper();
+            _dynamicsMapper = new SearchProjectsItemDynamicsMapper();
         }
 
         [Fact]
         public void NullInput_Returns_Null()
         {
-            var result = _mapper.Map(null);
+            var result = _dynamicsMapper.Map(null);
 
             Assert.Null(result);
         }
@@ -29,7 +29,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal((Guid)default, result.ProjectId);
         }
@@ -42,7 +42,7 @@ namespace API.Tests.MapperTests
                 ProjectId = Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1")
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(Guid.Parse("a16e9020-9123-4420-8055-851d1b672fb1"), result.ProjectId);
         }
@@ -52,7 +52,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Null(result.ProjectInitiatorUid);
         }
@@ -68,7 +68,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorUid = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectInitiatorUid);
         }
@@ -78,7 +78,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Null(result.ProjectName);
         }
@@ -95,7 +95,7 @@ namespace API.Tests.MapperTests
                 ProjectName = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectName);
         }
@@ -105,7 +105,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Null(result.ProjectInitiatorFullName);
         }
@@ -122,7 +122,7 @@ namespace API.Tests.MapperTests
                 ProjectInitiatorFullName = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectInitiatorFullName);
         }
@@ -132,7 +132,7 @@ namespace API.Tests.MapperTests
         {
             var searchProjectsD365Model = new SearchProjectsD365Model();
             
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(default, result.ProjectStatus);
         }
@@ -147,7 +147,7 @@ namespace API.Tests.MapperTests
                 ProjectStatus = input
             };
 
-            var result = _mapper.Map(searchProjectsD365Model);
+            var result = _dynamicsMapper.Map(searchProjectsD365Model);
 
             Assert.Equal(expected, result.ProjectStatus);
         }

--- a/API.Tests/MappersTests/SearchProjectsPageResponseMapperTests.cs
+++ b/API.Tests/MappersTests/SearchProjectsPageResponseMapperTests.cs
@@ -9,18 +9,18 @@ namespace API.Tests.MapperTests
 {
     public class SearchProjectsPageResponseMapperTests
     {
-        private readonly Mapping.SearchProjectsPageResponseMapper _mapper;
+        private readonly Mapping.SearchProjectsPageResponseDynamicsMapper _dynamicsMapper;
 
         public SearchProjectsPageResponseMapperTests()
         {
-            var itemMapper = new SearchProjectsItemMapper();
-            _mapper = new Mapping.SearchProjectsPageResponseMapper(itemMapper);
+            var itemMapper = new SearchProjectsItemDynamicsMapper();
+            _dynamicsMapper = new Mapping.SearchProjectsPageResponseDynamicsMapper(itemMapper);
         }
 
         [Fact]
         public void NullInput_Returns_NullValue()
         {
-            var result = _mapper.Map(null);
+            var result = _dynamicsMapper.Map(null);
 
             Assert.Null(result);
         }
@@ -36,7 +36,7 @@ namespace API.Tests.MapperTests
                 TotalPages = input
             };
 
-            var result = _mapper.Map(inputPageModel);
+            var result = _dynamicsMapper.Map(inputPageModel);
 
             Assert.Equal(expected, result.TotalPages);
         }
@@ -52,7 +52,7 @@ namespace API.Tests.MapperTests
                 CurrentPage = input
             };
 
-            var result = _mapper.Map(inputPageModel);
+            var result = _dynamicsMapper.Map(inputPageModel);
 
             Assert.Equal(expected, result.CurrentPage);
         }
@@ -60,12 +60,12 @@ namespace API.Tests.MapperTests
         [Fact]
         public void ItemMapper_CallTest()
         {
-            var itemMapper = new Mock<IMapper<SearchProjectsD365Model, SearchProjectsModel>>();
+            var itemMapper = new Mock<IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel>>();
 
             itemMapper.Setup(m => m.Map(It.IsAny<SearchProjectsD365Model>()))
                       .Verifiable();
 
-            var pageMapper = new SearchProjectsPageResponseMapper(itemMapper.Object);
+            var pageMapper = new SearchProjectsPageResponseDynamicsMapper(itemMapper.Object);
 
             var inputModel = new SearchProjectsD365PageModel
             {

--- a/API.Tests/RepositoriesTests/AcademiesRepositoryTests.cs
+++ b/API.Tests/RepositoriesTests/AcademiesRepositoryTests.cs
@@ -20,13 +20,13 @@ namespace API.Tests.RepositoriesTests
         private readonly Mock<IAuthenticatedHttpClient> _mockClient;
         private readonly Mock<IOdataUrlBuilder<GetAcademiesD365Model>> _mockUrlBuilder;
         private readonly AcademiesDynamicsRepository _subject;
-        private readonly Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>> _365AcademiesMapper;
+        private readonly Mock<IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>> _365AcademiesMapper;
 
         public AcademiesRepositoryTests()
         {
             _mockClient = new Mock<IAuthenticatedHttpClient>();
             _mockUrlBuilder = new Mock<IOdataUrlBuilder<GetAcademiesD365Model>>();
-            _365AcademiesMapper = new Mock<IMapper<GetAcademiesD365Model, GetAcademiesModel>>();
+            _365AcademiesMapper = new Mock<IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>>();
             var mockedLogger = new Mock<ILogger<AcademiesDynamicsRepository>>();
             _subject = new AcademiesDynamicsRepository(_mockClient.Object, _mockUrlBuilder.Object, mockedLogger.Object,
                 _365AcademiesMapper.Object);

--- a/API.Tests/RepositoriesTests/TrustsRepositoryTests.cs
+++ b/API.Tests/RepositoriesTests/TrustsRepositoryTests.cs
@@ -20,13 +20,13 @@ namespace API.Tests.RepositoriesTests
         private readonly TrustsDynamicsRepository _subject;
         private readonly Mock<IOdataUrlBuilder<GetTrustsD365Model>> _mockUrlBuilder;
         private readonly Mock<IAuthenticatedHttpClient> _mockClient;
-        private readonly Mock<IMapper<GetTrustsD365Model, GetTrustsModel>> _getTrustMapper;
+        private readonly Mock<IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>> _getTrustMapper;
 
         public TrustsRepositoryTests()
         {
             _mockClient = new Mock<IAuthenticatedHttpClient>();
             _mockUrlBuilder = new Mock<IOdataUrlBuilder<GetTrustsD365Model>>();
-            _getTrustMapper = new Mock<IMapper<GetTrustsD365Model, GetTrustsModel>>();
+            _getTrustMapper = new Mock<IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>>();
             var mockedLogger = new Mock<ILogger<TrustsDynamicsRepository>>();
             var mockSanitizer = new Mock<IODataSanitizer>();
 

--- a/Data.Mock/MockTrustsRepository.cs
+++ b/Data.Mock/MockTrustsRepository.cs
@@ -1,0 +1,7 @@
+namespace Data.Mock
+{
+    public class MockTrustsRepository
+    {
+        
+    }
+}

--- a/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
+++ b/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS.Tests.TestFixtures
+{
+    public class TrustSearchResults
+    {
+        
+    }
+}

--- a/Data.TRAMS.Tests/TestFixtures/Trusts.cs
+++ b/Data.TRAMS.Tests/TestFixtures/Trusts.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS.Tests.TestFixtures
+{
+    public class Trusts
+    {
+        
+    }
+}

--- a/Data.TRAMS/ITramsHttpClient.cs
+++ b/Data.TRAMS/ITramsHttpClient.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Data.TRAMS.Tests
+{
+    public interface ITramsHttpClient
+    {
+        public Task<string>
+    }
+}

--- a/Data.TRAMS/TramsAcademiesRepository.cs
+++ b/Data.TRAMS/TramsAcademiesRepository.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS
+{
+    public class TramsAcademiesRepository
+    {
+        
+    }
+}

--- a/Data.TRAMS/TramsHttpClient.cs
+++ b/Data.TRAMS/TramsHttpClient.cs
@@ -1,0 +1,7 @@
+namespace Data.TRAMS
+{
+    public class TramsHttpClient
+    {
+        
+    }
+}

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Data.Mock\Data.Mock.csproj" />
+    <ProjectReference Include="..\Data.TRAMS\Data.TRAMS.csproj" />
     <ProjectReference Include="..\Data\Data.csproj" />
     <ProjectReference Include="..\DocumentGeneration\DocumentGeneration.csproj" />
     <ProjectReference Include="..\TRAMS-API\API.csproj" />
@@ -27,8 +28,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="App_Code" />
   </ItemGroup>
 </Project>

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -11,7 +11,7 @@ using API.Repositories;
 using API.Repositories.Interfaces;
 using Data;
 using Data.Mock;
-using DocumentGeneration;
+using Data.TRAMS;
 using Frontend.Services;
 using Frontend.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -58,10 +58,10 @@ namespace Frontend
 
             services.AddSingleton(CreateHttpClient());
             services.AddSingleton<IAuthenticatedHttpClient>(r => CreateHttpClient());
-            services.AddTransient<IMapper<GetTrustsD365Model, GetTrustsModel>, GetTrustsReponseMapper>();
+
 
             ConfigureDynamicsRepositories(services);
-            ConfigureRepositories(services);
+            ConfigureRepositories(services, Configuration);
             ConfigureHelpers(services);
             ConfigureMappers(services);
             ConfigureServiceClasses(services);
@@ -120,39 +120,52 @@ namespace Frontend
             services.AddTransient<IProjectsRepository, ProjectsDynamicsRepository>();
         }
 
-        private static void ConfigureRepositories(IServiceCollection services)
+        private static void ConfigureRepositories(IServiceCollection services, IConfiguration configuration)
         {
-            services.AddTransient<IAcademies, MockAcademyRepository>();
+            var tramsApiBase = configuration["TRAMS_API_BASE"];
+            if (string.IsNullOrEmpty(tramsApiBase))
+            {
+                services.AddTransient<IAcademies, MockAcademyRepository>();
+                services.AddTransient<ITrusts, MockTrustsRepository>();
+            }
+            else
+            {
+                services.AddHttpClient("trams",
+                    client => { client.BaseAddress = new Uri(tramsApiBase); });
+                services.AddHttpClient<ITrusts, TramsTrustsRepository>("trams");
+                services.AddHttpClient<IAcademies, TramsAcademiesRepository>("trams");
+            }
         }
 
         private static void ConfigureMappers(IServiceCollection services)
         {
-            services.AddTransient<IMapper<GetTrustsD365Model, GetTrustsModel>,
-                GetTrustsReponseMapper>();
+            services.AddTransient<IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>,
+                GetTrustsReponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<GetAcademiesD365Model, GetAcademiesModel>,
-                GetAcademiesResponseMapper>();
+            services.AddTransient<IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>,
+                GetAcademiesResponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>,
-                PutProjectAcademiesRequestMapper>();
+            services.AddTransient<IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>,
+                PutProjectAcademiesRequestDynamicsMapper>();
 
-            services.AddTransient<IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>,
-                PostProjectAcademiesRequestMapper>();
+            services
+                .AddTransient<IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>,
+                    PostProjectAcademiesRequestDynamicsMapper>();
 
-            services.AddTransient<IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>,
-                PostProjectsRequestMapper>();
+            services.AddTransient<IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>,
+                PostProjectsRequestDynamicsMapper>();
 
-            services.AddTransient<IMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>,
-                GetProjectAcademiesResponseMapper>();
+            services.AddTransient<IDynamicsMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>,
+                GetProjectAcademiesResponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<GetProjectsD365Model, GetProjectsResponseModel>,
-                GetProjectsResponseMapper>();
+            services.AddTransient<IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel>,
+                GetProjectsResponseDynamicsMapper>();
 
-            services.AddTransient<IMapper<SearchProjectsD365Model, SearchProjectsModel>,
-                SearchProjectsItemMapper>();
+            services.AddTransient<IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel>,
+                SearchProjectsItemDynamicsMapper>();
 
-            services.AddTransient<IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>,
-                SearchProjectsPageResponseMapper>();
+            services.AddTransient<IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>,
+                SearchProjectsPageResponseDynamicsMapper>();
         }
 
         private static void ConfigureHelpers(IServiceCollection services)

--- a/TRAMS-API/Mapping/IDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/IDynamicsMapper.cs
@@ -1,6 +1,6 @@
 ﻿namespace API.Mapping
 {
-    public interface IMapper<T, V>
+    public interface IDynamicsMapper<T, V>
     {
         V Map(T input);
     }

--- a/TRAMS-API/Mapping/Request/PostProjectAcademiesRequestDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Request/PostProjectAcademiesRequestDynamicsMapper.cs
@@ -5,11 +5,11 @@ using System.Linq;
 
 namespace API.Mapping.Request
 {
-    public class PutProjectAcademiesRequestMapper : IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
+    public class PostProjectAcademiesRequestDynamicsMapper : IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>
     {
-        public PatchProjectAcademiesD365Model Map(PutProjectAcademiesRequestModel input)
+        public PostAcademyTransfersProjectAcademyD365Model Map(PostProjectsAcademiesModel input)
         {
-            return new PatchProjectAcademiesD365Model
+            return new PostAcademyTransfersProjectAcademyD365Model
             {
                 AcademyId = $"/accounts({input.AcademyId})",
                 EsfaInterventionReasons = input.EsfaInterventionReasons != null && input.EsfaInterventionReasons.Any()
@@ -21,7 +21,11 @@ namespace API.Mapping.Request
                                               ? input.RddOrRscInterventionReasons.Select(r => ((int)MappingDictionaries.RddOrRscInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                  .ToDelimitedString()
                                               : null,
-                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained
+                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained,
+                Trusts = input.Trusts != null
+                         ? input.Trusts.Select(t => new PostAcademyTransfersProjectAcademyTrustD365Model { TrustId = $"/accounts({t.TrustId})" })
+                                       .ToList()
+                         : new List<PostAcademyTransfersProjectAcademyTrustD365Model>()
             };
         }
     }

--- a/TRAMS-API/Mapping/Request/PostProjectsRequestDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Request/PostProjectsRequestDynamicsMapper.cs
@@ -5,13 +5,13 @@ using System.Linq;
 
 namespace API.Mapping.Request
 {
-    public class PostProjectsRequestMapper : IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>
+    public class PostProjectsRequestDynamicsMapper : IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model>
     {
-        private readonly IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> _projectAcademiesMapper;
+        private readonly IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> _projectAcademiesDynamicsMapper;
 
-        public PostProjectsRequestMapper(IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> projectAcademiesMapper)
+        public PostProjectsRequestDynamicsMapper(IDynamicsMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model> projectAcademiesDynamicsMapper)
         {
-            _projectAcademiesMapper = projectAcademiesMapper;
+            _projectAcademiesDynamicsMapper = projectAcademiesDynamicsMapper;
         }
 
         public PostAcademyTransfersProjectsD365Model Map(PostProjectsRequestModel input)
@@ -21,7 +21,7 @@ namespace API.Mapping.Request
                 return null;
             }
 
-            var academies = input.ProjectAcademies?.Select(p => _projectAcademiesMapper.Map(p)).ToList();
+            var academies = input.ProjectAcademies?.Select(p => _projectAcademiesDynamicsMapper.Map(p)).ToList();
 
 
             var output = new PostAcademyTransfersProjectsD365Model

--- a/TRAMS-API/Mapping/Request/PutProjectAcademiesRequestDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Request/PutProjectAcademiesRequestDynamicsMapper.cs
@@ -5,11 +5,11 @@ using System.Linq;
 
 namespace API.Mapping.Request
 {
-    public class PostProjectAcademiesRequestMapper : IMapper<PostProjectsAcademiesModel, PostAcademyTransfersProjectAcademyD365Model>
+    public class PutProjectAcademiesRequestDynamicsMapper : IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
     {
-        public PostAcademyTransfersProjectAcademyD365Model Map(PostProjectsAcademiesModel input)
+        public PatchProjectAcademiesD365Model Map(PutProjectAcademiesRequestModel input)
         {
-            return new PostAcademyTransfersProjectAcademyD365Model
+            return new PatchProjectAcademiesD365Model
             {
                 AcademyId = $"/accounts({input.AcademyId})",
                 EsfaInterventionReasons = input.EsfaInterventionReasons != null && input.EsfaInterventionReasons.Any()
@@ -21,11 +21,7 @@ namespace API.Mapping.Request
                                               ? input.RddOrRscInterventionReasons.Select(r => ((int)MappingDictionaries.RddOrRscInterventionReasonEnumMap.GetValueOrDefault(r)).ToString())
                                                                                  .ToDelimitedString()
                                               : null,
-                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained,
-                Trusts = input.Trusts != null
-                         ? input.Trusts.Select(t => new PostAcademyTransfersProjectAcademyTrustD365Model { TrustId = $"/accounts({t.TrustId})" })
-                                       .ToList()
-                         : new List<PostAcademyTransfersProjectAcademyTrustD365Model>()
+                RddOrRscInterventionReasonsExplained = input.RddOrRscInterventionReasonsExplained
             };
         }
     }

--- a/TRAMS-API/Mapping/Response/GetAcademiesResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetAcademiesResponseDynamicsMapper.cs
@@ -3,11 +3,11 @@ using API.Models.Upstream.Response;
 
 namespace API.Mapping.Response
 {
-    public class GetAcademiesResponseMapper : IMapper<GetAcademiesD365Model, GetAcademiesModel>
+    public class GetAcademiesResponseDynamicsMapper : IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel>
     {
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetAcademiesResponseMapper(IEstablishmentNameFormatter establishmentNameFormatter)
+        public GetAcademiesResponseDynamicsMapper(IEstablishmentNameFormatter establishmentNameFormatter)
         {
             _establishmentNameFormatter = establishmentNameFormatter;
         }

--- a/TRAMS-API/Mapping/Response/GetProjectAcademiesResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetProjectAcademiesResponseDynamicsMapper.cs
@@ -7,12 +7,12 @@ using System.Linq;
 
 namespace API.Mapping.Response
 {
-    public class GetProjectAcademiesResponseMapper : IMapper<AcademyTransfersProjectAcademy,
+    public class GetProjectAcademiesResponseDynamicsMapper : IDynamicsMapper<AcademyTransfersProjectAcademy,
                                                              GetProjectsAcademyResponseModel>
     {
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetProjectAcademiesResponseMapper(IEstablishmentNameFormatter establishmentNameFormatter)
+        public GetProjectAcademiesResponseDynamicsMapper(IEstablishmentNameFormatter establishmentNameFormatter)
         {
             _establishmentNameFormatter = establishmentNameFormatter;
         }

--- a/TRAMS-API/Mapping/Response/GetProjectsResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetProjectsResponseDynamicsMapper.cs
@@ -6,17 +6,17 @@ using System.Linq;
 
 namespace API.Mapping.Response
 {
-    public class GetProjectsResponseMapper : IMapper<GetProjectsD365Model, GetProjectsResponseModel>
+    public class GetProjectsResponseDynamicsMapper : IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel>
     {
-        private readonly IMapper<AcademyTransfersProjectAcademy,
-                                 GetProjectsAcademyResponseModel> _academyMapper;
+        private readonly IDynamicsMapper<AcademyTransfersProjectAcademy,
+                                 GetProjectsAcademyResponseModel> _academyDynamicsMapper;
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetProjectsResponseMapper(IMapper<AcademyTransfersProjectAcademy,
-                                                 GetProjectsAcademyResponseModel> academyMapper,
+        public GetProjectsResponseDynamicsMapper(IDynamicsMapper<AcademyTransfersProjectAcademy,
+                                                 GetProjectsAcademyResponseModel> academyDynamicsMapper,
                                          IEstablishmentNameFormatter establishmentNameFormatter)
         {
-            _academyMapper = academyMapper;
+            _academyDynamicsMapper = academyDynamicsMapper;
             _establishmentNameFormatter = establishmentNameFormatter;
         }
 
@@ -71,7 +71,7 @@ namespace API.Mapping.Response
         {
             return input.Academies == null || input.Academies.Count == 0
                    ? new List<GetProjectsAcademyResponseModel>()
-                   : input.Academies?.Select(a => _academyMapper.Map(a))
+                   : input.Academies?.Select(a => _academyDynamicsMapper.Map(a))
                                      .ToList();
         }
     }

--- a/TRAMS-API/Mapping/Response/GetTrustsReponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/Response/GetTrustsReponseDynamicsMapper.cs
@@ -3,11 +3,11 @@ using API.Models.Upstream.Response;
 
 namespace API.Mapping.Response
 {
-    public class GetTrustsReponseMapper : IMapper<GetTrustsD365Model, GetTrustsModel>
+    public class GetTrustsReponseDynamicsMapper : IDynamicsMapper<GetTrustsD365Model, GetTrustsModel>
     {
         private readonly IEstablishmentNameFormatter _establishmentNameFormatter;
 
-        public GetTrustsReponseMapper(IEstablishmentNameFormatter establishmentNameFormatter)
+        public GetTrustsReponseDynamicsMapper(IEstablishmentNameFormatter establishmentNameFormatter)
         {
             _establishmentNameFormatter = establishmentNameFormatter;
         }

--- a/TRAMS-API/Mapping/SearchProjectsItemDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/SearchProjectsItemDynamicsMapper.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace API.Mapping
 {
-    public class SearchProjectsItemMapper : IMapper<SearchProjectsD365Model, SearchProjectsModel>
+    public class SearchProjectsItemDynamicsMapper : IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel>
     {
         public SearchProjectsModel Map(SearchProjectsD365Model input)
         {

--- a/TRAMS-API/Mapping/SearchProjectsPageResponseDynamicsMapper.cs
+++ b/TRAMS-API/Mapping/SearchProjectsPageResponseDynamicsMapper.cs
@@ -5,13 +5,13 @@ using System.Linq;
 
 namespace API.Mapping
 {
-    public class SearchProjectsPageResponseMapper : IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>
+    public class SearchProjectsPageResponseDynamicsMapper : IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel>
     {
-        private readonly IMapper<SearchProjectsD365Model, SearchProjectsModel> _itemMapper;
+        private readonly IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel> _itemDynamicsMapper;
 
-        public SearchProjectsPageResponseMapper(IMapper<SearchProjectsD365Model, SearchProjectsModel> itemMapper)
+        public SearchProjectsPageResponseDynamicsMapper(IDynamicsMapper<SearchProjectsD365Model, SearchProjectsModel> itemDynamicsMapper)
         {
-            _itemMapper = itemMapper;
+            _itemDynamicsMapper = itemDynamicsMapper;
         }
 
         public SearchProjectsPageModel Map(SearchProjectsD365PageModel input)
@@ -21,7 +21,7 @@ namespace API.Mapping
                 return null;
             }
 
-            var items = input.Projects?.Select(p => _itemMapper.Map(p))
+            var items = input.Projects?.Select(p => _itemDynamicsMapper.Map(p))
                                        .ToList();
 
             return new SearchProjectsPageModel

--- a/TRAMS-API/Repositories/AcademiesDynamicsRepository.cs
+++ b/TRAMS-API/Repositories/AcademiesDynamicsRepository.cs
@@ -19,17 +19,17 @@ namespace API.Repositories
         private readonly IAuthenticatedHttpClient _client;
         private readonly IOdataUrlBuilder<GetAcademiesD365Model> _urlBuilder;
         private readonly ILogger<AcademiesDynamicsRepository> _logger;
-        private readonly IMapper<GetAcademiesD365Model, GetAcademiesModel> _getAcademies365Mapper;
+        private readonly IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel> _getAcademies365DynamicsMapper;
 
         public AcademiesDynamicsRepository(IAuthenticatedHttpClient client,
             IOdataUrlBuilder<GetAcademiesD365Model> urlBuilder,
             ILogger<AcademiesDynamicsRepository> logger,
-            IMapper<GetAcademiesD365Model, GetAcademiesModel> getAcademies365Mapper)
+            IDynamicsMapper<GetAcademiesD365Model, GetAcademiesModel> getAcademies365DynamicsMapper)
         {
             _client = client;
             _urlBuilder = urlBuilder;
             _logger = logger;
-            _getAcademies365Mapper = getAcademies365Mapper;
+            _getAcademies365DynamicsMapper = getAcademies365DynamicsMapper;
         }
 
         public async Task<RepositoryResult<GetAcademiesModel>> GetAcademyById(Guid id)
@@ -54,7 +54,7 @@ namespace API.Repositories
                     return new RepositoryResult<GetAcademiesModel> {Result = null};
                 }
 
-                var mappedResult = _getAcademies365Mapper.Map(castedResult);
+                var mappedResult = _getAcademies365DynamicsMapper.Map(castedResult);
                 return new RepositoryResult<GetAcademiesModel> {Result = mappedResult};
             }
 
@@ -89,7 +89,7 @@ namespace API.Repositories
             if (response.IsSuccessStatusCode)
             {
                 var castedResults = JsonConvert.DeserializeObject<ResultSet<GetAcademiesD365Model>>(responseContent);
-                var mappedResults = castedResults.Items.Select(item => _getAcademies365Mapper.Map(item)).ToList();
+                var mappedResults = castedResults.Items.Select(item => _getAcademies365DynamicsMapper.Map(item)).ToList();
 
                 return new RepositoryResult<List<GetAcademiesModel>> {Result = mappedResults};
             }

--- a/TRAMS-API/Repositories/ProjectsDynamicsRepository.cs
+++ b/TRAMS-API/Repositories/ProjectsDynamicsRepository.cs
@@ -27,39 +27,39 @@ namespace API.Repositories
         private readonly ILogger<ProjectsDynamicsRepository> _logger;
         private readonly IOdataUrlBuilder<AcademyTransfersProjectAcademy> _projectAcademyUrlBuilder;
         private readonly IFetchXmlSanitizer _fetchXmlSanitizer;
-        private readonly IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> _postProjectsMapper;
+        private readonly IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> _postProjectsDynamicsMapper;
 
-        private readonly IMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>
-            _getProjectAcademyMapper;
+        private readonly IDynamicsMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel>
+            _getProjectAcademyDynamicsMapper;
 
-        private readonly IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
-            _putProjectAcademiesMapper;
+        private readonly IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model>
+            _putProjectAcademiesDynamicsMapper;
 
-        private readonly IMapper<GetProjectsD365Model, GetProjectsResponseModel> _getProjectsMapper;
+        private readonly IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel> _getProjectsDynamicsMapper;
 
-        private readonly IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> _searchProjectsMapper;
+        private readonly IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> _searchProjectsDynamicsMapper;
 
         public ProjectsDynamicsRepository(IAuthenticatedHttpClient client,
             IOdataUrlBuilder<GetProjectsD365Model> urlBuilder,
             IOdataUrlBuilder<AcademyTransfersProjectAcademy> projectAcademyUrlBuilder,
             IFetchXmlSanitizer fetchXmlSanitizer,
             ILogger<ProjectsDynamicsRepository> logger,
-            IMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> postProjectsMapper,
-            IMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel> getProjectAcademyMapper,
-            IMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model> putProjectAcademiesMapper,
-            IMapper<GetProjectsD365Model, GetProjectsResponseModel> getProjectsMapper,
-            IMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> searchProjectsMapper)
+            IDynamicsMapper<PostProjectsRequestModel, PostAcademyTransfersProjectsD365Model> postProjectsDynamicsMapper,
+            IDynamicsMapper<AcademyTransfersProjectAcademy, GetProjectsAcademyResponseModel> getProjectAcademyDynamicsMapper,
+            IDynamicsMapper<PutProjectAcademiesRequestModel, PatchProjectAcademiesD365Model> putProjectAcademiesDynamicsMapper,
+            IDynamicsMapper<GetProjectsD365Model, GetProjectsResponseModel> getProjectsDynamicsMapper,
+            IDynamicsMapper<SearchProjectsD365PageModel, SearchProjectsPageModel> searchProjectsDynamicsMapper)
         {
             _client = client;
             _urlBuilder = urlBuilder;
             _projectAcademyUrlBuilder = projectAcademyUrlBuilder;
             _fetchXmlSanitizer = fetchXmlSanitizer;
             _logger = logger;
-            _postProjectsMapper = postProjectsMapper;
-            _getProjectAcademyMapper = getProjectAcademyMapper;
-            _putProjectAcademiesMapper = putProjectAcademiesMapper;
-            _getProjectsMapper = getProjectsMapper;
-            _searchProjectsMapper = searchProjectsMapper;
+            _postProjectsDynamicsMapper = postProjectsDynamicsMapper;
+            _getProjectAcademyDynamicsMapper = getProjectAcademyDynamicsMapper;
+            _putProjectAcademiesDynamicsMapper = putProjectAcademiesDynamicsMapper;
+            _getProjectsDynamicsMapper = getProjectsDynamicsMapper;
+            _searchProjectsDynamicsMapper = searchProjectsDynamicsMapper;
         }
 
         public async Task<RepositoryResult<SearchProjectsPageModel>> SearchProject(string search,
@@ -119,7 +119,7 @@ namespace API.Repositories
                     Projects = pageResults
                 };
 
-                var mappedPageResult = _searchProjectsMapper.Map(pageResult);
+                var mappedPageResult = _searchProjectsDynamicsMapper.Map(pageResult);
                 return new RepositoryResult<SearchProjectsPageModel> {Result = mappedPageResult};
             }
 
@@ -152,7 +152,7 @@ namespace API.Repositories
             if (response.IsSuccessStatusCode)
             {
                 var castedResults = JsonConvert.DeserializeObject<AcademyTransfersProjectAcademy>(responseContent);
-                var mappedResults = _getProjectAcademyMapper.Map(castedResults);
+                var mappedResults = _getProjectAcademyDynamicsMapper.Map(castedResults);
 
                 return new RepositoryResult<GetProjectsAcademyResponseModel> {Result = mappedResults};
             }
@@ -187,7 +187,7 @@ namespace API.Repositories
             {
                 var castedResults = JsonConvert.DeserializeObject<GetProjectsD365Model>(responseContent);
 
-                return new RepositoryResult<GetProjectsResponseModel> {Result = _getProjectsMapper.Map(castedResults)};
+                return new RepositoryResult<GetProjectsResponseModel> {Result = _getProjectsDynamicsMapper.Map(castedResults)};
             }
 
             //At this point, log the error and configure the repository result to inform the caller that the repo failed
@@ -205,7 +205,7 @@ namespace API.Repositories
 
         public async Task<RepositoryResult<Guid?>> InsertProject(PostProjectsRequestModel project)
         {
-            var mappedProject = _postProjectsMapper.Map(project);
+            var mappedProject = _postProjectsDynamicsMapper.Map(project);
             var jsonBody = JsonConvert.SerializeObject(mappedProject);
 
             var buffer = System.Text.Encoding.UTF8.GetBytes(jsonBody);
@@ -245,7 +245,7 @@ namespace API.Repositories
         public async Task<RepositoryResult<Guid?>> UpdateProjectAcademy(Guid id, PutProjectAcademiesRequestModel model)
         {
             var url = _projectAcademyUrlBuilder.BuildRetrieveOneUrl("sip_academytransfersprojectacademies", id);
-            var mappedModel = _putProjectAcademiesMapper.Map(model);
+            var mappedModel = _putProjectAcademiesDynamicsMapper.Map(model);
             var jsonContent = JsonConvert.SerializeObject(mappedModel);
             var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 

--- a/TRAMS-API/Repositories/TrustsDynamicsRepository.cs
+++ b/TRAMS-API/Repositories/TrustsDynamicsRepository.cs
@@ -22,18 +22,18 @@ namespace API.Repositories
         private readonly IAuthenticatedHttpClient _client;
         private readonly IODataSanitizer _oDataSanitizer;
         private readonly ILogger<TrustsDynamicsRepository> _logger;
-        private readonly IMapper<GetTrustsD365Model, GetTrustsModel> _getTrustMapper;
+        private readonly IDynamicsMapper<GetTrustsD365Model, GetTrustsModel> _getTrustDynamicsMapper;
 
         public TrustsDynamicsRepository(IAuthenticatedHttpClient client,
             IOdataUrlBuilder<GetTrustsD365Model> urlBuilder,
             IODataSanitizer oDataSanitizer,
-            ILogger<TrustsDynamicsRepository> logger, IMapper<GetTrustsD365Model, GetTrustsModel> getTrustMapper)
+            ILogger<TrustsDynamicsRepository> logger, IDynamicsMapper<GetTrustsD365Model, GetTrustsModel> getTrustDynamicsMapper)
         {
             _client = client;
             _urlBuilder = urlBuilder;
             _oDataSanitizer = oDataSanitizer;
             _logger = logger;
-            _getTrustMapper = getTrustMapper;
+            _getTrustDynamicsMapper = getTrustDynamicsMapper;
         }
 
         public async Task<RepositoryResult<GetTrustsModel>> GetTrustById(Guid id)
@@ -67,7 +67,7 @@ namespace API.Repositories
                     return new RepositoryResult<GetTrustsModel> {Result = null};
                 }
 
-                var mappedResult = _getTrustMapper.Map(castedResult);
+                var mappedResult = _getTrustDynamicsMapper.Map(castedResult);
                 return new RepositoryResult<GetTrustsModel> {Result = mappedResult};
             }
 
@@ -98,7 +98,7 @@ namespace API.Repositories
             if (response.IsSuccessStatusCode)
             {
                 var castedResults = JsonConvert.DeserializeObject<ResultSet<GetTrustsD365Model>>(responseContent);
-                var mappedResults = castedResults.Items.Select(r => _getTrustMapper.Map(r)).ToList();
+                var mappedResults = castedResults.Items.Select(r => _getTrustDynamicsMapper.Map(r)).ToList();
 
                 return new RepositoryResult<List<GetTrustsModel>> {Result = mappedResults};
             }


### PR DESCRIPTION
### Context

To prepare for the TRAMS Api, this renames the existing mappers to DynamicsMappers, to differentiate between those and the new TRAMS API Mappers

### Changes proposed in this pull request

- Rename dynamics mappers

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

