### PR TITLE
Migrate dynamics project creation to shared interface

### DIFF
--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -9,6 +9,7 @@ using API.Models.Upstream.Response;
 using API.ODataHelpers;
 using API.Repositories;
 using API.Repositories.Interfaces;
+using API.Wrappers;
 using Data;
 using Data.Mock;
 using Data.Models;
@@ -63,8 +64,15 @@ namespace Frontend
             services.AddSingleton<IAuthenticatedHttpClient>(r => CreateHttpClient());
 
 
-            ConfigureDynamicsRepositories(services);
-            ConfigureRepositories(services, Configuration);
+            if (string.IsNullOrEmpty(Configuration["USE_TRAMS_REPOSITORIES"]))
+            {
+                ConfigureDynamicsRepositories(services);
+            }
+            else
+            {
+                ConfigureTramsRepositories(services, Configuration);
+            }
+
             ConfigureHelpers(services);
             ConfigureMappers(services);
             ConfigureServiceClasses(services);
@@ -118,12 +126,15 @@ namespace Frontend
 
         private static void ConfigureDynamicsRepositories(IServiceCollection services)
         {
+            services.AddTransient<IProjects, DynamicsProjectWrapper>();
+            services.AddTransient<IAcademies, MockAcademyRepository>();
+            services.AddTransient<ITrusts, MockTrustsRepository>();
             services.AddTransient<ITrustsRepository, TrustsDynamicsRepository>();
             services.AddTransient<IAcademiesRepository, AcademiesDynamicsRepository>();
             services.AddTransient<IProjectsRepository, ProjectsDynamicsRepository>();
         }
 
-        private static void ConfigureRepositories(IServiceCollection services, IConfiguration configuration)
+        private static void ConfigureTramsRepositories(IServiceCollection services, IConfiguration configuration)
         {
             var tramsApiBase = configuration["TRAMS_API_BASE"];
             var tramsApiKey = configuration["TRAMS_API_KEY"];

--- a/TRAMS-API/Wrappers/DynamicsProjectWrapper.cs
+++ b/TRAMS-API/Wrappers/DynamicsProjectWrapper.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Models.Upstream.Enums;
+using API.Models.Upstream.Request;
+using API.Models.Upstream.Response;
+using API.Repositories.Interfaces;
+using Data;
+using Data.Models;
+using Data.Models.Projects;
+
+namespace API.Wrappers
+{
+    public class DynamicsProjectWrapper : IProjects
+    {
+        private readonly IProjectsRepository _projectsRepository;
+
+        public DynamicsProjectWrapper(IProjectsRepository projectsRepository)
+        {
+            _projectsRepository = projectsRepository;
+        }
+
+        public async Task<RepositoryResult<Project>> GetByUrn(string urn)
+        {
+            var guid = Guid.Parse(urn);
+
+            var result = await _projectsRepository.GetProjectById(guid);
+            var project = result.Result;
+
+            return new RepositoryResult<Project>
+            {
+                Result = MapDynamicsProject(project)
+            };
+        }
+
+        private static Project MapDynamicsProject(GetProjectsResponseModel project)
+        {
+            return new Project
+            {
+                Urn = project.ProjectId.ToString(),
+                Features = new TransferFeatures(),
+                OutgoingTrustUkprn = project.ProjectTrusts[1].TrustId.ToString(),
+                TransferringAcademies = new List<TransferringAcademies>
+                {
+                    new TransferringAcademies
+                    {
+                        OutgoingAcademyUkprn = project.ProjectAcademies[0].AcademyId.ToString(),
+                        IncomingTrustUkprn = project.ProjectTrusts[0].TrustId.ToString()
+                    }
+                }
+            };
+        }
+
+        public Task<RepositoryResult<Project>> Update(Project project)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<RepositoryResult<Project>> Create(Project project)
+        {
+            var dynamicsProject = ConvertProjectToDynamicsProject(project);
+            var result = await _projectsRepository.InsertProject(dynamicsProject);
+
+            if (result.Result == null)
+            {
+                return new RepositoryResult<Project>
+                {
+                    Error = result.Error
+                };
+            }
+
+            project.Urn = result.Result.Value.ToString();
+            return new RepositoryResult<Project>
+            {
+                Result = project
+            };
+        }
+
+        private static PostProjectsRequestModel ConvertProjectToDynamicsProject(Project project)
+        {
+            var academies = project.TransferringAcademies.Select(projectAcademy => new PostProjectsAcademiesModel
+            {
+                AcademyId = Guid.Parse(projectAcademy.OutgoingAcademyUkprn),
+                Trusts = new List<PostProjectsAcademiesTrustsModel>
+                {
+                    new PostProjectsAcademiesTrustsModel {TrustId = Guid.Parse(project.OutgoingTrustUkprn)}
+                }
+            }).ToList();
+
+            var dynamicsProject = new PostProjectsRequestModel
+            {
+                ProjectInitiatorFullName = "academy",
+                ProjectInitiatorUid = Guid.NewGuid().ToString(),
+                ProjectAcademies = academies,
+                ProjectStatus = ProjectStatusEnum.InProgress,
+                ProjectTrusts = new List<PostProjectsTrustsModel>
+                {
+                    new PostProjectsTrustsModel
+                        {TrustId = Guid.Parse(project.TransferringAcademies[0].IncomingTrustUkprn)},
+                    new PostProjectsTrustsModel {TrustId = Guid.Parse(project.OutgoingTrustUkprn)}
+                }
+            };
+            return dynamicsProject;
+        }
+    }
+}


### PR DESCRIPTION
### Context

We're migrating over to the planned TRAMS API - this moves the controller away from depending on the dynamics specific project interface, and to the new shared interface.

Additionally, as a result, there is some temporary code to map between ProjectId GUIDs (Dynamics) to Project URNs, and the relevant resources.

Once we've migrated, this code will be deleted, and as such has no tests.

### Changes proposed in this pull request

- Create DynaimcsProjectWrapper for wrapping project calls
- Migrate transfers controller

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

