### PR TITLE
Add transfer dates summary page

### DIFF
--- a/Data.Mock/MockProjectRepository.cs
+++ b/Data.Mock/MockProjectRepository.cs
@@ -81,10 +81,6 @@ namespace Data.Mock
                         OutgoingAcademyUkprn = "3333333",
                         IncomingTrustUkprn = "2222222"
                     }
-                },
-                Features = new TransferFeatures
-                {
-                    ReasonForTransfer = new ReasonForTransfer()
                 }
             };
         }
@@ -114,6 +110,12 @@ namespace Data.Mock
                         IsSubjectToRddOrEsfaIntervention = true,
                         InterventionDetails = "Intervention details",
                     }
+                },
+                TransferDates = new TransferDates
+                {
+                    FirstDiscussed = "01/03/2021",
+                    Target = "01/09/2021",
+                    Htb = "01/06/2021"
                 }
             };
         }

--- a/Data/Models/Project.cs
+++ b/Data/Models/Project.cs
@@ -5,14 +5,26 @@ namespace Data.Models
 {
     public class Project
     {
+        public Project()
+        {
+            Features = new TransferFeatures();
+            TransferDates = new TransferDates();
+            TransferringAcademies = new List<TransferringAcademies>();
+        }
+
         public string Urn { get; set; }
         public string Name { get; set; }
         public string OutgoingTrustUkprn { get; set; }
         public string OutgoingTrustName { get; set; }
-        
+
         public string State { get; set; }
         public string Status { get; set; }
         public List<TransferringAcademies> TransferringAcademies { get; set; }
         public TransferFeatures Features { get; set; }
+        public TransferDates TransferDates { get; set; }
+    }
+
+    public class TransferDates
+    {
     }
 }

--- a/Data/Models/Project.cs
+++ b/Data/Models/Project.cs
@@ -26,5 +26,8 @@ namespace Data.Models
 
     public class TransferDates
     {
+        public string FirstDiscussed { get; set; }
+        public string Target { get; set; }
+        public string Htb { get; set; }
     }
 }

--- a/Data/Models/Projects/TransferFeatures.cs
+++ b/Data/Models/Projects/TransferFeatures.cs
@@ -44,7 +44,5 @@ namespace Data.Models.Projects
         public ReasonForTransfer ReasonForTransfer { get; set; }
         public TransferTypes TypeOfTransfer { get; set; }
         public string OtherTypeOfTransfer { get; set; }
-
-        public bool HasTransferReasonBeenSet => ReasonForTransfer.IsSubjectToRddOrEsfaIntervention != null;
     }
 }

--- a/Data/Models/Projects/TransferFeatures.cs
+++ b/Data/Models/Projects/TransferFeatures.cs
@@ -4,6 +4,11 @@ namespace Data.Models.Projects
 {
     public class TransferFeatures
     {
+        public TransferFeatures()
+        {
+            ReasonForTransfer = new ReasonForTransfer();
+        }
+
         public enum ProjectInitiators
         {
             Empty = 0,

--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -1,0 +1,44 @@
+using Data;
+using Data.Models;
+using Frontend.Controllers.Projects;
+using Frontend.Models;
+using Frontend.Tests.Helpers;
+using Moq;
+using Xunit;
+
+namespace Frontend.Tests.ControllerTests.Projects
+{
+    public class TransferDatesControllerTests
+    {
+        private readonly TransferDatesController _subject;
+        private readonly Mock<IProjects> _projectsRepository;
+        private readonly Project _foundProject;
+
+        public TransferDatesControllerTests()
+        {
+            _foundProject = new Project()
+            {
+                Urn = "0001"
+            };
+
+            _projectsRepository = new Mock<IProjects>();
+
+            _projectsRepository.Setup(r => r.GetByUrn(It.IsAny<string>()))
+                .ReturnsAsync(new RepositoryResult<Project>() {Result = _foundProject});
+
+            _subject = new TransferDatesController(_projectsRepository.Object);
+        }
+
+        public class IndexTests : TransferDatesControllerTests
+        {
+            [Fact]
+            public async void GivenUrn_AssignsModelToTheView()
+            {
+                var result = await _subject.Index("0001");
+                var viewModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(result);
+
+                Assert.Equal(_foundProject.Urn, viewModel.Project.Urn);
+            }
+        }
+    }
+}

--- a/Frontend.Tests/Helpers/ControllerTestHelpers.cs
+++ b/Frontend.Tests/Helpers/ControllerTestHelpers.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Frontend.Tests.Helpers
+{
+    public static class ControllerTestHelpers
+    {
+        public static TViewModel GetViewModelFromResult<TViewModel>(IActionResult result)
+        {
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var viewModel = Assert.IsType<TViewModel>(viewResult.Model);
+            return viewModel;
+        }
+    }
+}

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using Data;
+using Frontend.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Frontend.Controllers.Projects
+{
+    [Authorize]
+    [Route("project/{urn}/transfer-dates")]
+    public class TransferDatesController : Controller
+    {
+        private readonly IProjects _projectsRepository;
+
+        public TransferDatesController(IProjects projectsRepository)
+        {
+            _projectsRepository = projectsRepository;
+        }
+
+        public async Task<IActionResult> Index(string urn)
+        {
+            var model = await GetModel(urn);
+            return View(model);
+        }
+
+        private async Task<TransferDatesViewModel> GetModel(string urn)
+        {
+            var project = await _projectsRepository.GetByUrn(urn);
+
+            var model = new TransferDatesViewModel
+            {
+                Project = project.Result
+            };
+            
+            return model;
+        }
+    }
+}

--- a/Frontend/Helpers/DatesHelper.cs
+++ b/Frontend/Helpers/DatesHelper.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Frontend.Helpers
+{
+    public class DatesHelper
+    {
+        public static string DayMonthYearToDateString(string day, string month, string year)
+        {
+            return $"{day}/{month}/{year}";
+        }
+
+        public static List<string> DateStringToDayMonthYear(string dateString)
+        {
+            return dateString.Split("/").ToList();
+        }
+
+        public static string DateStringToGovUkDate(string dateString)
+        {
+            var splitDate = dateString.Split("/");
+            var date = new DateTime(int.Parse(splitDate[2]), int.Parse(splitDate[1]), int.Parse(splitDate[0]));
+            return date.ToString("d MMMM yyyy");
+        }
+    }
+}

--- a/Frontend/Models/TransferDatesViewModel.cs
+++ b/Frontend/Models/TransferDatesViewModel.cs
@@ -1,0 +1,12 @@
+namespace Frontend.Models
+{
+    public class TransferDatesViewModel : ProjectViewModel
+    {
+        public readonly FormErrorsViewModel FormErrors;
+
+        public TransferDatesViewModel()
+        {
+            FormErrors = new FormErrorsViewModel();
+        }
+    }
+}

--- a/Frontend/Views/Features/Index.cshtml
+++ b/Frontend/Views/Features/Index.cshtml
@@ -110,13 +110,6 @@
             </div>
         </dl>
 
-        <form action="#" method="post" novalidate="">
-            <input type="hidden" name="answers-checked" value="true">
-            <div class="govuk-button-group">
-                <button class="govuk-button" data-module="govuk-button">
-                    Save and continue
-                </button>
-            </div>
-        </form>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Save and continue</a>
     </div>
 </div>

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -35,8 +35,8 @@
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="dates">Set transfer dates</a>
-                        </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="dates">Unavailable</strong>
+                            <a aria-describedby="dates" asp-controller="TransferDates" asp-action="Index" asp-route-urn="@ViewData["ProjectId"]">Set transfer dates</a>
+                        </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="dates">Not started</strong>
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -1,0 +1,113 @@
+@using Frontend.Helpers
+@model Frontend.Models.TransferDatesViewModel
+
+@{
+    ViewBag.Title = "title";
+    Layout = "_Layout";
+    var transferDates = Model.Project.TransferDates;
+}
+
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Back to task list</a>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+        <span class="govuk-caption-m">
+            Reference number: @Model.Project.Name
+        </span>
+        <h1 class="govuk-heading-l">
+            Set transfer dates
+        </h1>
+        <h2 class="govuk-heading-m">
+            Outgoing trust: <span class="govuk-!-font-weight-regular govuk-!-font-size-24">@Model.Project.OutgoingTrustName</span>
+        </h2>
+        <p class="govuk-body">
+            This information is pre-populated from TRAMS and the school's application form.
+        </p>
+        <hr class="govuk-section-break govuk-section-break--l">
+    </div>
+</div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Date when the transfer was first discussed
+                </dt>
+                @if (string.IsNullOrEmpty(transferDates.FirstDiscussed))
+                {
+                    <dd class="govuk-summary-list__value">
+                        <span class="dfe-empty-tag">Empty</span>
+                    </dd>
+                }
+                else
+                {
+                    <dd class="govuk-summary-list__value">
+                        @{
+                            var display = DatesHelper.DateStringToGovUkDate(transferDates.FirstDiscussed);
+                            @display
+                        }
+                    </dd>
+                }
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">date first discussed</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Target date for transfer
+                </dt>
+                @if (string.IsNullOrEmpty(transferDates.Target))
+                {
+                    <dd class="govuk-summary-list__value">
+                        <span class="dfe-empty-tag">Empty</span>
+                    </dd>
+                }
+                else
+                {
+                    <dd class="govuk-summary-list__value">
+                        @{
+                            var display = DatesHelper.DateStringToGovUkDate(transferDates.Target);
+                            @display
+                        }
+                    </dd>
+                }
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">target date for transfer</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Set HTB date
+                </dt>
+                @if (string.IsNullOrEmpty(transferDates.Htb))
+                {
+                    <dd class="govuk-summary-list__value">
+                        <span class="dfe-empty-tag">Empty</span>
+                    </dd>
+                }
+                else
+                {
+                    <dd class="govuk-summary-list__value">
+                        @{
+                            var display = DatesHelper.DateStringToGovUkDate(transferDates.Htb);
+                            @display
+                        }
+                    </dd>
+                }
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">HTB date</span>
+                    </a>
+                </dd>
+            </div>
+        </dl>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Save and continue</a>
+    </div>
+</div>


### PR DESCRIPTION
### Context

We want to record the dates relevant to the transfer of the academy. This PR is the first in creating the relevant pages for it

### Changes proposed in this pull request

- Create the model for transfer dates
- Create summary page for transfer dates
- Add helper methods for handling date strings

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

