### PR TITLE
Increase width of rationale display

### DIFF
--- a/Frontend/Views/Rationale/Index.cshtml
+++ b/Frontend/Views/Rationale/Index.cshtml
@@ -32,7 +32,7 @@
                 <dt class="govuk-summary-list__key">
                     Rationale for project
                 </dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-width-full">
                     @if (string.IsNullOrEmpty(Model.Project.Rationale.Project))
                     {
                         <span class="dfe-empty-tag">Empty</span>
@@ -52,7 +52,7 @@
                 <dt class="govuk-summary-list__key">
                     Rationale for the trust or sponsor
                 </dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-width-full">
                     @if (string.IsNullOrEmpty(Model.Project.Rationale.Trust))
                     {
                         <span class="dfe-empty-tag">Empty</span>


### PR DESCRIPTION
### Context

Rationale's are typically quite lengthy, in order to ease reading this we want to increase the width of the column they're displayed in

### Changes proposed in this pull request

- Add Govuk full width classes to the rationales in the summary list

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

