### PR TITLE
Add project rationale to data model

### DIFF
--- a/Data.Mock/MockProjectRepository.cs
+++ b/Data.Mock/MockProjectRepository.cs
@@ -120,13 +120,13 @@ namespace Data.Mock
                         InterventionDetails = "Intervention details",
                     }
                 },
-                TransferDates = new TransferDates
+                Dates = new TransferDates
                 {
                     FirstDiscussed = "01/03/2021",
                     Target = "01/09/2021",
                     Htb = "01/06/2021"
                 },
-                TransferBenefits = new TransferBenefits
+                Benefits = new TransferBenefits
                 {
                     IntendedBenefits = new List<TransferBenefits.IntendedBenefit>
                     {
@@ -138,6 +138,11 @@ namespace Data.Mock
                     {
                         {TransferBenefits.OtherFactor.HighProfile, "Some extra detail about this high profile transfer"}
                     }
+                },
+                Rationale = new TransferRationale
+                {
+                    Project = "This is the rationale for the project",
+                    Trust = "This is the rationale for the trust or sponsor"
                 }
             };
         }

--- a/Data/Models/Project.cs
+++ b/Data/Models/Project.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using Data.Models.Projects;
 
 namespace Data.Models
@@ -8,10 +7,11 @@ namespace Data.Models
     {
         public Project()
         {
-            Features = new TransferFeatures();
-            TransferDates = new TransferDates();
-            TransferBenefits = new TransferBenefits();
             TransferringAcademies = new List<TransferringAcademies>();
+            Features = new TransferFeatures();
+            Dates = new TransferDates();
+            Benefits = new TransferBenefits();
+            Rationale = new TransferRationale();
         }
 
         public string Urn { get; set; }
@@ -23,66 +23,8 @@ namespace Data.Models
         public string Status { get; set; }
         public List<TransferringAcademies> TransferringAcademies { get; set; }
         public TransferFeatures Features { get; set; }
-        public TransferDates TransferDates { get; set; }
-
-        public TransferBenefits TransferBenefits { get; set; }
-    }
-
-    public class TransferBenefits
-    {
-        public TransferBenefits()
-        {
-            IntendedBenefits = new List<IntendedBenefit>();
-            OtherFactors = new Dictionary<OtherFactor, string>();
-        }
-
-        public enum IntendedBenefit
-        {
-            Empty = 0,
-
-            [Display(Name = "Strengthening governance")]
-            StrengtheningGovernance,
-
-            [Display(Name = "Improving safeguarding")]
-            ImprovingSafeguarding,
-
-            [Display(Name = "Stronger leadership")]
-            StrongerLeadership,
-
-            [Display(Name = "Securing financial recovery")]
-            SecurityFinancialRecovery,
-
-            [Display(Name = "Improving Ofsted rating")]
-            ImprovingOfstedRating,
-
-            [Display(Name = "A central financial team and central support")]
-            CentralFinanceTeamAndSupport,
-            Other
-        }
-
-        public enum OtherFactor
-        {
-            Empty = 0,
-
-            [Display(Name = "This is a high profile transfer (ministers and media could be involved)")]
-            HighProfile,
-
-            [Display(Name = "There are complex land and building issues")]
-            ComplexLandAndBuildingIssues,
-
-            [Display(Name = "There are finance and debt concerns")]
-            FinanceAndDebtConcerns
-        }
-
-        public List<IntendedBenefit> IntendedBenefits { get; set; }
-        public string OtherIntendedBenefit { get; set; }
-        public Dictionary<OtherFactor, string> OtherFactors { get; set; }
-    }
-
-    public class TransferDates
-    {
-        public string FirstDiscussed { get; set; }
-        public string Target { get; set; }
-        public string Htb { get; set; }
+        public TransferDates Dates { get; set; }
+        public TransferBenefits Benefits { get; set; }
+        public TransferRationale Rationale { get; set; }
     }
 }

--- a/Data/Models/Projects/TransferBenefits.cs
+++ b/Data/Models/Projects/TransferBenefits.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Data.Models.Projects
+{
+    public class TransferBenefits
+    {
+        public TransferBenefits()
+        {
+            IntendedBenefits = new List<IntendedBenefit>();
+            OtherFactors = new Dictionary<OtherFactor, string>();
+        }
+
+        public enum IntendedBenefit
+        {
+            Empty = 0,
+
+            [Display(Name = "Strengthening governance")]
+            StrengtheningGovernance,
+
+            [Display(Name = "Improving safeguarding")]
+            ImprovingSafeguarding,
+
+            [Display(Name = "Stronger leadership")]
+            StrongerLeadership,
+
+            [Display(Name = "Securing financial recovery")]
+            SecurityFinancialRecovery,
+
+            [Display(Name = "Improving Ofsted rating")]
+            ImprovingOfstedRating,
+
+            [Display(Name = "A central financial team and central support")]
+            CentralFinanceTeamAndSupport,
+            Other
+        }
+
+        public enum OtherFactor
+        {
+            Empty = 0,
+
+            [Display(Name = "This is a high profile transfer (ministers and media could be involved)")]
+            HighProfile,
+
+            [Display(Name = "There are complex land and building issues")]
+            ComplexLandAndBuildingIssues,
+
+            [Display(Name = "There are finance and debt concerns")]
+            FinanceAndDebtConcerns
+        }
+
+        public List<IntendedBenefit> IntendedBenefits { get; set; }
+        public string OtherIntendedBenefit { get; set; }
+        public Dictionary<OtherFactor, string> OtherFactors { get; set; }
+    }
+}

--- a/Data/Models/Projects/TransferDates.cs
+++ b/Data/Models/Projects/TransferDates.cs
@@ -1,0 +1,9 @@
+namespace Data.Models.Projects
+{
+    public class TransferDates
+    {
+        public string FirstDiscussed { get; set; }
+        public string Target { get; set; }
+        public string Htb { get; set; }
+    }
+}

--- a/Data/Models/Projects/TransferRationale.cs
+++ b/Data/Models/Projects/TransferRationale.cs
@@ -1,0 +1,8 @@
+namespace Data.Models.Projects
+{
+    public class TransferRationale
+    {
+        public string Project { get; set; }
+        public string Trust { get; set; }
+    }
+}

--- a/Frontend.Tests/ControllerTests/Projects/BenefitsControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/BenefitsControllerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Data;
 using Data.Models;
+using Data.Models.Projects;
 using Frontend.Controllers.Projects;
 using Frontend.Models;
 using Frontend.Tests.Helpers;
@@ -73,7 +74,7 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     _projectsRepository.Verify(r =>
                         r.Update(It.Is<Project>(
-                            project => project.TransferBenefits.IntendedBenefits.All(intendedBenefits.Contains))));
+                            project => project.Benefits.IntendedBenefits.All(intendedBenefits.Contains))));
                 }
 
                 [Fact]
@@ -89,8 +90,8 @@ namespace Frontend.Tests.ControllerTests.Projects
                     await _subject.IntendedBenefitsPost("0001", intendedBenefits.ToArray(), "Other benefit");
                     _projectsRepository.Verify(r =>
                         r.Update(It.Is<Project>(
-                            project => project.TransferBenefits.IntendedBenefits.All(intendedBenefits.Contains) &&
-                                       project.TransferBenefits.OtherIntendedBenefit == "Other benefit")
+                            project => project.Benefits.IntendedBenefits.All(intendedBenefits.Contains) &&
+                                       project.Benefits.OtherIntendedBenefit == "Other benefit")
                         )
                     );
                 }
@@ -172,7 +173,7 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Func<Project, bool> assertOtherFactorsEqual = project =>
                     {
-                        var projectOtherFactors = project.TransferBenefits.OtherFactors;
+                        var projectOtherFactors = project.Benefits.OtherFactors;
                         var highProfile = projectOtherFactors[TransferBenefits.OtherFactor.HighProfile];
                         var complexIssues =
                             projectOtherFactors[TransferBenefits.OtherFactor.ComplexLandAndBuildingIssues];
@@ -215,8 +216,8 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     await _subject.OtherFactorsPost("0001", otherFactors, "High profile", "", "");
                     _projectsRepository.Verify(r => r.Update(It.Is<Project>(
-                        project => project.TransferBenefits.OtherFactors.Keys.Count == 1 &&
-                                   project.TransferBenefits.OtherFactors[TransferBenefits.OtherFactor.HighProfile] ==
+                        project => project.Benefits.OtherFactors.Keys.Count == 1 &&
+                                   project.Benefits.OtherFactors[TransferBenefits.OtherFactor.HighProfile] ==
                                    "High profile"
                     )));
                 }
@@ -229,8 +230,8 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     await _subject.OtherFactorsPost("0001", otherFactors, "", "Complex issues", "");
                     _projectsRepository.Verify(r => r.Update(It.Is<Project>(
-                        project => project.TransferBenefits.OtherFactors.Keys.Count == 1 &&
-                                   project.TransferBenefits.OtherFactors[
+                        project => project.Benefits.OtherFactors.Keys.Count == 1 &&
+                                   project.Benefits.OtherFactors[
                                        TransferBenefits.OtherFactor.ComplexLandAndBuildingIssues] ==
                                    "Complex issues"
                     )));
@@ -244,8 +245,8 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     await _subject.OtherFactorsPost("0001", otherFactors, "", "", "Finance concerns");
                     _projectsRepository.Verify(r => r.Update(It.Is<Project>(
-                        project => project.TransferBenefits.OtherFactors.Keys.Count == 1 &&
-                                   project.TransferBenefits.OtherFactors[
+                        project => project.Benefits.OtherFactors.Keys.Count == 1 &&
+                                   project.Benefits.OtherFactors[
                                        TransferBenefits.OtherFactor.FinanceAndDebtConcerns] ==
                                    "Finance concerns"
                     )));
@@ -263,12 +264,12 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     await _subject.OtherFactorsPost("0001", otherFactors, "", "", "");
                     _projectsRepository.Verify(r => r.Update(It.Is<Project>(
-                        project => project.TransferBenefits.OtherFactors.Keys.Count == 3 &&
-                                   project.TransferBenefits.OtherFactors.ContainsKey(TransferBenefits.OtherFactor
+                        project => project.Benefits.OtherFactors.Keys.Count == 3 &&
+                                   project.Benefits.OtherFactors.ContainsKey(TransferBenefits.OtherFactor
                                        .HighProfile) &&
-                                   project.TransferBenefits.OtherFactors.ContainsKey(TransferBenefits.OtherFactor
+                                   project.Benefits.OtherFactors.ContainsKey(TransferBenefits.OtherFactor
                                        .ComplexLandAndBuildingIssues) &&
-                                   project.TransferBenefits.OtherFactors.ContainsKey(TransferBenefits.OtherFactor
+                                   project.Benefits.OtherFactors.ContainsKey(TransferBenefits.OtherFactor
                                        .FinanceAndDebtConcerns)
                     )));
                 }

--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -72,7 +72,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                     await _subject.FirstDiscussedPost("0001", day, month, year);
 
                     _projectsRepository.Verify(r =>
-                        r.Update(It.Is<Project>(project => project.TransferDates.FirstDiscussed == expectedDate)));
+                        r.Update(It.Is<Project>(project => project.Dates.FirstDiscussed == expectedDate)));
                 }
 
                 [Fact]
@@ -139,7 +139,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                     await _subject.TargetDatePost("0001", day, month, year);
 
                     _projectsRepository.Verify(r =>
-                        r.Update(It.Is<Project>(project => project.TransferDates.Target == expectedDate)));
+                        r.Update(It.Is<Project>(project => project.Dates.Target == expectedDate)));
                 }
 
                 [Fact]
@@ -204,7 +204,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                     await _subject.HtbDatePost("0001", htbDate);
 
                     _projectsRepository.Verify(r =>
-                        r.Update(It.Is<Project>(project => project.TransferDates.Htb == htbDate)));
+                        r.Update(It.Is<Project>(project => project.Dates.Htb == htbDate)));
                 }
 
                 [Fact]

--- a/Frontend.Tests/ModelTests/BenefitsViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/BenefitsViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Data.Models;
+using Data.Models.Projects;
 using DocumentFormat.OpenXml.Spreadsheet;
 using Frontend.Helpers;
 using Frontend.Models;
@@ -36,7 +37,7 @@ namespace Frontend.Tests.ModelTests
                     TransferBenefits.IntendedBenefit.ImprovingOfstedRating
                 };
 
-                _model.Project.TransferBenefits.IntendedBenefits = intendedBenefits;
+                _model.Project.Benefits.IntendedBenefits = intendedBenefits;
 
                 var expectedDisplayValues =
                     intendedBenefits.Select(EnumHelpers<TransferBenefits.IntendedBenefit>.GetDisplayValue).ToList();
@@ -58,8 +59,8 @@ namespace Frontend.Tests.ModelTests
                     TransferBenefits.IntendedBenefit.Other
                 };
 
-                _model.Project.TransferBenefits.IntendedBenefits = intendedBenefits;
-                _model.Project.TransferBenefits.OtherIntendedBenefit = "Can create cat sanctuary";
+                _model.Project.Benefits.IntendedBenefits = intendedBenefits;
+                _model.Project.Benefits.OtherIntendedBenefit = "Can create cat sanctuary";
 
                 var expectedDisplayValues =
                     intendedBenefits
@@ -95,7 +96,7 @@ namespace Frontend.Tests.ModelTests
                     {TransferBenefits.OtherFactor.FinanceAndDebtConcerns, ""}
                 };
 
-                _model.Project.TransferBenefits.OtherFactors = otherFactors;
+                _model.Project.Benefits.OtherFactors = otherFactors;
 
                 var expectedSummary = otherFactors.Keys
                     .Select(EnumHelpers<TransferBenefits.OtherFactor>.GetDisplayValue)

--- a/Frontend.Tests/ModelTests/TransferDatesViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/TransferDatesViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Data.Models;
+using Data.Models.Projects;
 using Frontend.Models;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Frontend.Tests.ModelTests
         public void GivenFirstDiscussedDate_ReturnsTheCorrectDateViewModel(string inputDate, string expectedDay,
             string expectedMonth, string expectedYear)
         {
-            var project = new Project {TransferDates = new TransferDates {FirstDiscussed = inputDate}};
+            var project = new Project {Dates = new TransferDates {FirstDiscussed = inputDate}};
             var model = new TransferDatesViewModel {Project = project};
             Assert.Equal(expectedDay, model.TransferFirstDiscussed.Day);
             Assert.Equal(expectedMonth, model.TransferFirstDiscussed.Month);
@@ -29,7 +30,7 @@ namespace Frontend.Tests.ModelTests
         public void GivenTargetTransferDate_ReturnsTheCorrectDateViewModel(string inputDate, string expectedDay,
             string expectedMonth, string expectedYear)
         {
-            var project = new Project {TransferDates = new TransferDates {Target = inputDate}};
+            var project = new Project {Dates = new TransferDates {Target = inputDate}};
             var model = new TransferDatesViewModel {Project = project};
             Assert.Equal(expectedDay, model.TargetDate.Day);
             Assert.Equal(expectedMonth, model.TargetDate.Month);
@@ -54,7 +55,7 @@ namespace Frontend.Tests.ModelTests
                 "Monday 2 November 2020", "Tuesday 1 December 2020", "Friday 1 January 2021"
             };
 
-            var project = new Project {TransferDates = new TransferDates {Htb = "03/08/2020"}};
+            var project = new Project {Dates = new TransferDates {Htb = "03/08/2020"}};
             var model = new TransferDatesViewModel {Project = project};
             var htbDates = model.PotentialHtbDates("02/01/2020");
 
@@ -66,7 +67,7 @@ namespace Frontend.Tests.ModelTests
         [Fact]
         public void GivenStartingHtbDateIsFirstWorkingDayInMonth_GenerateHtbDatesIncludingThatDate()
         {
-            var project = new Project {TransferDates = new TransferDates {Htb = "03/08/2020"}};
+            var project = new Project {Dates = new TransferDates {Htb = "03/08/2020"}};
             var model = new TransferDatesViewModel {Project = project};
             var htbDates = model.PotentialHtbDates("03/02/2020");
             Assert.Equal("03/02/2020", htbDates[0].Value);
@@ -75,7 +76,7 @@ namespace Frontend.Tests.ModelTests
         [Fact]
         public void GivenStartingHtbDateIsNotFirstWorkingDayInMonth_GenerateHtbDatesExcludingThatDate()
         {
-            var project = new Project {TransferDates = new TransferDates {Htb = "03/08/2020"}};
+            var project = new Project {Dates = new TransferDates {Htb = "03/08/2020"}};
             var model = new TransferDatesViewModel {Project = project};
             var htbDates = model.PotentialHtbDates("07/02/2020");
             Assert.Equal("02/03/2020", htbDates[0].Value);

--- a/Frontend/Controllers/Projects/BenefitsController.cs
+++ b/Frontend/Controllers/Projects/BenefitsController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Data;
 using Data.Models;
+using Data.Models.Projects;
 using Frontend.Helpers;
 using Frontend.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -51,11 +52,11 @@ namespace Frontend.Controllers.Projects
             TransferBenefits.IntendedBenefit[] intendedBenefits, string otherBenefit)
         {
             var model = await GetModel(urn);
-            model.Project.TransferBenefits.IntendedBenefits =
+            model.Project.Benefits.IntendedBenefits =
                 new List<TransferBenefits.IntendedBenefit>(intendedBenefits);
-            model.Project.TransferBenefits.OtherIntendedBenefit = otherBenefit;
+            model.Project.Benefits.OtherIntendedBenefit = otherBenefit;
 
-            if (model.Project.TransferBenefits.IntendedBenefits.Count == 0)
+            if (model.Project.Benefits.IntendedBenefits.Count == 0)
             {
                 var firstBenefit =
                     EnumHelpers<TransferBenefits.IntendedBenefit>.GetDisplayableValues(TransferBenefits.IntendedBenefit
@@ -65,7 +66,7 @@ namespace Frontend.Controllers.Projects
                 return View(model);
             }
 
-            if (model.Project.TransferBenefits.IntendedBenefits.Contains(TransferBenefits.IntendedBenefit.Other) &&
+            if (model.Project.Benefits.IntendedBenefits.Contains(TransferBenefits.IntendedBenefit.Other) &&
                 string.IsNullOrEmpty(otherBenefit))
             {
                 model.FormErrors.AddError("otherBenefit", "otherBenefit", "Please enter the other benefit");
@@ -108,7 +109,7 @@ namespace Frontend.Controllers.Projects
                 projectFactors.Add(TransferBenefits.OtherFactor.FinanceAndDebtConcerns, financeAndDebtDescription);
             }
 
-            model.Project.TransferBenefits.OtherFactors = projectFactors;
+            model.Project.Benefits.OtherFactors = projectFactors;
             await _projectsRepository.Update(model.Project);
             return RedirectToAction("Index", new {urn});
         }

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -39,7 +39,7 @@ namespace Frontend.Controllers.Projects
         {
             var model = await GetModel(urn);
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
-            model.Project.TransferDates.FirstDiscussed = dateString;
+            model.Project.Dates.FirstDiscussed = dateString;
 
             if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
             {
@@ -70,7 +70,7 @@ namespace Frontend.Controllers.Projects
         {
             var model = await GetModel(urn);
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
-            model.Project.TransferDates.Target = dateString;
+            model.Project.Dates.Target = dateString;
 
             if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
             {
@@ -100,7 +100,7 @@ namespace Frontend.Controllers.Projects
         public async Task<IActionResult> HtbDatePost(string urn, string htbDate)
         {
             var model = await GetModel(urn);
-            model.Project.TransferDates.Htb = htbDate;
+            model.Project.Dates.Htb = htbDate;
 
             if (string.IsNullOrEmpty(htbDate))
             {

--- a/Frontend/Models/BenefitsViewModel.cs
+++ b/Frontend/Models/BenefitsViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Data.Models;
+using Data.Models.Projects;
 using Frontend.Helpers;
 using Frontend.Models.Forms;
 
@@ -18,14 +19,14 @@ namespace Frontend.Models
 
         public List<string> IntendedBenefitsSummary()
         {
-            var summary = Project.TransferBenefits.IntendedBenefits
+            var summary = Project.Benefits.IntendedBenefits
                 .FindAll(EnumHelpers<TransferBenefits.IntendedBenefit>.HasDisplayValue)
                 .Select(EnumHelpers<TransferBenefits.IntendedBenefit>.GetDisplayValue)
                 .ToList();
 
-            if (Project.TransferBenefits.IntendedBenefits.Contains(TransferBenefits.IntendedBenefit.Other))
+            if (Project.Benefits.IntendedBenefits.Contains(TransferBenefits.IntendedBenefit.Other))
             {
-                summary.Add($"Other: {Project.TransferBenefits.OtherIntendedBenefit}");
+                summary.Add($"Other: {Project.Benefits.OtherIntendedBenefit}");
             }
 
             return summary;
@@ -33,7 +34,7 @@ namespace Frontend.Models
 
         public List<string[]> OtherFactorsSummary()
         {
-            return Project.TransferBenefits.OtherFactors.Select(otherFactor => new[]
+            return Project.Benefits.OtherFactors.Select(otherFactor => new[]
             {
                 EnumHelpers<TransferBenefits.OtherFactor>.GetDisplayValue(otherFactor.Key),
                 otherFactor.Value

--- a/Frontend/Models/TransferDatesViewModel.cs
+++ b/Frontend/Models/TransferDatesViewModel.cs
@@ -16,8 +16,8 @@ namespace Frontend.Models
             FormErrors = new FormErrorsViewModel();
         }
 
-        public DateInputViewModel TransferFirstDiscussed => DateInputForField(Project.TransferDates.FirstDiscussed);
-        public DateInputViewModel TargetDate => DateInputForField(Project.TransferDates.Target);
+        public DateInputViewModel TransferFirstDiscussed => DateInputForField(Project.Dates.FirstDiscussed);
+        public DateInputViewModel TargetDate => DateInputForField(Project.Dates.Target);
 
         private static DateInputViewModel DateInputForField(string transferDatesFirstDiscussed)
         {
@@ -33,7 +33,7 @@ namespace Frontend.Models
             {
                 Name = "htbDate", Value = DatesHelper.DateTimeToDateString(htbDate),
                 DisplayName = htbDate.ToString("dddd d MMMM yyyy"),
-                Checked = Project.TransferDates.Htb == DatesHelper.DateTimeToDateString(htbDate)
+                Checked = Project.Dates.Htb == DatesHelper.DateTimeToDateString(htbDate)
             }).ToList();
         }
     }

--- a/Frontend/Views/Benefits/Index.cshtml
+++ b/Frontend/Views/Benefits/Index.cshtml
@@ -35,7 +35,7 @@
                 <dt class="govuk-summary-list__key">
                     What are the benefits the transfer intended to bring?
                 </dt>
-                @if (Model.Project.TransferBenefits.IntendedBenefits.Count == 0)
+                @if (Model.Project.Benefits.IntendedBenefits.Count == 0)
                 {
                     <dd class="govuk-summary-list__value">
                         <span class="dfe-empty-tag">Empty</span>
@@ -63,7 +63,7 @@
                     Are there any other factors to consider during this transfer?
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    @if (Model.Project.TransferBenefits.OtherFactors.Keys.Count == 0)
+                    @if (Model.Project.Benefits.OtherFactors.Keys.Count == 0)
                     {
                         <span class="dfe-empty-tag">Empty</span>
                     }

--- a/Frontend/Views/Benefits/IntendedBenefits.cshtml
+++ b/Frontend/Views/Benefits/IntendedBenefits.cshtml
@@ -1,5 +1,6 @@
 @using Frontend.Helpers
 @using Data.Models
+@using Data.Models.Projects
 @model BenefitsViewModel
 
 @{
@@ -41,7 +42,7 @@
                         @foreach (var intendedBenefit in EnumHelpers<TransferBenefits.IntendedBenefit>.GetDisplayableValues(TransferBenefits.IntendedBenefit.Empty))
                         {
                             <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="@intendedBenefit.ToString()" name="intendedBenefits" type="checkbox" value="@intendedBenefit.ToString()" checked="@Model.Project.TransferBenefits.IntendedBenefits.Contains(intendedBenefit)">
+                                <input class="govuk-checkboxes__input" id="@intendedBenefit.ToString()" name="intendedBenefits" type="checkbox" value="@intendedBenefit.ToString()" checked="@Model.Project.Benefits.IntendedBenefits.Contains(intendedBenefit)">
                                 <label class="govuk-label govuk-checkboxes__label" for="@intendedBenefit.ToString()">
                                     @{
                                         var displayValue = EnumHelpers<TransferBenefits.IntendedBenefit>.GetDisplayValue(intendedBenefit);
@@ -56,7 +57,7 @@
                         }
 
                         <div class="govuk-checkboxes__item">
-                            <input class="govuk-checkboxes__input" id="@otherBenefit" name="intendedBenefits" type="checkbox" value="@otherBenefit" aria-controls="conditional-other-benefit" aria-expanded="false" checked="@Model.Project.TransferBenefits.IntendedBenefits.Contains(TransferBenefits.IntendedBenefit.Other)">
+                            <input class="govuk-checkboxes__input" id="@otherBenefit" name="intendedBenefits" type="checkbox" value="@otherBenefit" aria-controls="conditional-other-benefit" aria-expanded="false" checked="@Model.Project.Benefits.IntendedBenefits.Contains(TransferBenefits.IntendedBenefit.Other)">
                             <label class="govuk-label govuk-checkboxes__label" for="@otherBenefit">
                                 Add an other benefit
                             </label>

--- a/Frontend/Views/Benefits/OtherFactors.cshtml
+++ b/Frontend/Views/Benefits/OtherFactors.cshtml
@@ -1,11 +1,12 @@
 @using Data.Models
+@using Data.Models.Projects
 @using Frontend.Helpers
 @model BenefitsViewModel
 
 @{
     ViewBag.Title = "title";
     Layout = "_Layout";
-    var otherFactors = Model.Project.TransferBenefits.OtherFactors;
+    var otherFactors = Model.Project.Benefits.OtherFactors;
 
     var highProfileChecked = otherFactors.ContainsKey(TransferBenefits.OtherFactor.HighProfile);
     var highProfile = new[]

--- a/Frontend/Views/TransferDates/HtbDate.cshtml
+++ b/Frontend/Views/TransferDates/HtbDate.cshtml
@@ -4,7 +4,7 @@
 @{
     ViewBag.Title = "Set HTB date";
     Layout = "_Layout";
-    var htbDate = Model.Project.TransferDates.Htb;
+    var htbDate = Model.Project.Dates.Htb;
     var htbStartDate = string.IsNullOrEmpty(htbDate) ? DatesHelper.DateTimeToDateString(DateTime.Today) : htbDate;
     var formClasses = Model.FormErrors.FormClassesForField("htbDate");
 }

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -4,7 +4,7 @@
 @{
     ViewBag.Title = "Set transfer dates";
     Layout = "_Layout";
-    var transferDates = Model.Project.TransferDates;
+    var transferDates = Model.Project.Dates;
 }
 
 @section BeforeMain


### PR DESCRIPTION
### Context

In preparation for adding a new editable section - this PR adds a new field to the Project model.

Additionally, this cleans up some redundant naming on fields in the project model

### Changes proposed in this pull request

- Add Rationale field to project
- Remove "Transfer" from the names of fields that it was redundant on
### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

