### PR TITLE
Migrate project index to new interface

### DIFF
--- a/Data/Models/Project.cs
+++ b/Data/Models/Project.cs
@@ -6,7 +6,10 @@ namespace Data.Models
     public class Project
     {
         public string Urn { get; set; }
+        public string Name { get; set; }
         public string OutgoingTrustUkprn { get; set; }
+        public string OutgoingTrustName { get; set; }
+        
         public string State { get; set; }
         public string Status { get; set; }
         public List<TransferringAcademies> TransferringAcademies { get; set; }

--- a/Frontend.Tests/ControllerTests/ProjectControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/ProjectControllerTests.cs
@@ -4,6 +4,7 @@ using API.Models.Upstream.Response;
 using API.Repositories;
 using API.Repositories.Interfaces;
 using Data;
+using Data.Models;
 using Frontend.Controllers;
 using Moq;
 using Xunit;
@@ -13,11 +14,11 @@ namespace Frontend.Tests.ControllerTests
     public class ProjectControllerTests
     {
         private readonly ProjectController _subject;
-        private readonly Mock<IProjectsRepository> _projectsRepository;
+        private readonly Mock<IProjects> _projectsRepository;
 
         public ProjectControllerTests()
         {
-            _projectsRepository = new Mock<IProjectsRepository>();
+            _projectsRepository = new Mock<IProjects>();
             _subject = new ProjectController(_projectsRepository.Object);
         }
 
@@ -28,19 +29,13 @@ namespace Frontend.Tests.ControllerTests
             {
                 var projectId = Guid.NewGuid();
 
-                _projectsRepository.Setup(r => r.GetProjectById(projectId)).ReturnsAsync(
-                    new RepositoryResult<GetProjectsResponseModel>
+                _projectsRepository.Setup(r => r.GetByUrn(projectId.ToString())).ReturnsAsync(
+                    new RepositoryResult<Project>
                     {
-                        Result = new GetProjectsResponseModel
+                        Result = new Project
                         {
-                            ProjectName = "Some name",
-                            ProjectTrusts = new List<GetProjectsTrustResponseModel>
-                            {
-                                new GetProjectsTrustResponseModel
-                                {
-                                    TrustName = "Meow Meowington's Trust"
-                                }
-                            }
+                            Name = "Some name",
+                            OutgoingTrustName = "Meow Meowington's Trust"
                         }
                     });
 

--- a/Frontend/Controllers/ProjectController.cs
+++ b/Frontend/Controllers/ProjectController.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using API.Repositories.Interfaces;
+using Data;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,19 +10,19 @@ namespace Frontend.Controllers
     [Route("project/{id}")]
     public class ProjectController : Controller
     {
-        private readonly IProjectsRepository _projectsRepository;
+        private readonly IProjects _projectRepository;
 
-        public ProjectController(IProjectsRepository projectsRepository)
+        public ProjectController(IProjects projectRepository)
         {
-            _projectsRepository = projectsRepository;
+            _projectRepository = projectRepository;
         }
         
         public async Task<IActionResult> Index([FromRoute] Guid id)
         {
-            var project = await _projectsRepository.GetProjectById(id);
+            var project = await _projectRepository.GetByUrn(id.ToString());
             
-            ViewData["OutgoingTrustName"] = project.Result.ProjectTrusts[0].TrustName;
-            ViewData["ProjectName"] = project.Result.ProjectName;
+            ViewData["OutgoingTrustName"] = project.Result.OutgoingTrustName;
+            ViewData["ProjectName"] = project.Result.Name;
             ViewData["ProjectId"] = id;
             
             return View();

--- a/TRAMS-API/Wrappers/DynamicsProjectWrapper.cs
+++ b/TRAMS-API/Wrappers/DynamicsProjectWrapper.cs
@@ -39,7 +39,9 @@ namespace API.Wrappers
             return new Project
             {
                 Urn = project.ProjectId.ToString(),
+                Name = project.ProjectName,
                 Features = new TransferFeatures(),
+                OutgoingTrustName = project.ProjectTrusts[1].TrustName,
                 OutgoingTrustUkprn = project.ProjectTrusts[1].TrustId.ToString(),
                 TransferringAcademies = new List<TransferringAcademies>
                 {


### PR DESCRIPTION
### Context

In preparation for the new TRAMS API - We're migrating away from dynamics specific code within the `Frontend` repository, except for references to the `Wrapper` classes

### Changes proposed in this pull request

Migrate project index to the dynamics wrapper
Update project model with project name and trust information

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

