### PR TITLE
Removed current framework from performance page

### DIFF
--- a/Data.Mock/MockAcademyRepository.cs
+++ b/Data.Mock/MockAcademyRepository.cs
@@ -26,7 +26,6 @@ namespace Data.Mock
                     DistanceToSponsorHq = "Placeholder",
                     MpAndParty = "Placeholder",
                     OfstedJudgementDate = "Placeholder",
-                    CurrentFramework = "Placeholder",
                     AchievementOfPupil = "Placeholder",
                     QualityOfTeaching = "Placeholder",
                     BehaviourAndSafetyOfPupil = "Placeholder",

--- a/Data/Models/Academies/AcademyPerformance.cs
+++ b/Data/Models/Academies/AcademyPerformance.cs
@@ -17,7 +17,6 @@ namespace Data.Models.Academies
         public string DistanceToSponsorHq { get; set; }
         public string MpAndParty { get; set; }
         public string OfstedJudgementDate { get; set; }
-        public string CurrentFramework { get; set; }
         public string AchievementOfPupil { get; set; }
         public string QualityOfTeaching { get; set; }
         public string BehaviourAndSafetyOfPupil { get; set; }
@@ -40,7 +39,6 @@ namespace Data.Models.Academies
                 new FormField {Title = "Distance to sponsor HQ", Value = DistanceToSponsorHq},
                 new FormField {Title = "MP (Party)", Value = MpAndParty},
                 new FormField {Title = "Ofsted judgement date", Value = OfstedJudgementDate},
-                new FormField {Title = "Current framework", Value = CurrentFramework},
                 new FormField {Title = "Achievement of pupil", Value = AchievementOfPupil},
                 new FormField {Title = "Quality of teaching", Value = QualityOfTeaching},
                 new FormField {Title = "Behaviour and safety of pupil", Value = BehaviourAndSafetyOfPupil},


### PR DESCRIPTION
### Context

Remove "current framework" from academy performance page

### Changes proposed in this pull request

- Removed "current framework" from academy performance page

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

