### PR TITLE
Add Target Dates for transfer page

### DIFF
--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -53,6 +53,7 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.Equal(_foundProject.Urn, viewModel.Project.Urn);
                 }
+                
             }
 
             public class PostTests : FirstDiscussedTests
@@ -60,6 +61,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [Theory]
                 [InlineData("01", "01", "2020", "01/01/2020")]
                 [InlineData("20", "02", "2021", "20/02/2021")]
+                [InlineData("2", "2", "2021", "02/02/2021")]
                 public async void GivenUrnAndFullDate_UpdatesTheProjectWithTheCorrectDate(string day, string month,
                     string year, string expectedDate)
                 {
@@ -99,6 +101,73 @@ namespace Frontend.Tests.ControllerTests.Projects
                 public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year)
                 {
                     var response = await _subject.FirstDiscussedPost("0001", day, month, year);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("Please enter a valid date", responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
+            }
+        }
+
+        public class TargetDateTests : TransferDatesControllerTests
+        {
+            public class GetTests : TargetDateTests
+            {
+                [Fact]
+                public async void GivenUrn_AssignsModelToTheView()
+                {
+                    var result = await _subject.TargetDate("0001");
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(result);
+
+                    Assert.Equal(_foundProject.Urn, viewModel.Project.Urn);
+                }
+            }
+
+            public class PostTests : TargetDateTests
+            {
+                [Theory]
+                [InlineData("01", "01", "2020", "01/01/2020")]
+                [InlineData("20", "02", "2021", "20/02/2021")]
+                [InlineData("2", "2", "2021", "02/02/2021")]
+                public async void GivenUrnAndFullDate_UpdatesTheProjectWithTheCorrectDate(string day, string month,
+                    string year, string expectedDate)
+                {
+                    await _subject.TargetDatePost("0001", day, month, year);
+
+                    _projectsRepository.Verify(r =>
+                        r.Update(It.Is<Project>(project => project.TransferDates.Target == expectedDate)));
+                }
+
+                [Fact]
+                public async void GivenUrnAndFullDate_RedirectsToTheSummaryPage()
+                {
+                    var response = await _subject.TargetDatePost("0001", "01", "01", "2020");
+                    ControllerTestHelpers.AssertResultRedirectsToAction(response, "Index");
+                }
+
+                [Theory]
+                [InlineData(null, "1", "2020")]
+                [InlineData("1", null, "2020")]
+                [InlineData("1", "1", null)]
+                public async void GivenPartsOfDateMissing_SetErrorOnTheModel(string day, string month, string year)
+                {
+                    var response = await _subject.TargetDatePost("0001", day, month, year);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("Please enter the target date for the transfer",
+                        responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
+
+                [Theory]
+                [InlineData("0", "1", "2020")]
+                [InlineData("32", "1", "2020")]
+                [InlineData("1", "0", "2020")]
+                [InlineData("1", "13", "2020")]
+                [InlineData("1", "13", "0")]
+                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year)
+                {
+                    var response = await _subject.TargetDatePost("0001", day, month, year);
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using Data;
 using Frontend.Helpers;

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -57,6 +57,37 @@ namespace Frontend.Controllers.Projects
             return RedirectToAction("Index", new {urn});
         }
 
+        [HttpGet("target-date")]
+        public async Task<IActionResult> TargetDate(string urn)
+        {
+            var model = await GetModel(urn);
+            return View(model);
+        }
+
+        [HttpPost("target-date")]
+        [ActionName("TargetDate")]
+        public async Task<IActionResult> TargetDatePost(string urn, string day, string month, string year)
+        {
+            var model = await GetModel(urn);
+            var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
+            model.Project.TransferDates.Target = dateString;
+
+            if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
+            {
+                model.FormErrors.AddError("day", "day", "Please enter the target date for the transfer");
+                return View(model);
+            }
+
+            if (!DatesHelper.IsValidDate(dateString))
+            {
+                model.FormErrors.AddError("day", "day", "Please enter a valid date");
+                return View(model);
+            }
+
+            await _projectsRepository.Update(model.Project);
+            return RedirectToAction("Index", new {urn});
+        }
+
         private async Task<TransferDatesViewModel> GetModel(string urn)
         {
             var project = await _projectsRepository.GetByUrn(urn);

--- a/Frontend/Helpers/DatesHelper.cs
+++ b/Frontend/Helpers/DatesHelper.cs
@@ -9,6 +9,10 @@ namespace Frontend.Helpers
     {
         public static string DayMonthYearToDateString(string day, string month, string year)
         {
+            day = string.IsNullOrEmpty(day) ? "" : day.PadLeft(2, '0');
+            month = string.IsNullOrEmpty(month) ? "" : month.PadLeft(2, '0');
+            year = string.IsNullOrEmpty(year) ? "" : year.PadLeft(4, '0');
+            
             return $"{day}/{month}/{year}";
         }
 

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -77,7 +77,7 @@
                     </dd>
                 }
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
+                    <a class="govuk-link" asp-action="TargetDate">
                         Change<span class="govuk-visually-hidden">target date for transfer</span>
                     </a>
                 </dd>

--- a/Frontend/Views/TransferDates/TargetDate.cshtml
+++ b/Frontend/Views/TransferDates/TargetDate.cshtml
@@ -1,7 +1,7 @@
 @model TransferDatesViewModel
 
 @{
-    ViewBag.Title = "Add the date the transfer was first discussed with the outgoing trust";
+    ViewBag.Title = "Add the target date for the transfer";
     Layout = "_Layout";
     var formClasses = Model.FormErrors.HasErrors ? "govuk-form-group--error" : "";
 }
@@ -15,17 +15,17 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <form asp-action="FirstDiscussed" asp-route-urn="@Model.Project.Urn" method="post" novalidate="">
+        <form asp-action="TargetDate" asp-route-urn="@Model.Project.Urn" method="post" novalidate="">
             <div class="govuk-form-group @formClasses">
-                <fieldset class="govuk-fieldset" role="group" aria-describedby="transfer-first-discussed-date-hint">
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="target-date-for-transfer-hint">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: @Model.Project.Name
+                                Reference number: AS_6759840
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">
-                            Add the date the transfer was first discussed with the outgoing trust
+                            Add the target date for the transfer
                         </h1>
                     </legend>
                     <div id="target-date-for-transfer-hint" class="govuk-hint">
@@ -45,7 +45,7 @@
                                 <label class="govuk-label govuk-date-input__label" for="day">
                                     Day
                                 </label>
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="day" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TransferFirstDiscussed.Day">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="day" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TargetDate.Day">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
@@ -53,7 +53,7 @@
                                 <label class="govuk-label govuk-date-input__label" for="month">
                                     Month
                                 </label>
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="month" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TransferFirstDiscussed.Month">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="month" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TargetDate.Month">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
@@ -61,7 +61,7 @@
                                 <label class="govuk-label govuk-date-input__label" for="year">
                                     Year
                                 </label>
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="year" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TransferFirstDiscussed.Year">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="year" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.TargetDate.Year">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Context

Allows our users to enter the target date for the transfer to take place

### Changes proposed in this pull request

- Add target date for transfer page
- Link to target date from summary page

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

