### PR TITLE
Create Transfer First Discussed pages

### DIFF
--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -40,5 +40,42 @@ namespace Frontend.Tests.ControllerTests.Projects
                 Assert.Equal(_foundProject.Urn, viewModel.Project.Urn);
             }
         }
+
+        public class FirstDiscussedTests : TransferDatesControllerTests
+        {
+            public class GetTests : FirstDiscussedTests
+            {
+                [Fact]
+                public async void GivenUrn_AssignsModelToTheView()
+                {
+                    var result = await _subject.FirstDiscussed("0001");
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(result);
+
+                    Assert.Equal(_foundProject.Urn, viewModel.Project.Urn);
+                }
+            }
+
+            public class PostTests : FirstDiscussedTests
+            {
+                [Theory]
+                [InlineData("01", "01", "2020", "01/01/2020")]
+                [InlineData("20", "02", "2021", "20/02/2021")]
+                public async void GivenUrnAndFullDate_UpdatesTheProjectWithTheCorrectDate(string day, string month,
+                    string year, string expectedDate)
+                {
+                    await _subject.FirstDiscussedPost("0001", day, month, year);
+
+                    _projectsRepository.Verify(r =>
+                        r.Update(It.Is<Project>(project => project.TransferDates.FirstDiscussed == expectedDate)));
+                }
+
+                [Fact]
+                public async void GivenUrnAndFullDate_RedirectsToTheSummaryPage()
+                {
+                    var response = await _subject.FirstDiscussedPost("0001", "01", "01", "2020");
+                    ControllerTestHelpers.AssertResultRedirectsToAction(response, "Index");
+                }
+            }
+        }
     }
 }

--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -75,6 +75,35 @@ namespace Frontend.Tests.ControllerTests.Projects
                     var response = await _subject.FirstDiscussedPost("0001", "01", "01", "2020");
                     ControllerTestHelpers.AssertResultRedirectsToAction(response, "Index");
                 }
+
+                [Theory]
+                [InlineData(null, "1", "2020")]
+                [InlineData("1", null, "2020")]
+                [InlineData("1", "1", null)]
+                public async void GivenPartsOfDateMissing_SetErrorOnTheModel(string day, string month, string year)
+                {
+                    var response = await _subject.FirstDiscussedPost("0001", day, month, year);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("Please enter the date the transfer was first discussed",
+                        responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
+
+                [Theory]
+                [InlineData("0", "1", "2020")]
+                [InlineData("32", "1", "2020")]
+                [InlineData("1", "0", "2020")]
+                [InlineData("1", "13", "2020")]
+                [InlineData("1", "13", "0")]
+                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year)
+                {
+                    var response = await _subject.FirstDiscussedPost("0001", day, month, year);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("Please enter a valid date", responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
             }
         }
     }

--- a/Frontend.Tests/Helpers/ControllerTestHelpers.cs
+++ b/Frontend.Tests/Helpers/ControllerTestHelpers.cs
@@ -11,5 +11,13 @@ namespace Frontend.Tests.Helpers
             var viewModel = Assert.IsType<TViewModel>(viewResult.Model);
             return viewModel;
         }
+
+        public static RedirectToActionResult AssertResultRedirectsToAction(IActionResult result, string actionName)
+        {
+            var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal(actionName, redirectResult.ActionName);
+
+            return redirectResult;
+        }
     }
 }

--- a/Frontend.Tests/ModelTests/TransferDatesViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/TransferDatesViewModelTests.cs
@@ -1,0 +1,37 @@
+using Data.Models;
+using Frontend.Models;
+using Xunit;
+
+namespace Frontend.Tests.ModelTests
+{
+    public class TransferDatesViewModelTests
+    {
+        [Theory]
+        [InlineData("", "", "", "")]
+        [InlineData("20/02/2020", "20", "02", "2020")]
+        [InlineData("13/01/2021", "13", "01", "2021")]
+        public void GivenFirstDiscussedDate_ReturnsTheCorrectDateViewModel(string inputDate, string expectedDay,
+            string expectedMonth, string expectedYear)
+        {
+            var project = new Project {TransferDates = new TransferDates {FirstDiscussed = inputDate}};
+            var model = new TransferDatesViewModel {Project = project};
+            Assert.Equal(expectedDay, model.TransferFirstDiscussed.Day);
+            Assert.Equal(expectedMonth, model.TransferFirstDiscussed.Month);
+            Assert.Equal(expectedYear, model.TransferFirstDiscussed.Year);
+        }
+        
+        [Theory]
+        [InlineData("", "", "", "")]
+        [InlineData("20/02/2020", "20", "02", "2020")]
+        [InlineData("13/01/2021", "13", "01", "2021")]
+        public void GivenTargetTransferDate_ReturnsTheCorrectDateViewModel(string inputDate, string expectedDay,
+            string expectedMonth, string expectedYear)
+        {
+            var project = new Project {TransferDates = new TransferDates {Target = inputDate}};
+            var model = new TransferDatesViewModel {Project = project};
+            Assert.Equal(expectedDay, model.TargetDate.Day);
+            Assert.Equal(expectedMonth, model.TargetDate.Month);
+            Assert.Equal(expectedYear, model.TargetDate.Year);
+        }
+    }
+}

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Data;
+using Frontend.Helpers;
 using Frontend.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -23,6 +24,23 @@ namespace Frontend.Controllers.Projects
             return View(model);
         }
 
+        [HttpGet("first-discussed")]
+        public async Task<IActionResult> FirstDiscussed(string urn)
+        {
+            var model = await GetModel(urn);
+            return View(model);
+        }
+
+        [HttpPost("first-discussed")]
+        [ActionName("FirstDiscussed")]
+        public async Task<IActionResult> FirstDiscussedPost(string urn, string day, string month, string year)
+        {
+            var model = await GetModel(urn);
+            model.Project.TransferDates.FirstDiscussed = DatesHelper.DayMonthYearToDateString(day, month, year);
+            await _projectsRepository.Update(model.Project);
+            return RedirectToAction("Index", new {urn});
+        }
+
         private async Task<TransferDatesViewModel> GetModel(string urn)
         {
             var project = await _projectsRepository.GetByUrn(urn);
@@ -31,7 +49,7 @@ namespace Frontend.Controllers.Projects
             {
                 Project = project.Result
             };
-            
+
             return model;
         }
     }

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Data;
 using Frontend.Helpers;
@@ -36,7 +38,21 @@ namespace Frontend.Controllers.Projects
         public async Task<IActionResult> FirstDiscussedPost(string urn, string day, string month, string year)
         {
             var model = await GetModel(urn);
-            model.Project.TransferDates.FirstDiscussed = DatesHelper.DayMonthYearToDateString(day, month, year);
+            var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
+            model.Project.TransferDates.FirstDiscussed = dateString;
+
+            if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
+            {
+                model.FormErrors.AddError("day", "day", "Please enter the date the transfer was first discussed");
+                return View(model);
+            }
+
+            if (!DatesHelper.IsValidDate(dateString))
+            {
+                model.FormErrors.AddError("day", "day", "Please enter a valid date");
+                return View(model);
+            }
+
             await _projectsRepository.Update(model.Project);
             return RedirectToAction("Index", new {urn});
         }

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -29,4 +29,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Models\Projects" />
+  </ItemGroup>
 </Project>

--- a/Frontend/Helpers/DatesHelper.cs
+++ b/Frontend/Helpers/DatesHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 
 namespace Frontend.Helpers
@@ -14,6 +13,11 @@ namespace Frontend.Helpers
 
         public static List<string> DateStringToDayMonthYear(string dateString)
         {
+            if (string.IsNullOrEmpty(dateString))
+            {
+                return new List<string>() {"", "", ""};
+            }
+
             return dateString.Split("/").ToList();
         }
 

--- a/Frontend/Helpers/DatesHelper.cs
+++ b/Frontend/Helpers/DatesHelper.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Frontend.Helpers
 {
-    public class DatesHelper
+    public static class DatesHelper
     {
         public static string DayMonthYearToDateString(string day, string month, string year)
         {
@@ -26,6 +27,11 @@ namespace Frontend.Helpers
             var splitDate = dateString.Split("/");
             var date = new DateTime(int.Parse(splitDate[2]), int.Parse(splitDate[1]), int.Parse(splitDate[0]));
             return date.ToString("d MMMM yyyy");
+        }
+
+        public static bool IsValidDate(string dateString)
+        {
+            return DateTime.TryParseExact(dateString, "dd/MM/yyyy", null, DateTimeStyles.None, out _);
         }
     }
 }

--- a/Frontend/Models/FeaturesViewModel.cs
+++ b/Frontend/Models/FeaturesViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Data.Models.Projects;
 using Frontend.Helpers;
+using Frontend.Models.Forms;
 
 namespace Frontend.Models
 {

--- a/Frontend/Models/Forms/DateInputViewModel.cs
+++ b/Frontend/Models/Forms/DateInputViewModel.cs
@@ -1,0 +1,9 @@
+namespace Frontend.Models.Forms
+{
+    public class DateInputViewModel
+    {
+        public string Day { get; set; }
+        public string Month { get; set; }
+        public string Year { get; set; }
+    }
+}

--- a/Frontend/Models/Forms/FormError.cs
+++ b/Frontend/Models/Forms/FormError.cs
@@ -1,4 +1,4 @@
-namespace Frontend.Models
+namespace Frontend.Models.Forms
 {
     public class FormError
     {

--- a/Frontend/Models/Forms/FormErrorsViewModel.cs
+++ b/Frontend/Models/Forms/FormErrorsViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Frontend.Models
+namespace Frontend.Models.Forms
 {
     public class FormErrorsViewModel
     {

--- a/Frontend/Models/Forms/RadioButtonViewModel.cs
+++ b/Frontend/Models/Forms/RadioButtonViewModel.cs
@@ -1,4 +1,4 @@
-namespace Frontend.Models
+namespace Frontend.Models.Forms
 {
     public class RadioButtonViewModel
     {

--- a/Frontend/Models/TransferDatesViewModel.cs
+++ b/Frontend/Models/TransferDatesViewModel.cs
@@ -1,3 +1,5 @@
+using Frontend.Models.Forms;
+
 namespace Frontend.Models
 {
     public class TransferDatesViewModel : ProjectViewModel

--- a/Frontend/Models/TransferDatesViewModel.cs
+++ b/Frontend/Models/TransferDatesViewModel.cs
@@ -1,3 +1,4 @@
+using Frontend.Helpers;
 using Frontend.Models.Forms;
 
 namespace Frontend.Models
@@ -9,6 +10,15 @@ namespace Frontend.Models
         public TransferDatesViewModel()
         {
             FormErrors = new FormErrorsViewModel();
+        }
+
+        public DateInputViewModel TransferFirstDiscussed => DateInputForField(Project.TransferDates.FirstDiscussed);
+        public DateInputViewModel TargetDate => DateInputForField(Project.TransferDates.Target);
+
+        private static DateInputViewModel DateInputForField(string transferDatesFirstDiscussed)
+        {
+            var splitDate = DatesHelper.DateStringToDayMonthYear(transferDatesFirstDiscussed);
+            return new DateInputViewModel() {Day = splitDate[0], Month = splitDate[1], Year = splitDate[2]};
         }
     }
 }

--- a/Frontend/Views/Shared/_FormErrorSummary.cshtml
+++ b/Frontend/Views/Shared/_FormErrorSummary.cshtml
@@ -1,4 +1,4 @@
-@model FormErrorsViewModel
+@model Frontend.Models.Forms.FormErrorsViewModel
 @if (Model.HasErrors)
 {
     <div class="govuk-grid-row">

--- a/Frontend/Views/Shared/_InlineRadioButtons.cshtml
+++ b/Frontend/Views/Shared/_InlineRadioButtons.cshtml
@@ -1,4 +1,4 @@
-@model List<RadioButtonViewModel>
+@model List<Frontend.Models.Forms.RadioButtonViewModel>
 
 <div class="govuk-radios govuk-radios--inline">
     @foreach (var radioButton in Model)

--- a/Frontend/Views/Shared/_RadioButtons.cshtml
+++ b/Frontend/Views/Shared/_RadioButtons.cshtml
@@ -1,4 +1,4 @@
-@model List<RadioButtonViewModel>
+@model List<Frontend.Models.Forms.RadioButtonViewModel>
 
 <div class="govuk-radios">
     @foreach (var radioButton in Model)

--- a/Frontend/Views/TransferDates/FirstDiscussed.cshtml
+++ b/Frontend/Views/TransferDates/FirstDiscussed.cshtml
@@ -1,7 +1,7 @@
 @model TransferDatesViewModel
 
 @{
-    ViewBag.Title = "title";
+    ViewBag.Title = "Add the date the transfer was first discussed with the outgoing trust";
     Layout = "_Layout";
     var formClasses = Model.FormErrors.HasErrors ? "govuk-form-group--error" : "";
 }

--- a/Frontend/Views/TransferDates/FirstDiscussed.cshtml
+++ b/Frontend/Views/TransferDates/FirstDiscussed.cshtml
@@ -1,0 +1,99 @@
+@model TransferDatesViewModel
+
+@{
+    ViewBag.Title = "title";
+    Layout = "_Layout";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form asp-action="FirstDiscussed" asp-route-urn="@Model.Project.Urn" method="post" novalidate="">
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="transfer-first-discussed-date-hint">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading">
+                            <span class="govuk-caption-m">
+                                Reference number: @Model.Project.Name
+                            </span>
+                        </h1>
+                        <h1 class="govuk-heading-l">
+                            Add the date the transfer was first discussed with the outgoing trust
+                        </h1>
+                    </legend>
+                    <div id="transfer-first-discussed-date-hint" class="govuk-hint">
+                        For example, 23 03 2007
+                    </div>
+                    <div class="govuk-date-input" id="transfer-first-discussed-date">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-date-input__label" for="day">
+                                    Day
+                                </label>
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="day" type="text" pattern="[0-9]*" inputmode="numeric">
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-date-input__label" for="month">
+                                    Month
+                                </label>
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="month" type="text" pattern="[0-9]*" inputmode="numeric">
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-date-input__label" for="year">
+                                    Year
+                                </label>
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="year" type="text" pattern="[0-9]*" inputmode="numeric">
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <button class="govuk-button" data-module="govuk-button">
+                Save and continue
+            </button>
+        </form>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+        <aside class="app-related-items" role="complementary">
+            <h2 class="govuk-heading-s" id="subsection-title">
+                Useful information
+            </h2>
+            <nav role="navigation" aria-labelledby="subsection-title">
+                <ul class="govuk-list govuk-!-font-size-16">
+                    <li>
+                        <a class="govuk-link" href="#">
+                            View full application
+                        </a>
+                    </li>
+                    <li>
+                        <a class="govuk-link" href="#">
+                            School information on TRAMS
+                        </a>
+                    </li>
+                    <hr class="govuk-grid-one-third govuk-section-break govuk-section-break--m govuk-section-break--visible">
+                </ul>
+            </nav>
+            <h2 class="govuk-heading-s" id="subsection-title">
+                Guidance
+            </h2>
+            <nav role="navigation" aria-labelledby="subsection-title">
+                <ul class="govuk-list govuk-!-font-size-16">
+                    <li>
+                        <a class="govuk-link" href="#">
+                            Guidance for setting an HTB date
+                        </a>
+                    </li>
+                    <li>
+                        <a class="govuk-link" href="#">
+                            Full Guidance
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </aside>
+    </div>
+</div>

--- a/Frontend/Views/TransferDates/FirstDiscussed.cshtml
+++ b/Frontend/Views/TransferDates/FirstDiscussed.cshtml
@@ -3,12 +3,20 @@
 @{
     ViewBag.Title = "title";
     Layout = "_Layout";
+    var formClasses = Model.FormErrors.HasErrors ? "govuk-form-group--error" : "";
 }
+
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+}
+
+@await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="FirstDiscussed" asp-route-urn="@Model.Project.Urn" method="post" novalidate="">
-            <div class="govuk-form-group">
+            <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" role="group" aria-describedby="transfer-first-discussed-date-hint">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">
@@ -23,13 +31,21 @@
                     <div id="transfer-first-discussed-date-hint" class="govuk-hint">
                         For example, 23 03 2007
                     </div>
+
+                    @if (Model.FormErrors.HasErrorForField("day"))
+                    {
+                        <span id="who-initiated-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> @Model.FormErrors.ErrorForField("day").ErrorMessage
+                        </span>
+                    }
+
                     <div class="govuk-date-input" id="transfer-first-discussed-date">
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label class="govuk-label govuk-date-input__label" for="day">
                                     Day
                                 </label>
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="day" type="text" pattern="[0-9]*" inputmode="numeric">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="day" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TransferFirstDiscussed.Day">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
@@ -37,7 +53,7 @@
                                 <label class="govuk-label govuk-date-input__label" for="month">
                                     Month
                                 </label>
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="month" type="text" pattern="[0-9]*" inputmode="numeric">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="month" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TransferFirstDiscussed.Month">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
@@ -45,7 +61,7 @@
                                 <label class="govuk-label govuk-date-input__label" for="year">
                                     Year
                                 </label>
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="year" type="text" pattern="[0-9]*" inputmode="numeric">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="year" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TransferFirstDiscussed.Year">
                             </div>
                         </div>
                     </div>

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -2,7 +2,7 @@
 @model Frontend.Models.TransferDatesViewModel
 
 @{
-    ViewBag.Title = "title";
+    ViewBag.Title = "Set transfer dates";
     Layout = "_Layout";
     var transferDates = Model.Project.TransferDates;
 }

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -52,7 +52,7 @@
                     </dd>
                 }
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
+                    <a class="govuk-link" asp-action="FirstDiscussed" asp-route-urn="@Model.Project.Urn">
                         Change<span class="govuk-visually-hidden">date first discussed</span>
                     </a>
                 </dd>


### PR DESCRIPTION

### Context

Part of the work on adding transfer dates - this adds in the ability to set the date the transfer was first discussed with the trust

### Changes proposed in this pull request

- Move form view models to forms folder
- Add transfer dates view model with tests
- Support posting valid date
- Validate first discussed date

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

