### PR TITLE
Migrate get trust academies

### DIFF
--- a/Data.Mock/MockAcademyRepository.cs
+++ b/Data.Mock/MockAcademyRepository.cs
@@ -47,7 +47,7 @@ namespace Data.Mock
                     AchievementOfPupils = "Placeholder",
                     BehaviourAndSafetyOfPupils = "Placeholder",
                     EarlyYearsProvision = "Placeholder",
-                    Effectiveness = "Placeholder",
+                    OverallEffectiveness = "Placeholder",
                     InspectionDate = "Placeholder",
                     LeadershipAndManagement = "Placeholder",
                     QualityOfTeaching = "Placeholder",

--- a/Data/Models/Academies/LatestOfstedJudgement.cs
+++ b/Data/Models/Academies/LatestOfstedJudgement.cs
@@ -6,7 +6,7 @@ namespace Data.Models.Academies
     {
         public string SchoolName { get; set; }
         public string InspectionDate { get; set; }
-        public string Effectiveness { get; set; }
+        public string OverallEffectiveness { get; set; }
         public string AchievementOfPupils { get; set; }
         public string QualityOfTeaching { get; set; }
         public string BehaviourAndSafetyOfPupils { get; set; }
@@ -19,7 +19,7 @@ namespace Data.Models.Academies
             {
                 new FormField {Title = "School name", Value = SchoolName},
                 new FormField {Title = "Ofsted inspection date", Value = InspectionDate},
-                new FormField {Title = "Overall effectiveness", Value = Effectiveness},
+                new FormField {Title = "Overall effectiveness", Value = OverallEffectiveness},
                 new FormField {Title = "Achievement of pupils", Value = AchievementOfPupils},
                 new FormField {Title = "Quality of teaching", Value = QualityOfTeaching},
                 new FormField {Title = "Behaviour and safety of pupils", Value = BehaviourAndSafetyOfPupils},

--- a/Data/Models/Academy.cs
+++ b/Data/Models/Academy.cs
@@ -6,8 +6,8 @@ namespace Data.Models
 {
     public class Academy
     {
-        public Guid DynamicsId { get; set; }
         public string Ukprn { get; set; }
+        public string Urn { get; set; }
         public string Name { get; set; }
         public AcademyPerformance Performance { get; set; }
         public PupilNumbers PupilNumbers { get; set; }

--- a/Data/Models/Academy.cs
+++ b/Data/Models/Academy.cs
@@ -9,6 +9,10 @@ namespace Data.Models
         public string Ukprn { get; set; }
         public string Urn { get; set; }
         public string Name { get; set; }
+        public string LocalAuthorityName { get; set; }
+        public string EstablishmentType { get; set; }
+        public string ReligiousCharacter { get; set; }
+        public string Pfi { get; set; }
         public AcademyPerformance Performance { get; set; }
         public PupilNumbers PupilNumbers { get; set; }
 

--- a/Data/Models/Trust.cs
+++ b/Data/Models/Trust.cs
@@ -10,5 +10,7 @@ namespace Data.Models
         public string EstablishmentType { get; set; }
         public string GiasGroupId { get; set; }
         public List<string> Address { get; set; }
+        
+        public List<Academy> Academies { get; set; }
     }
 }

--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -1,10 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
-using API.Models.Upstream.Response;
-using API.Repositories;
 using Data;
 using Data.Models;
 using Frontend.Controllers;
@@ -209,7 +206,7 @@ namespace Frontend.Tests.ControllerTests
             }
 
             [Fact]
-            public async void GivenGuid_LookupTrustFromAPIAndAssignToView()
+            public async void GivenId_LookupTrustFromAPIAndAssignToView()
             {
                 var response = await _subject.OutgoingTrustDetails(_trustId);
 
@@ -222,7 +219,7 @@ namespace Frontend.Tests.ControllerTests
             }
 
             [Fact]
-            public async void GivenGuidAndQuery_AssignQueryToTheView()
+            public async void GivenIdAndQuery_AssignQueryToTheView()
             {
                 await _subject.OutgoingTrustDetails(_trustId, "Trust name");
                 Assert.Equal("Trust name", _subject.ViewData["Query"]);
@@ -239,24 +236,24 @@ namespace Frontend.Tests.ControllerTests
         public class ConfirmOutgoingTrustTests : TransfersControllerTests
         {
             [Fact]
-            public void GivenTrustGuid_StoresTheTrustInTheSessionAndRedirects()
+            public void GivenTrustId_StoresTheTrustInTheSessionAndRedirects()
             {
-                var trustId = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
+                const string trustId = "9a7be920-eaa0-e911-a83f-000d3a3852af";
                 var response = _subject.ConfirmOutgoingTrust(trustId);
 
                 _session.Verify(s => s.Set(
                     "OutgoingTrustId",
                     It.Is<byte[]>(input =>
-                        Encoding.UTF8.GetString(input) == trustId.ToString()
+                        Encoding.UTF8.GetString(input) == trustId
                     )));
 
                 AssertRedirectToAction(response, "OutgoingTrustAcademies");
             }
 
             [Fact]
-            public void GivenTrustGuid_ClearExistingInformationInTheSession()
+            public void GivenTrustId_ClearExistingInformationInTheSession()
             {
-                var trustId = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
+                var trustId = "9a7be920-eaa0-e911-a83f-000d3a3852af";
                 _subject.ConfirmOutgoingTrust(trustId);
 
                 _session.Verify(s => s.Remove("IncomingTrustId"));
@@ -291,7 +288,7 @@ namespace Frontend.Tests.ControllerTests
             }
 
             [Fact]
-            public async void GivenTrustGuidInSession_FetchesTheAcademiesForThatTrust()
+            public async void GivenTrustIdInSession_FetchesTheAcademiesForThatTrust()
             {
                 var response = await _subject.OutgoingTrustAcademies();
                 var viewResponse = Assert.IsType<ViewResult>(response);
@@ -333,22 +330,22 @@ namespace Frontend.Tests.ControllerTests
             [Fact]
             public async void GivenOutgoingAcademiesExistInSession_PutsOutgoingAcademyIdIntoTheViewData()
             {
-                var outgoingAcademyId = Guid.NewGuid();
-                var outgoingAcademyIds = new List<Guid> {outgoingAcademyId};
+                const string outgoingAcademyId = "AcademyId";
+                var outgoingAcademyIds = new List<string> {outgoingAcademyId};
                 var outgoingAcademyIdsByteArray = Encoding.UTF8.GetBytes(string.Join(",", outgoingAcademyIds));
                 _session.Setup(s => s.TryGetValue("OutgoingAcademyIds", out outgoingAcademyIdsByteArray)).Returns(true);
 
                 var response = await _subject.OutgoingTrustAcademies();
                 var viewResponse = Assert.IsType<ViewResult>(response);
 
-                Assert.Equal(outgoingAcademyId.ToString(), viewResponse.ViewData["OutgoingAcademyId"]);
+                Assert.Equal(outgoingAcademyId, viewResponse.ViewData["OutgoingAcademyId"]);
             }
         }
 
         public class SubmitOutgoingTrustAcademiesTests : TransfersControllerTests
         {
             [Fact]
-            public void GivenAcademyGuid_StoresItInTheSessionAndRedirects()
+            public void GivenAcademyId_StoresItInTheSessionAndRedirects()
             {
                 var idOne = "9a7be920-eaa0-e911-a83f-000d3a3852af";
 
@@ -365,7 +362,7 @@ namespace Frontend.Tests.ControllerTests
             }
 
             [Fact]
-            public void GivenNoAcademyGuid_RedirectBackToOutgoingTrustAcademiesWithError()
+            public void GivenNoAcademyId_RedirectBackToOutgoingTrustAcademiesWithError()
             {
                 var result = _subject.SubmitOutgoingTrustAcademies(null);
 
@@ -526,7 +523,7 @@ namespace Frontend.Tests.ControllerTests
         public class IncomingTrustDetailsTests : TransfersControllerTests
         {
             [Fact]
-            public async void GivenGuid_LookupTrustFromAPIAndAssignToView()
+            public async void GivenId_LookupTrustFromAPIAndAssignToView()
             {
                 var trustId = "9a7be920-eaa0-e911-a83f-000d3a3855a3";
                 var foundTrust = new Trust
@@ -573,15 +570,15 @@ namespace Frontend.Tests.ControllerTests
         public class ConfirmIncomingTrustTests : TransfersControllerTests
         {
             [Fact]
-            public void GivenTrustGuid_StoresTheTrustInTheSessionAndRedirects()
+            public void GivenTrustId_StoresTheTrustInTheSessionAndRedirects()
             {
-                var trustId = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
+                const string trustId = "9a7be920-eaa0-e911-a83f-000d3a3852af";
                 var response = _subject.ConfirmIncomingTrust(trustId);
 
                 _session.Verify(s => s.Set(
                     "IncomingTrustId",
                     It.Is<byte[]>(input =>
-                        Encoding.UTF8.GetString(input) == trustId.ToString()
+                        Encoding.UTF8.GetString(input) == trustId
                     )));
                 AssertRedirectToAction(response, "CheckYourAnswers");
             }
@@ -607,7 +604,7 @@ namespace Frontend.Tests.ControllerTests
             {
                 _outgoingTrust = new Trust
                 {
-                    Ukprn = "9a7be920-eaa0-e911-a83f-000d3a3852af", Academies = new List<Academy>()
+                    Ukprn = "9a7be920-eaa0-e911-a83f-000d3a3852af", Academies = new List<Academy>
                     {
                         _academyOne, _academyTwo, _academyThree
                     }
@@ -676,27 +673,27 @@ namespace Frontend.Tests.ControllerTests
 
         public class SubmitProjectTests : TransfersControllerTests
         {
-            private readonly GetTrustsModel _outgoingTrust = new GetTrustsModel
-                {Id = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af")};
+            private readonly Trust _outgoingTrust = new Trust
+                {Ukprn = "9a7be920-eaa0-e911-a83f-000d3a3852af"};
 
-            private readonly GetTrustsModel _incomingTrust = new GetTrustsModel
-                {Id = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a385210")};
+            private readonly Trust _incomingTrust = new Trust
+                {Ukprn = "9a7be920-eaa0-e911-a83f-000d3a385210"};
 
-            private readonly GetAcademiesModel _academyOne = new GetAcademiesModel
-                {Id = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a385211")};
+            private readonly Academy _academyOne = new Academy
+                {Ukprn = "9a7be920-eaa0-e911-a83f-000d3a385211"};
 
-            private readonly GetAcademiesModel _academyTwo = new GetAcademiesModel
-                {Id = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a385212")};
+            private readonly Academy _academyTwo = new Academy
+                {Ukprn = "9a7be920-eaa0-e911-a83f-000d3a385212"};
 
             public SubmitProjectTests()
             {
-                var outgoingTrustIdByteArray = Encoding.UTF8.GetBytes(_outgoingTrust.Id.ToString());
+                var outgoingTrustIdByteArray = Encoding.UTF8.GetBytes(_outgoingTrust.Ukprn);
                 _session.Setup(s => s.TryGetValue("OutgoingTrustId", out outgoingTrustIdByteArray)).Returns(true);
 
-                var incomingTrustIdByteArray = Encoding.UTF8.GetBytes(_incomingTrust.Id.ToString());
+                var incomingTrustIdByteArray = Encoding.UTF8.GetBytes(_incomingTrust.Ukprn);
                 _session.Setup(s => s.TryGetValue("IncomingTrustId", out incomingTrustIdByteArray)).Returns(true);
 
-                var outgoingAcademyIds = new List<Guid> {_academyOne.Id, _academyTwo.Id};
+                var outgoingAcademyIds = new List<string> {_academyOne.Ukprn, _academyTwo.Ukprn};
                 var outgoingAcademyIdsByteArray = Encoding.UTF8.GetBytes(string.Join(",", outgoingAcademyIds));
                 _session.Setup(s => s.TryGetValue("OutgoingAcademyIds", out outgoingAcademyIdsByteArray)).Returns(true);
 
@@ -727,11 +724,11 @@ namespace Frontend.Tests.ControllerTests
 
                 _projectsRepository.Verify(
                     r => r.Create(It.Is<Project>(input =>
-                        input.TransferringAcademies[0].OutgoingAcademyUkprn == _academyOne.Id.ToString() &&
-                        input.TransferringAcademies[0].IncomingTrustUkprn == _incomingTrust.Id.ToString() &&
-                        input.TransferringAcademies[1].OutgoingAcademyUkprn == _academyTwo.Id.ToString() &&
-                        input.TransferringAcademies[1].IncomingTrustUkprn == _incomingTrust.Id.ToString() &&
-                        input.OutgoingTrustUkprn == _outgoingTrust.Id.ToString())),
+                        input.TransferringAcademies[0].OutgoingAcademyUkprn == _academyOne.Ukprn &&
+                        input.TransferringAcademies[0].IncomingTrustUkprn == _incomingTrust.Ukprn &&
+                        input.TransferringAcademies[1].OutgoingAcademyUkprn == _academyTwo.Ukprn &&
+                        input.TransferringAcademies[1].IncomingTrustUkprn == _incomingTrust.Ukprn &&
+                        input.OutgoingTrustUkprn == _outgoingTrust.Ukprn)),
                     Times.Once);
             }
 

--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -274,21 +274,23 @@ namespace Frontend.Tests.ControllerTests
 
             public OutgoingTrustAcademiesTests()
             {
-                var trustId = Guid.Parse("9a7be920-eaa0-e911-a83f-000d3a3852af");
-                var trustIdByteArray = Encoding.UTF8.GetBytes(trustId.ToString());
+                var trustId = "9a7be920-eaa0-e911-a83f-000d3a3852af";
+                var trustIdByteArray = Encoding.UTF8.GetBytes(trustId);
 
                 _session.Setup(s => s.TryGetValue("OutgoingTrustId", out trustIdByteArray)).Returns(true);
 
-                _academiesRepository.Setup(r => r.GetAcademiesByTrustId(trustId)).ReturnsAsync(
-                    new RepositoryResult<List<GetAcademiesModel>>
+                _trustsRepository.Setup(r => r.GetByUkprn(trustId)).ReturnsAsync(
+                    new RepositoryResult<Trust>
                     {
-                        Result = new List<GetAcademiesModel>
+                        Result = new Trust
                         {
-                            new GetAcademiesModel {AcademyName = AcademyName},
-                            new GetAcademiesModel {AcademyName = AcademyNameTwo},
+                            Academies = new List<Academy>
+                            {
+                                new Academy {Name = AcademyName},
+                                new Academy {Name = AcademyNameTwo}
+                            }
                         }
-                    }
-                );
+                    });
             }
 
             [Fact]
@@ -298,8 +300,8 @@ namespace Frontend.Tests.ControllerTests
                 var viewResponse = Assert.IsType<ViewResult>(response);
                 var viewModel = Assert.IsType<OutgoingTrustAcademies>(viewResponse.Model);
 
-                Assert.Equal(AcademyName, viewModel.Academies[0].AcademyName);
-                Assert.Equal(AcademyNameTwo, viewModel.Academies[1].AcademyName);
+                Assert.Equal(AcademyName, viewModel.Academies[0].Name);
+                Assert.Equal(AcademyNameTwo, viewModel.Academies[1].Name);
             }
 
             [Fact]
@@ -531,13 +533,13 @@ namespace Frontend.Tests.ControllerTests
             public async void GivenGuid_LookupTrustFromAPIAndAssignToView()
             {
                 var trustId = "9a7be920-eaa0-e911-a83f-000d3a3855a3";
-                var foundTrust = new Trust()
+                var foundTrust = new Trust
                 {
                     Ukprn = trustId,
                     Name = "Trust name"
                 };
 
-                _trustsRepository.Setup(r => r.GetByUkprn(trustId)).ReturnsAsync(new RepositoryResult<Trust>()
+                _trustsRepository.Setup(r => r.GetByUkprn(trustId)).ReturnsAsync(new RepositoryResult<Trust>
                 {
                     Result = foundTrust
                 });
@@ -556,13 +558,13 @@ namespace Frontend.Tests.ControllerTests
             public async void GivenChangeLink_SetChangeLinkInView()
             {
                 var trustId = "9a7be920-eaa0-e911-a83f-000d3a3855a3";
-                var foundTrust = new Trust()
+                var foundTrust = new Trust
                 {
                     Ukprn = trustId,
                     Name = "Trust name"
                 };
 
-                _trustsRepository.Setup(r => r.GetByUkprn(trustId)).ReturnsAsync(new RepositoryResult<Trust>()
+                _trustsRepository.Setup(r => r.GetByUkprn(trustId)).ReturnsAsync(new RepositoryResult<Trust>
                 {
                     Result = foundTrust
                 });

--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -21,7 +21,6 @@ namespace Frontend.Tests.ControllerTests
 {
     public class TransfersControllerTests
     {
-        private readonly Mock<IAcademiesRepository> _academiesRepository;
         private readonly Mock<IProjects> _projectsRepository;
         private readonly Mock<ITrusts> _trustsRepository;
 
@@ -30,7 +29,6 @@ namespace Frontend.Tests.ControllerTests
 
         public TransfersControllerTests()
         {
-            _academiesRepository = new Mock<IAcademiesRepository>();
             _projectsRepository = new Mock<IProjects>();
             _trustsRepository = new Mock<ITrusts>();
             _session = new Mock<ISession>();
@@ -44,8 +42,7 @@ namespace Frontend.Tests.ControllerTests
                 new TempDataDictionaryFactory(tempDataProvider.Object);
             var tempData = tempDataDictionaryFactory.GetTempData(httpContext);
 
-            _subject = new TransfersController(_academiesRepository.Object,
-                _projectsRepository.Object,
+            _subject = new TransfersController(_projectsRepository.Object,
                 _trustsRepository.Object
             ) {TempData = tempData, ControllerContext = {HttpContext = httpContext}};
         }

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -118,9 +118,9 @@ namespace Frontend.Controllers
             return View(model);
         }
 
-        public IActionResult SubmitOutgoingTrustAcademies(Guid? academyId, bool change = false)
+        public IActionResult SubmitOutgoingTrustAcademies(string academyId, bool change = false)
         {
-            if (!academyId.HasValue)
+            if (string.IsNullOrEmpty(academyId))
             {
                 TempData["ErrorMessage"] = "Please select an academy";
                 return RedirectToAction("OutgoingTrustAcademies");
@@ -207,8 +207,7 @@ namespace Frontend.Controllers
         {
             var outgoingTrustId = HttpContext.Session.GetString(OutgoingTrustIdSessionKey);
             Trust incomingTrust = null;
-            var academyIds = Session.GetStringListFromSession(HttpContext.Session, OutgoingAcademyIdSessionKey)
-                .Select(Guid.Parse);
+            var academyIds = Session.GetStringListFromSession(HttpContext.Session, OutgoingAcademyIdSessionKey);
 
             var outgoingTrustResponse = await _trustsRepository.GetByUkprn(outgoingTrustId);
 
@@ -220,9 +219,8 @@ namespace Frontend.Controllers
                 incomingTrust = incomingTrustResponse.Result;
             }
 
-            var academiesForTrust =
-                await _dynamicsAcademiesRepository.GetAcademiesByTrustId(Guid.Parse(outgoingTrustId));
-            var selectedAcademies = academiesForTrust.Result.Where(academy => academyIds.Contains(academy.Id)).ToList();
+            var selectedAcademies = outgoingTrustResponse.Result.Academies
+                .Where(academy => academyIds.Contains(academy.Ukprn)).ToList();
 
             var model = new CheckYourAnswers
             {

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using API.Models.Upstream.Response;
 using API.Repositories;
 using Data;
 using Data.Models;
@@ -95,10 +94,9 @@ namespace Frontend.Controllers
 
         public async Task<IActionResult> OutgoingTrustAcademies(bool change = false)
         {
-            var sessionGuid = HttpContext.Session.GetString(OutgoingTrustIdSessionKey);
             var sessionAcademyIds = HttpContext.Session.GetString(OutgoingAcademyIdSessionKey);
-            var outgoingTrustId = Guid.Parse(sessionGuid);
-            ViewData["OutgoingTrustId"] = outgoingTrustId.ToString();
+            var outgoingTrustId = HttpContext.Session.GetString(OutgoingTrustIdSessionKey);
+            ViewData["OutgoingTrustId"] = outgoingTrustId;
             ViewData["ChangeLink"] = change;
             ViewData["OutgoingAcademyId"] = null;
 
@@ -108,9 +106,8 @@ namespace Frontend.Controllers
                 ViewData["OutgoingAcademyId"] = academyId;
             }
 
-            var academiesRepoResult = await _dynamicsAcademiesRepository.GetAcademiesByTrustId(outgoingTrustId);
-            var academies = academiesRepoResult.Result;
-            var model = new OutgoingTrustAcademies {Academies = academies};
+            var trustRepoResult = await _trustsRepository.GetByUkprn(outgoingTrustId);
+            var model = new OutgoingTrustAcademies {Academies = trustRepoResult.Result.Academies};
 
             ViewData["Error.Exists"] = false;
             if (TempData.Peek("ErrorMessage") == null) return View(model);

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using API.Repositories;
 using Data;
 using Data.Models;
 using Data.Models.Projects;
@@ -19,14 +18,11 @@ namespace Frontend.Controllers
         private const string OutgoingAcademyIdSessionKey = "OutgoingAcademyIds";
         private const string IncomingTrustIdSessionKey = "IncomingTrustId";
         private const string OutgoingTrustIdSessionKey = "OutgoingTrustId";
-        private readonly IAcademiesRepository _dynamicsAcademiesRepository;
         private readonly IProjects _projectsRepository;
         private readonly ITrusts _trustsRepository;
 
-        public TransfersController(IAcademiesRepository dynamicsAcademiesRepository,
-            IProjects projectsRepository, ITrusts trustsRepository)
+        public TransfersController(IProjects projectsRepository, ITrusts trustsRepository)
         {
-            _dynamicsAcademiesRepository = dynamicsAcademiesRepository;
             _projectsRepository = projectsRepository;
             _trustsRepository = trustsRepository;
         }

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Data;
@@ -79,9 +78,9 @@ namespace Frontend.Controllers
             return View(model);
         }
 
-        public IActionResult ConfirmOutgoingTrust(Guid trustId)
+        public IActionResult ConfirmOutgoingTrust(string trustId)
         {
-            HttpContext.Session.SetString(OutgoingTrustIdSessionKey, trustId.ToString());
+            HttpContext.Session.SetString(OutgoingTrustIdSessionKey, trustId);
             HttpContext.Session.Remove(IncomingTrustIdSessionKey);
             HttpContext.Session.Remove(OutgoingAcademyIdSessionKey);
 
@@ -192,9 +191,9 @@ namespace Frontend.Controllers
             return View(model);
         }
 
-        public IActionResult ConfirmIncomingTrust(Guid trustId)
+        public IActionResult ConfirmIncomingTrust(string trustId)
         {
-            HttpContext.Session.SetString(IncomingTrustIdSessionKey, trustId.ToString());
+            HttpContext.Session.SetString(IncomingTrustIdSessionKey, trustId);
 
             return RedirectToAction("CheckYourAnswers");
         }
@@ -230,18 +229,18 @@ namespace Frontend.Controllers
 
         public async Task<IActionResult> SubmitProject()
         {
-            var outgoingTrustId = Guid.Parse(HttpContext.Session.GetString(OutgoingTrustIdSessionKey));
-            var incomingTrustId = Guid.Parse(HttpContext.Session.GetString(IncomingTrustIdSessionKey));
-            var academyIds = Session.GetStringListFromSession(HttpContext.Session, OutgoingAcademyIdSessionKey)
-                .Select(Guid.Parse).ToList();
+            var outgoingTrustId = HttpContext.Session.GetString(OutgoingTrustIdSessionKey);
+            var incomingTrustId = HttpContext.Session.GetString(IncomingTrustIdSessionKey);
+            var academyIds = Session.GetStringListFromSession(HttpContext.Session, OutgoingAcademyIdSessionKey);
+                
 
             var project = new Project
             {
-                OutgoingTrustUkprn = outgoingTrustId.ToString(),
-                TransferringAcademies = academyIds.Select(id => new TransferringAcademies()
+                OutgoingTrustUkprn = outgoingTrustId,
+                TransferringAcademies = academyIds.Select(id => new TransferringAcademies
                 {
                     OutgoingAcademyUkprn = id.ToString(),
-                    IncomingTrustUkprn = incomingTrustId.ToString()
+                    IncomingTrustUkprn = incomingTrustId
                 }).ToList()
             };
 

--- a/Frontend/Views/Transfers/CheckYourAnswers.cshtml
+++ b/Frontend/Views/Transfers/CheckYourAnswers.cshtml
@@ -36,7 +36,7 @@
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Name</dt>
-                    <dd class="govuk-summary-list__value">@academy.AcademyName</dd>
+                    <dd class="govuk-summary-list__value">@academy.Name</dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link" asp-action="OutgoingTrustAcademies" asp-route-change="true">Change <span class="govuk-visually-hidden">Academy</span></a>
                     </dd>
@@ -63,17 +63,17 @@
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Ofsted Rating</dt>
-                    <dd class="govuk-summary-list__value">@academy.OfstedRating</dd>
+                    <dd class="govuk-summary-list__value">@academy.LatestOfstedJudgement.OverallEffectiveness</dd>
                     <dd class="govuk-summary-list__actions"></dd>
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Last inspection</dt>
-                    <dd class="govuk-summary-list__value">@academy.OfstedInspectionDate?.ToString("d MMMM yyyy")</dd>
+                    <dd class="govuk-summary-list__value">@academy.LatestOfstedJudgement.InspectionDate</dd>
                     <dd class="govuk-summary-list__actions"></dd>
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">PFI (private finance initiative)</dt>
-                    @if (academy.Pfi == null)
+                    @if (string.IsNullOrEmpty(academy.Pfi))
                     {
                         <dd class="govuk-summary-list__value">Does not apply</dd>
                     }

--- a/Frontend/Views/Transfers/CheckYourAnswers.cshtml.cs
+++ b/Frontend/Views/Transfers/CheckYourAnswers.cshtml.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using API.Models.Upstream.Response;
 using Data.Models;
 
 namespace Frontend.Views.Transfers
@@ -7,7 +6,7 @@ namespace Frontend.Views.Transfers
     public class CheckYourAnswers
     {
         public Trust OutgoingTrust;
-        public List<GetAcademiesModel> OutgoingAcademies;
+        public List<Academy> OutgoingAcademies;
         public Trust IncomingTrust;
     }
 }

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -63,11 +63,11 @@
                             <div class="govuk-radios__item">
                                 @if ((string) ViewData["OutgoingAcademyUkprn"] == academy.Ukprn)
                                 {
-                                    <input class="govuk-radios__input" id="@academy.Ukprn" name="academyUkprn" type="radio" value="@academy.Ukprn" checked>
+                                    <input class="govuk-radios__input" id="@academy.Ukprn" name="academyId" type="radio" value="@academy.Ukprn" checked>
                                 }
                                 else
                                 {
-                                    <input class="govuk-radios__input" id="@academy.Ukprn" name="academyUkprn" type="radio" value="@academy.Ukprn">
+                                    <input class="govuk-radios__input" id="@academy.Ukprn" name="academyId" type="radio" value="@academy.Ukprn">
                                 }
                                 <label class="govuk-label govuk-radios__label" for="@academy.Ukprn">
                                     @academy.Name (URN @academy.Urn)

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -30,7 +30,7 @@
                 <div class="govuk-error-summary__body">
                     <ul class="govuk-list govuk-error-summary__list">
                         <li>
-                            <a href="#@Model.Academies[0].Id" data-qa="error__text">
+                            <a href="#@Model.Academies[0].Name" data-qa="error__text">
                                 @ViewData["Error.Message"]
                             </a>
                         </li>
@@ -61,16 +61,16 @@
                         @foreach (var academy in Model.Academies)
                         {
                             <div class="govuk-radios__item">
-                                @if ((string) ViewData["OutgoingAcademyId"] == academy.Id.ToString())
+                                @if ((string) ViewData["OutgoingAcademyUkprn"] == academy.Ukprn)
                                 {
-                                    <input class="govuk-radios__input" id="@academy.Id" name="academyId" type="radio" value="@academy.Id" checked>
+                                    <input class="govuk-radios__input" id="@academy.Ukprn" name="academyUkprn" type="radio" value="@academy.Ukprn" checked>
                                 }
                                 else
                                 {
-                                    <input class="govuk-radios__input" id="@academy.Id" name="academyId" type="radio" value="@academy.Id">
+                                    <input class="govuk-radios__input" id="@academy.Ukprn" name="academyUkprn" type="radio" value="@academy.Ukprn">
                                 }
-                                <label class="govuk-label govuk-radios__label" for="@academy.Id">
-                                    @academy.AcademyName (URN @academy.Urn)
+                                <label class="govuk-label govuk-radios__label" for="@academy.Ukprn">
+                                    @academy.Name (URN @academy.Urn)
                                 </label>
                             </div>
                         }

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml.cs
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
 using API.Models.Upstream.Response;
+using Data.Models;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Frontend.Views.Transfers
 {
     public class OutgoingTrustAcademies : PageModel
     {
-        public List<GetAcademiesModel> Academies;
+        public List<Academy> Academies;
     }
 }

--- a/TRAMS-API/Wrappers/DynamicsTrustsWrapper.cs
+++ b/TRAMS-API/Wrappers/DynamicsTrustsWrapper.cs
@@ -7,6 +7,7 @@ using API.Repositories;
 using API.Repositories.Interfaces;
 using Data;
 using Data.Models;
+using Data.Models.Academies;
 
 namespace API.Wrappers
 {
@@ -58,7 +59,16 @@ namespace API.Wrappers
                 {
                     Name = academy.AcademyName,
                     Ukprn = academy.Id.ToString(),
-                    Urn = academy.Urn
+                    Urn = academy.Urn,
+                    LocalAuthorityName = academy.LocalAuthorityName,
+                    EstablishmentType = academy.EstablishmentType,
+                    ReligiousCharacter = academy.ReligiousCharacter,
+                    Pfi = academy.Pfi,
+                    LatestOfstedJudgement = new LatestOfstedJudgement()
+                    {
+                        OverallEffectiveness = academy.OfstedRating,
+                        InspectionDate = academy.OfstedInspectionDate?.ToString("d MMMM yyyy")
+                    }
                 }).ToList()
             };
 

--- a/TRAMS-API/Wrappers/DynamicsTrustsWrapper.cs
+++ b/TRAMS-API/Wrappers/DynamicsTrustsWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using API.Repositories;
 using API.Repositories.Interfaces;
 using Data;
 using Data.Models;
@@ -12,10 +13,13 @@ namespace API.Wrappers
     public class DynamicsTrustsWrapper : ITrusts
     {
         private readonly ITrustsRepository _dynamicsTrustsRepository;
+        private readonly IAcademiesRepository _dynamicsAcademiesRepository;
 
-        public DynamicsTrustsWrapper(ITrustsRepository dynamicsTrustsRepository)
+        public DynamicsTrustsWrapper(ITrustsRepository dynamicsTrustsRepository,
+            IAcademiesRepository dynamicsAcademiesRepository)
         {
             _dynamicsTrustsRepository = dynamicsTrustsRepository;
+            _dynamicsAcademiesRepository = dynamicsAcademiesRepository;
         }
 
         public async Task<RepositoryResult<List<TrustSearchResult>>> SearchTrusts(string searchQuery)
@@ -39,7 +43,9 @@ namespace API.Wrappers
         public async Task<RepositoryResult<Trust>> GetByUkprn(string ukprn)
         {
             var dynamicsResult = await _dynamicsTrustsRepository.GetTrustById(Guid.Parse(ukprn));
+            var dynamicsAcademies = await _dynamicsAcademiesRepository.GetAcademiesByTrustId(Guid.Parse(ukprn));
             var result = dynamicsResult.Result;
+            var academiesResult = dynamicsAcademies.Result;
             var mappedResult = new Trust
             {
                 Name = result.TrustName,
@@ -47,7 +53,13 @@ namespace API.Wrappers
                 EstablishmentType = result.EstablishmentType,
                 CompaniesHouseNumber = result.CompaniesHouseNumber,
                 GiasGroupId = result.TrustReferenceNumber,
-                Address = Regex.Split(result.Address, "\\r\\n|,").ToList()
+                Address = Regex.Split(result.Address, "\\r\\n|,").ToList(),
+                Academies = academiesResult.Select(academy => new Academy()
+                {
+                    Name = academy.AcademyName,
+                    Ukprn = academy.Id.ToString(),
+                    Urn = academy.Urn
+                }).ToList()
             };
 
             return new RepositoryResult<Trust>


### PR DESCRIPTION
### Context

As part of the work migrating to the new API

### Changes proposed in this pull request

- Migrate away from using GetTrustAcademies to getting the Academies from the GetTrustByUKPRN
- Clean up transfers controller away from GUIDs

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

