### PR TITLE
Update API Classes to match current naming

### DIFF
--- a/Data.Mock/MockProjectRepository.cs
+++ b/Data.Mock/MockProjectRepository.cs
@@ -82,13 +82,13 @@ namespace Data.Mock
                 Urn = EmptyProjectUrn,
                 Name = EmptyProjectNumber,
                 OutgoingTrustName = OutgoingTrustName,
-                OutgoingTrustUkprn = "1111111",
+                OutgoingTrustUkprn = "10060295",
                 TransferringAcademies = new List<TransferringAcademies>
                 {
                     new TransferringAcademies
                     {
-                        OutgoingAcademyUkprn = "3333333",
-                        IncomingTrustUkprn = "2222222"
+                        OutgoingAcademyUkprn = "10040290",
+                        IncomingTrustUkprn = "10059766"
                     }
                 }
             };
@@ -101,13 +101,13 @@ namespace Data.Mock
                 Urn = PopulatedProjectUrn,
                 Name = PopulatedProjectNumber,
                 OutgoingTrustName = OutgoingTrustName,
-                OutgoingTrustUkprn = "1111111",
+                OutgoingTrustUkprn = "10060295",
                 TransferringAcademies = new List<TransferringAcademies>
                 {
                     new TransferringAcademies
                     {
-                        OutgoingAcademyUkprn = "3333333",
-                        IncomingTrustUkprn = "2222222"
+                        OutgoingAcademyUkprn = "10040290",
+                        IncomingTrustUkprn = "10059766"
                     }
                 },
                 Features = new TransferFeatures

--- a/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
@@ -33,7 +33,7 @@ namespace Data.TRAMS.Tests
 
                 await _subject.GetAcademyByUkprn("12345");
 
-                _client.Verify(c => c.GetAsync("academy/12345"), Times.Once);
+                _client.Verify(c => c.GetAsync("establishment/12345"), Times.Once);
             }
 
             [Fact]

--- a/Data.TRAMS/Models/AcademyTransferProjectFeatures.cs
+++ b/Data.TRAMS/Models/AcademyTransferProjectFeatures.cs
@@ -1,0 +1,10 @@
+namespace Data.TRAMS.Models
+{
+    public class AcademyTransferProjectFeatures
+    {
+        public bool RddOrEsfaIntervention { get; set; }
+        public string RddOrEsfaInterventionDetail { get; set; }
+        public string TypeOfTransfer { get; set; }
+        public string WhoInitiatedTheTransfer { get; set; }
+    }
+}

--- a/Data.TRAMS/Models/Census.cs
+++ b/Data.TRAMS/Models/Census.cs
@@ -4,10 +4,10 @@ namespace Data.TRAMS.Models
 {
     public class Census
     {
-        [JsonProperty("census_date")] public string CensusDate { get; set; }
-        [JsonProperty("number_of_pupils")] public string NumberOfPupils { get; set; }
-        [JsonProperty("number_of_boys")] public string NumberOfBoys { get; set; }
-        [JsonProperty("number_of_girls")] public string NumberOfGirls { get; set; }
-        [JsonProperty("percentage_fsm")] public string PercentageFsm { get; set; }
+        public string CensusDate { get; set; }
+        public string NumberOfBoys { get; set; }
+        public string NumberOfGirls { get; set; }
+        public string NumberOfPupils { get; set; }
+        public string PercentageFsm { get; set; }
     }
 }

--- a/Data.TRAMS/Models/GroupContactAddress.cs
+++ b/Data.TRAMS/Models/GroupContactAddress.cs
@@ -1,8 +1,6 @@
-using Newtonsoft.Json;
-
 namespace Data.TRAMS.Models
 {
-    public class Address
+    public class GroupContactAddress
     {
         public string AdditionalLine { get; set; }
         public string County { get; set; }

--- a/Data.TRAMS/Models/MisEstablishment.cs
+++ b/Data.TRAMS/Models/MisEstablishment.cs
@@ -1,179 +1,75 @@
-using Newtonsoft.Json;
-
 namespace Data.TRAMS.Models
 {
     public class MisEstablishment
     {
-        [JsonProperty("site_name")] public string SiteName { get; set; }
-        [JsonProperty("web_link")] public string WebLink { get; set; }
-        [JsonProperty("LAESTAB")] public string Laestab { get; set; }
-        [JsonProperty("school_name")] public string SchoolName { get; set; }
-        [JsonProperty("ofsted_phase")] public string OfstedPhase { get; set; }
-        [JsonProperty("type_of_education")] public string TypeOfEducation { get; set; }
-        [JsonProperty("school_open_date")] public string SchoolOpenDate { get; set; }
-        [JsonProperty("sixth_form")] public string SixthForm { get; set; }
-
-        [JsonProperty("designated_religious_character")]
-        public string DesignatedReligiousCharacter { get; set; }
-
-        [JsonProperty("religious_ethos")] public string ReligiousEthos { get; set; }
-        [JsonProperty("faith_grouping")] public string FaithGrouping { get; set; }
-        [JsonProperty("ofsted_region")] public string OfstedRegion { get; set; }
-        [JsonProperty("region")] public string Region { get; set; }
-        [JsonProperty("local_authority")] public string LocalAuthority { get; set; }
-
-        [JsonProperty("parliamentary_constituency")]
-        public string ParliamentaryConstituency { get; set; }
-
-        [JsonProperty("postcode")] public string Postcode { get; set; }
-
-        [JsonProperty("income_deprivation_affecting_children_index_quintile")]
-        public string IncomeDeprivationAffectingChildrenIndexQuintile { get; set; }
-
-        [JsonProperty("total_number_of_pupils")]
-        public string TotalNumberOfPupils { get; set; }
-
-        [JsonProperty("latest_section_8_inspection_number_since_last_full_inspection")]
-        public string LatestSection8InspectionNumberSinceLastFullInspection { get; set; }
-
-        [JsonProperty("section_8_inspection_related_to_curren_school_urn")]
-        public string Section8InspectionRelatedToCurrenSchoolUrn { get; set; }
-
-        [JsonProperty("urn_at_time_of_section_8_inspection")]
-        public string UrnAtTimeOfSection8Inspection { get; set; }
-
-        [JsonProperty("LAESTAB_at_time_of_section_8_inspection")]
-        public string LaestabAtTimeOfSection8Inspection { get; set; }
-
-        [JsonProperty("school_name_at_time_of_section_8_inspection")]
-        public string SchoolNameAtTimeOfSection8Inspection { get; set; }
-
-        [JsonProperty("school_type_at_time_of_section_8_inspection")]
-        public string SchoolTypeAtTimeOfSection8Inspection { get; set; }
-
-        [JsonProperty("number_of_section_8_inspections_since_last_full_inspection")]
-        public string NumberOfSection8InspectionsSinceLastFullInspection { get; set; }
-
-        [JsonProperty("number_of_other_section_8_inspections_since_last_full_inspection")]
-        public string NumberOfOtherSection8InspectionsSinceLastFullInspection { get; set; }
-
-        [JsonProperty("date_of_latest_section_8_inspection")]
-        public string DateOfLatestSection8Inspection { get; set; }
-
-        [JsonProperty("section_8_inspection_publication_date")]
-        public string Section8InspectionPublicationDate { get; set; }
-
-        [JsonProperty("latest_section_8_inspection_converted_to_full_inspection")]
-        public string LatestSection8InspectionConvertedToFullInspection { get; set; }
-
-        [JsonProperty("section_8_inspection_overall_outcome")]
-        public string Section8InspectionOverallOutcome { get; set; }
-
-        [JsonProperty("inspection_number_of_latest_full_inspection")]
-        public string InspectionNumberOfLatestFullInspection { get; set; }
-
-        [JsonProperty("inspection_type")] public string InspectionType { get; set; }
-
-        [JsonProperty("inspection_type_grouping")]
-        public string InspectionTypeGrouping { get; set; }
-
-        [JsonProperty("event_type_grouping")] public string EventTypeGrouping { get; set; }
-
-        [JsonProperty("inspection_start_date")]
-        public string InspectionStartDate { get; set; }
-
-        [JsonProperty("inspection_end_date")] public string InspectionEndDate { get; set; }
-        [JsonProperty("publication_date")] public string PublicationDate { get; set; }
-
-        [JsonProperty("latest_full_inspection_relates_to_current_school_urn")]
-        public string LatestFullInspectionRelatesToCurrentSchoolUrn { get; set; }
-
-        [JsonProperty("school_urn_at_time_of_last_full_inspection")]
-        public string SchoolUrnAtTimeOfLastFullInspection { get; set; }
-
-        [JsonProperty("LAESTAB_at_time_of_last_full_inspection")]
-        public string LaestabAtTimeOfLastFullInspection { get; set; }
-
-        [JsonProperty("school_name_at_time_of_last_full_inspection")]
-        public string SchoolNameAtTimeOfLastFullInspection { get; set; }
-
-        [JsonProperty("school_type_at_time_of_last_full_inspection")]
-        public string SchoolTypeAtTimeOfLastFullInspection { get; set; }
-
-        [JsonProperty("overall_effectiveness")]
-        public string OverallEffectiveness { get; set; }
-
-        [JsonProperty("category_of_concern")] public string CategoryOfConcern { get; set; }
-        [JsonProperty("quality_of_education")] public string QualityOfEducation { get; set; }
-
-        [JsonProperty("behaviour_and_attitudes")]
         public string BehaviourAndAttitudes { get; set; }
-
-        [JsonProperty("personal_development")] public string PersonalDevelopment { get; set; }
-
-        [JsonProperty("effectiveness_of_leadership_and_management")]
-        public string EffectivenessOfLeadershipAndManagement { get; set; }
-
-        [JsonProperty("safeguarding_is_effective")]
-        public string SafeguardingIsEffective { get; set; }
-
-        [JsonProperty("early_years_provision")]
+        public string CategoryOfConcern { get; set; }
+        public string DateOfLatestSection8Inspection { get; set; }
+        public string DesignatedReligiousCharacter { get; set; }
         public string EarlyYearsProvision { get; set; }
-
-        [JsonProperty("sixth_form_provision")] public string SixthFormProvision { get; set; }
-
-        [JsonProperty("previous_full_inspection_number")]
-        public string PreviousFullInspectionNumber { get; set; }
-
-        [JsonProperty("previous_inspection_start_date")]
-        public string PreviousInspectionStartDate { get; set; }
-
-        [JsonProperty("previous_inspection_end_date")]
-        public string PreviousInspectionEndDate { get; set; }
-
-        [JsonProperty("previous_publication_date")]
-        public string PreviousPublicationDate { get; set; }
-
-        [JsonProperty("previous_full_inspection_relates_to_urn_of_current_school")]
-        public string PreviousFullInspectionRelatesToUrnOfCurrentSchool { get; set; }
-
-        [JsonProperty("urn_at_the_time_of_previous_full_inspection")]
-        public string UrnAtTheTimeOfPreviousFullInspection { get; set; }
-
-        [JsonProperty("LAESTAB_at_the_time_of_previous_full_inspection")]
+        public string EffectivenessOfLeadershipAndManagement { get; set; }
+        public string EventTypeGrouping { get; set; }
+        public string FaithGrouping { get; set; }
+        public string IncomeDeprivationAffectingChildrenIndexQuintile { get; set; }
+        public string InspectionEndDate { get; set; }
+        public string InspectionNumberOfLatestFullInspection { get; set; }
+        public string InspectionStartDate { get; set; }
+        public string InspectionType { get; set; }
+        public string InspectionTypeGrouping { get; set; }
+        public string Laestab { get; set; }
         public string LaestabAtTheTimeOfPreviousFullInspection { get; set; }
-
-        [JsonProperty("school_name_at_the_time_of_previous_full_inspection")]
-        public string SchoolNameAtTheTimeOfPreviousFullInspection { get; set; }
-
-        [JsonProperty("school_type_at_the_time_of_previous_full_inspection")]
-        public string SchoolTypeAtTheTimeOfPreviousFullInspection { get; set; }
-
-        [JsonProperty("previous_full_inspection_overall_effectiveness")]
-        public string PreviousFullInspectionOverallEffectiveness { get; set; }
-
-        [JsonProperty("previous_category_of_concern")]
-        public string PreviousCategoryOfConcern { get; set; }
-
-        [JsonProperty("previous_quality_of_education")]
-        public string PreviousQualityOfEducation { get; set; }
-
-        [JsonProperty("previous_behaviour_and_attitudes")]
+        public string LaestabAtTimeOfLastFullInspection { get; set; }
+        public string LaestabAtTimeOfSection8Inspection { get; set; }
+        public string LatestFullInspectionRelatesToCurrentSchoolUrn { get; set; }
+        public string LatestSection8InspectionConvertedToFullInspection { get; set; }
+        public string LatestSection8InspectionNumberSinceLastFullInspection { get; set; }
+        public string LocalAuthority { get; set; }
+        public string NumberOfOtherSection8InspectionsSinceLastFullInspection { get; set; }
+        public string NumberOfSection8InspectionsSinceLastFullInspection { get; set; }
+        public string OfstedPhase { get; set; }
+        public string OfstedRegion { get; set; }
+        public string OverallEffectiveness { get; set; }
+        public string ParliamentaryConstituency { get; set; }
+        public string PersonalDevelopment { get; set; }
+        public string Postcode { get; set; }
         public string PreviousBehaviourAndAttitudes { get; set; }
-
-        [JsonProperty("previous_personal_development")]
-        public string PreviousPersonalDevelopment { get; set; }
-
-        [JsonProperty("previous_effectiveness_of_leadership_and_management")]
-        public string PreviousEffectivenessOfLeadershipAndManagement { get; set; }
-
-        [JsonProperty("previous_is_safeguarding_effective")]
-        public string PreviousIsSafeguardingEffective { get; set; }
-
-        [JsonProperty("previous_early_years_provision")]
+        public string PreviousCategoryOfConcern { get; set; }
         public string PreviousEarlyYearsProvision { get; set; }
-
-        [JsonProperty("previous_sixth_form_provision")]
+        public string PreviousEffectivenessOfLeadershipAndManagement { get; set; }
+        public string PreviousFullInspectionNumber { get; set; }
+        public string PreviousFullInspectionOverallEffectiveness { get; set; }
+        public string PreviousFullInspectionRelatesToUrnOfCurrentSchool { get; set; }
+        public string PreviousInspectionEndDate { get; set; }
+        public string PreviousInspectionStartDate { get; set; }
+        public string PreviousIsSafeguardingEffective { get; set; }
+        public string PreviousPersonalDevelopment { get; set; }
+        public string PreviousPublicationDate { get; set; }
+        public string PreviousQualityOfEducation { get; set; }
         public string PreviousSixthFormProvision { get; set; }
+        public string PublicationDate { get; set; }
+        public string QualityOfEducation { get; set; }
+        public string Region { get; set; }
+        public string ReligiousEthos { get; set; }
+        public string SafeguardingIsEffective { get; set; }
+        public string SchoolName { get; set; }
+        public string SchoolNameAtTheTimeOfPreviousFullInspection { get; set; }
+        public string SchoolNameAtTimeOfLastFullInspection { get; set; }
+        public string SchoolNameAtTimeOfSection8Inspection { get; set; }
+        public string SchoolOpenDate { get; set; }
+        public string SchoolTypeAtTheTimeOfPreviousFullInspection { get; set; }
+        public string SchoolTypeAtTimeOfLastFullInspection { get; set; }
+        public string SchoolTypeAtTimeOfSection8Inspection { get; set; }
+        public string SchoolUrnAtTimeOfLastFullInspection { get; set; }
+        public string Section8InspectionOverallOutcome { get; set; }
+        public string Section8InspectionPublicationDate { get; set; }
+        public string Section8InspectionRelatedToCurrenSchoolUrn { get; set; }
+        public string SiteName { get; set; }
+        public string SixthForm { get; set; }
+        public string SixthFormProvision { get; set; }
+        public string TotalNumberOfPupils { get; set; }
+        public string TypeOfEducation { get; set; }
+        public string UrnAtTheTimeOfPreviousFullInspection { get; set; }
+        public string UrnAtTimeOfSection8Inspection { get; set; }
+        public string WebLink { get; set; }
     }
 }

--- a/Data.TRAMS/Models/Misfea.cs
+++ b/Data.TRAMS/Models/Misfea.cs
@@ -1,75 +1,33 @@
-using Newtonsoft.Json;
-
 namespace Data.TRAMS.Models
 {
     public class Misfea
     {
-        [JsonProperty("provider")] public Provider Provider { get; set; }
-        [JsonProperty("local_authority")] public string LocalAuthority { get; set; }
-        [JsonProperty("region")] public string Region { get; set; }
-        [JsonProperty("ofsted_region")] public string OfstedRegion { get; set; }
-
-        [JsonProperty("date_of_latest_short_inspection")]
-        public string DateOfLatestShortInspection { get; set; }
-
-        [JsonProperty("number_of_short_inspections_since_last_full_inspection_RAW")]
-        public string NumberOfShortInspectionsSinceLastFullInspectionRaw { get; set; }
-
-        [JsonProperty("number_of_short_inspections_since_last_full_inspection")]
-        public string NumberOfShortInspectionsSinceLastFullInspection { get; set; }
-
-        [JsonProperty("inspection_number")] public string InspectionNumber { get; set; }
-        [JsonProperty("inspection_type")] public string InspectionType { get; set; }
-
-        [JsonProperty("first_day_of_inspection")]
-        public string FirstDayOfInspection { get; set; }
-
-        [JsonProperty("last_day_of_inspection")]
-        public string LastDayOfInspection { get; set; }
-
-        [JsonProperty("date_published")] public string DatePublished { get; set; }
-
-        [JsonProperty("overall_effectiveness_RAW")]
-        public string OverallEffectivenessRaw { get; set; }
-
-        [JsonProperty("overall_effectiveness")]
-        public string OverallEffectiveness { get; set; }
-
-        [JsonProperty("quality_of_education_RAW")]
-        public string QualityOfEducationRaw { get; set; }
-
-        [JsonProperty("quality_of_education")] public string QualityOfEducation { get; set; }
-
-        [JsonProperty("behaviour_and_attitudes_RAW")]
-        public string BehaviourAndAttitudesRaw { get; set; }
-
-        [JsonProperty("behaviour_and_attitudes")]
         public string BehaviourAndAttitudes { get; set; }
-
-        [JsonProperty("personal_development_RAW")]
-        public string PersonalDevelopmentRaw { get; set; }
-
-        [JsonProperty("personal_development")] public string PersonalDevelopment { get; set; }
-
-        [JsonProperty("effectiveness_of_leadership_and_management_RAW")]
-        public string EffectivenessOfLeadershipAndManagementRaw { get; set; }
-
-        [JsonProperty("effectiveness_of_leadership_and_management")]
+        public string BehaviourAndAttitudesRaw { get; set; }
+        public string DateOfLatestShortInspection { get; set; }
+        public string DatePublished { get; set; }
         public string EffectivenessOfLeadershipAndManagement { get; set; }
-
-        [JsonProperty("is_safeguarding_effective")]
+        public string EffectivenessOfLeadershipAndManagementRaw { get; set; }
+        public string FirstDayOfInspection { get; set; }
+        public string InspectionNumber { get; set; }
+        public string InspectionType { get; set; }
         public string IsSafeguardingEffective { get; set; }
-
-        [JsonProperty("previous_inspection_number")]
+        public string LastDayOfInspection { get; set; }
+        public string LocalAuthority { get; set; }
+        public string NumberOfShortInspectionsSinceLastFullInspection { get; set; }
+        public string NumberOfShortInspectionsSinceLastFullInspectionRaw { get; set; }
+        public string OfstedRegion { get; set; }
+        public string OverallEffectiveness { get; set; }
+        public string OverallEffectivenessRaw { get; set; }
+        public string PersonalDevelopment { get; set; }
+        public string PersonalDevelopmentRaw { get; set; }
         public string PreviousInspectionNumber { get; set; }
-
-        [JsonProperty("previous_last_day_of_inspection")]
         public string PreviousLastDayOfInspection { get; set; }
-
-        [JsonProperty("previous_overall_effectiveness_RAW")]
-        public string PreviousOverallEffectivenessRaw { get; set; }
-
-        [JsonProperty("previous_overall_effectiveness")]
         public string PreviousOverallEffectiveness { get; set; }
+        public string PreviousOverallEffectivenessRaw { get; set; }
+        public Provider Provider { get; set; }
+        public string QualityOfEducation { get; set; }
+        public string QualityOfEducationRaw { get; set; }
+        public string Region { get; set; }
     }
 }

--- a/Data.TRAMS/Models/Provider.cs
+++ b/Data.TRAMS/Models/Provider.cs
@@ -1,13 +1,11 @@
-using Newtonsoft.Json;
-
 namespace Data.TRAMS.Models
 {
     public class Provider
     {
-        [JsonProperty("URN")] public string Urn { get; set; }
-        [JsonProperty("UKPRN")] public string Ukprn { get; set; }
-        [JsonProperty("name")] public string Name { get; set; }
-        [JsonProperty("type")] public string Type { get; set; }
-        [JsonProperty("group")] public string Group { get; set; }
+        public string Group { get; set; }
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public string Ukprn { get; set; }
+        public string Urn { get; set; }
     }
 }

--- a/Data.TRAMS/Models/SmartData.cs
+++ b/Data.TRAMS/Models/SmartData.cs
@@ -1,28 +1,14 @@
-using Newtonsoft.Json;
-
 namespace Data.TRAMS.Models
 {
     public class SmartData
     {
-        [JsonProperty("probability_of_declining")]
-        public string ProbabilityOfDeclining { get; set; }
-
-        [JsonProperty("probability_of_staying_the_same")]
-        public string ProbabilityOfStayingTheSame { get; set; }
-
-        [JsonProperty("probability_of_improving")]
-        public string ProbabilityOfImproving { get; set; }
-
-        [JsonProperty("predicted_change_in_progress_8_score")]
-        public string PredictedChangeInProgress8Score { get; set; }
-
-        [JsonProperty("predicted_chance_of_change_occurring")]
         public string PredictedChanceOfChangeOccurring { get; set; }
-
-        [JsonProperty("total_number_of_risks")]
+        public string PredictedChangeInProgress8Score { get; set; }
+        public string ProbabilityOfDeclining { get; set; }
+        public string ProbabilityOfImproving { get; set; }
+        public string ProbabilityOfStayingTheSame { get; set; }
+        public string RiskRatingNum { get; set; }
         public string TotalNumberOfRisks { get; set; }
-
-        [JsonProperty("total_risk_score")] public string TotalRiskScore { get; set; }
-        [JsonProperty("risk_rating_num")] public string RiskRatingNum { get; set; }
+        public string TotalRiskScore { get; set; }
     }
 }

--- a/Data.TRAMS/Models/TramsAcademy.cs
+++ b/Data.TRAMS/Models/TramsAcademy.cs
@@ -1,166 +1,109 @@
-using Newtonsoft.Json;
-
 namespace Data.TRAMS.Models
 {
     public class TramsAcademy
     {
-        [JsonProperty("urn")] public string Urn { get; set; }
-        [JsonProperty("local_authority_code")] public string LocalAuthorityCode { get; set; }
-        [JsonProperty("local_authority_name")] public string LocalAuthorityName { get; set; }
-        [JsonProperty("establishment_number")] public string EstablishmentNumber { get; set; }
-        [JsonProperty("establishment_name")] public string EstablishmentName { get; set; }
-        [JsonProperty("establishment_type")] public NameAndCode EstablishmentType { get; set; }
-
-        [JsonProperty("establishment_type_group_code")]
-        public string EstablishmentTypeGroupCode { get; set; }
-
-        [JsonProperty("establishment_status")] public NameAndCode EstablishmentStatus { get; set; }
-
-        [JsonProperty("reason_establishment_opened")]
-        public NameAndCode ReasonEstablishmentOpened { get; set; }
-
-        [JsonProperty("open_date")] public string OpenDate { get; set; }
-
-        [JsonProperty("reason_establishment_closed")]
-        public NameAndCode ReasonEstablishmentClosed { get; set; }
-
-        [JsonProperty("close_date")] public string CloseDate { get; set; }
-        [JsonProperty("phase_of_education")] public NameAndCode PhaseOfEducation { get; set; }
-        [JsonProperty("statutory_low_age")] public string StatutoryLowAge { get; set; }
-        [JsonProperty("statutory_high_age")] public string StatutoryHighAge { get; set; }
-        [JsonProperty("boarders")] public NameAndCode Boarders { get; set; }
-        [JsonProperty("nursery_provision")] public string NurseryProvision { get; set; }
-        [JsonProperty("official_sixth_form")] public NameAndCode OfficialSixthForm { get; set; }
-        [JsonProperty("gender")] public NameAndCode Gender { get; set; }
-        [JsonProperty("religious_character")] public NameAndCode ReligiousCharacter { get; set; }
-        [JsonProperty("religious_ethos")] public string ReligiousEthos { get; set; }
-        [JsonProperty("diocese")] public NameAndCode Diocese { get; set; }
-        [JsonProperty("admissions_policy")] public NameAndCode AdmissionsPolicy { get; set; }
-        [JsonProperty("school_capacity")] public string SchoolCapacity { get; set; }
-        [JsonProperty("special_classes")] public NameAndCode SpecialClasses { get; set; }
-        [JsonProperty("census")] public Census Census { get; set; }
-        [JsonProperty("trust_school_flag")] public NameAndCode TrustSchoolFlag { get; set; }
-        [JsonProperty("trusts")] public NameAndCode Trusts { get; set; }
-        [JsonProperty("school_sponsor_flag")] public string SchoolSponsorFlag { get; set; }
-        [JsonProperty("school_sponsors")] public string SchoolSponsors { get; set; }
-        [JsonProperty("federation_flag")] public string FederationFlag { get; set; }
-        [JsonProperty("federations")] public NameAndCode Federations { get; set; }
-        [JsonProperty("ukprn")] public string Ukprn { get; set; }
-        [JsonProperty("fehei_identifier")] public string FeheiIdentifier { get; set; }
-
-        [JsonProperty("further_education_type")]
-        public string FurtherEducationType { get; set; }
-
-        [JsonProperty("ofsted_last_inspection")]
-        public string OfstedLastInspection { get; set; }
-
-        [JsonProperty("ofsted_special_measures")]
-        public NameAndCode OfstedSpecialMeasures { get; set; }
-
-        [JsonProperty("last_changed_date")] public string LastChangedDate { get; set; }
-        [JsonProperty("address")] public Address Address { get; set; }
-        [JsonProperty("school_website")] public string SchoolWebsite { get; set; }
-        [JsonProperty("telephone_number")] public string TelephoneNumber { get; set; }
-        [JsonProperty("headteacher_title")] public string HeadteacherTitle { get; set; }
-
-        [JsonProperty("headteacher_first_name")]
-        public string HeadteacherFirstName { get; set; }
-
-        [JsonProperty("headteacher_last_name")]
-        public string HeadteacherLastName { get; set; }
-
-        [JsonProperty("headteacher_preferred_job_title")]
-        public string HeadteacherPreferredJobTitle { get; set; }
-
-        [JsonProperty("inspectorate")] public string Inspectorate { get; set; }
-        [JsonProperty("inspectorate_name")] public string InspectorateName { get; set; }
-        [JsonProperty("inspectorate_report")] public string InspectorateReport { get; set; }
-
-        [JsonProperty("date_of_last_inspection_visit")]
-        public string DateOfLastInspectionVisit { get; set; }
-
-        [JsonProperty("date_of_next_inspection_visit")]
-        public string DateOfNextInspectionVisit { get; set; }
-
-        [JsonProperty("teen_moth")] public string TeenMoth { get; set; }
-        [JsonProperty("teen_moth_places")] public string TeenMothPlaces { get; set; }
-        [JsonProperty("CCF")] public string Ccf { get; set; }
-        [JsonProperty("SENPRU")] public string Senpru { get; set; }
-        [JsonProperty("EBD")] public string Ebd { get; set; }
-        [JsonProperty("places_PRU")] public string PlacesPru { get; set; }
-        [JsonProperty("FTProv")] public string FtProv { get; set; }
-        [JsonProperty("ed_by_other")] public string EdByOther { get; set; }
-        [JsonProperty("section_14_approved")] public string Section14Approved { get; set; }
-        [JsonProperty("SEN1")] public string Sen1 { get; set; }
-        [JsonProperty("SEN2")] public string Sen2 { get; set; }
-        [JsonProperty("SEN3")] public string Sen3 { get; set; }
-        [JsonProperty("SEN4")] public string Sen4 { get; set; }
-        [JsonProperty("SEN5")] public string Sen5 { get; set; }
-        [JsonProperty("SEN6")] public string Sen6 { get; set; }
-        [JsonProperty("SEN7")] public string Sen7 { get; set; }
-        [JsonProperty("SEN8")] public string Sen8 { get; set; }
-        [JsonProperty("SEN9")] public string Sen9 { get; set; }
-        [JsonProperty("SEN10")] public string Sen10 { get; set; }
-        [JsonProperty("SEN11")] public string Sen11 { get; set; }
-        [JsonProperty("SEN12")] public string Sen12 { get; set; }
-        [JsonProperty("SEN13")] public string Sen13 { get; set; }
-
-        [JsonProperty("type_of_resourced_provision")]
-        public string TypeOfResourcedProvision { get; set; }
-
-        [JsonProperty("resourced_provision_on_roll")]
-        public string ResourcedProvisionOnRoll { get; set; }
-
-        [JsonProperty("resourced_provision_on_capacity")]
-        public string ResourcedProvisionOnCapacity { get; set; }
-
-        [JsonProperty("sen_unit_on_roll")] public string SenUnitOnRoll { get; set; }
-        [JsonProperty("sen_unit_capacity")] public string SenUnitCapacity { get; set; }
-        [JsonProperty("GOR")] public NameAndCode Gor { get; set; }
-
-        [JsonProperty("district_administrative")]
-        public NameAndCode DistrictAdministrative { get; set; }
-
-        [JsonProperty("administrative_ward")] public NameAndCode AdministrativeWard { get; set; }
-
-        [JsonProperty("parliamentary_constituency")]
-        public NameAndCode ParliamentaryConstituency { get; set; }
-
-        [JsonProperty("urban_rural")] public NameAndCode UrbanRural { get; set; }
-        [JsonProperty("GSSLA_code")] public string GsslaCode { get; set; }
-        [JsonProperty("easting")] public string Easting { get; set; }
-        [JsonProperty("northing")] public string Northing { get; set; }
-
-        [JsonProperty("census_area_statistic_ward")]
-        public string CensusAreaStatisticWard { get; set; }
-
-        [JsonProperty("MSOA")] public NameAndCode Msoa { get; set; }
-        [JsonProperty("LSOA")] public NameAndCode Lsoa { get; set; }
-        [JsonProperty("SENStat")] public string SenStat { get; set; }
-        [JsonProperty("SENNoStat")] public string SenNoStat { get; set; }
-
-        [JsonProperty("boarding_establishment")]
+        public Address Address { get; set; }
+        public NameAndCode AdministrativeWard { get; set; }
+        public NameAndCode AdmissionsPolicy { get; set; }
+        public NameAndCode Boarders { get; set; }
         public string BoardingEstablishment { get; set; }
-
-        [JsonProperty("props_name")] public string PropsName { get; set; }
-
-        [JsonProperty("previous_local_authority")]
-        public NameAndCode PreviousLocalAuthority { get; set; }
-
-        [JsonProperty("previous_establishment_number")]
-        public string PreviousEstablishmentNumber { get; set; }
-
-        [JsonProperty("ofsted_rating")] public string OfstedRating { get; set; }
-        [JsonProperty("RSC_region")] public string RscRegion { get; set; }
-        [JsonProperty("country")] public string Country { get; set; }
-        [JsonProperty("UPRN")] public string Uprn { get; set; }
-        [JsonProperty("MIS_establishment")] public MisEstablishment MisEstablishment { get; set; }
-
-        [JsonProperty("MIS_further_education_establishment")]
+        public string Ccf { get; set; }
+        public Census Census { get; set; }
+        public string CensusAreaStatisticWard { get; set; }
+        public string CloseDate { get; set; }
+        public Placeholder Concerns { get; set; }
+        public string Country { get; set; }
+        public string DateOfLastInspectionVisit { get; set; }
+        public string DateOfNextInspectionVisit { get; set; }
+        public NameAndCode Diocese { get; set; }
+        public NameAndCode DistrictAdministrative { get; set; }
+        public string Easting { get; set; }
+        public string Ebd { get; set; }
+        public string EdByOther { get; set; }
+        public string EstablishmentName { get; set; }
+        public string EstablishmentNumber { get; set; }
+        public NameAndCode EstablishmentStatus { get; set; }
+        public NameAndCode EstablishmentType { get; set; }
+        public string EstablishmentTypeGroupCode { get; set; }
+        public string FederationFlag { get; set; }
+        public NameAndCode Federations { get; set; }
+        public string FeheiIdentifier { get; set; }
+        public Placeholder Financial { get; set; }
+        public string FtProv { get; set; }
+        public string FurtherEducationType { get; set; }
+        public NameAndCode Gender { get; set; }
+        public NameAndCode Gor { get; set; }
+        public string GsslaCode { get; set; }
+        public string HeadteacherFirstName { get; set; }
+        public string HeadteacherLastName { get; set; }
+        public string HeadteacherPreferredJobTitle { get; set; }
+        public string HeadteacherTitle { get; set; }
+        public string Inspectorate { get; set; }
+        public string InspectorateName { get; set; }
+        public string InspectorateReport { get; set; }
+        public string LastChangedDate { get; set; }
+        public string LocalAuthorityCode { get; set; }
+        public string LocalAuthorityName { get; set; }
+        public NameAndCode Lsoa { get; set; }
+        public MisEstablishment MisEstablishment { get; set; }
         public Misfea MisFurtherEducationEstablishment { get; set; }
-
-        [JsonProperty("SMART_data")] public SmartData SmartData { get; set; }
-        [JsonProperty("financial")] public Placeholder Financial { get; set; }
-        [JsonProperty("concerns")] public Placeholder Concerns { get; set; }
+        public NameAndCode Msoa { get; set; }
+        public string Northing { get; set; }
+        public string NurseryProvision { get; set; }
+        public NameAndCode OfficialSixthForm { get; set; }
+        public string OfstedLastInspection { get; set; }
+        public string OfstedRating { get; set; }
+        public NameAndCode OfstedSpecialMeasures { get; set; }
+        public string OpenDate { get; set; }
+        public NameAndCode ParliamentaryConstituency { get; set; }
+        public NameAndCode PhaseOfEducation { get; set; }
+        public string PlacesPru { get; set; }
+        public string PreviousEstablishmentNumber { get; set; }
+        public NameAndCode PreviousLocalAuthority { get; set; }
+        public string PropsName { get; set; }
+        public NameAndCode ReasonEstablishmentClosed { get; set; }
+        public NameAndCode ReasonEstablishmentOpened { get; set; }
+        public NameAndCode ReligiousCharacter { get; set; }
+        public string ReligiousEthos { get; set; }
+        public string ResourcedProvisionOnCapacity { get; set; }
+        public string ResourcedProvisionOnRoll { get; set; }
+        public string RscRegion { get; set; }
+        public string SchoolCapacity { get; set; }
+        public string SchoolSponsorFlag { get; set; }
+        public string SchoolSponsors { get; set; }
+        public string SchoolWebsite { get; set; }
+        public string Section14Approved { get; set; }
+        public string Sen1 { get; set; }
+        public string Sen10 { get; set; }
+        public string Sen11 { get; set; }
+        public string Sen12 { get; set; }
+        public string Sen13 { get; set; }
+        public string Sen2 { get; set; }
+        public string Sen3 { get; set; }
+        public string Sen4 { get; set; }
+        public string Sen5 { get; set; }
+        public string Sen6 { get; set; }
+        public string Sen7 { get; set; }
+        public string Sen8 { get; set; }
+        public string Sen9 { get; set; }
+        public string SenNoStat { get; set; }
+        public string Senpru { get; set; }
+        public string SenStat { get; set; }
+        public string SenUnitCapacity { get; set; }
+        public string SenUnitOnRoll { get; set; }
+        public SmartData SmartData { get; set; }
+        public NameAndCode SpecialClasses { get; set; }
+        public string StatutoryHighAge { get; set; }
+        public string StatutoryLowAge { get; set; }
+        public string TeenMoth { get; set; }
+        public string TeenMothPlaces { get; set; }
+        public string TelephoneNumber { get; set; }
+        public NameAndCode Trusts { get; set; }
+        public NameAndCode TrustSchoolFlag { get; set; }
+        public string TypeOfResourcedProvision { get; set; }
+        public string Ukprn { get; set; }
+        public string Uprn { get; set; }
+        public NameAndCode UrbanRural { get; set; }
+        public string Urn { get; set; }
     }
 }

--- a/Data.TRAMS/Models/TramsProject.cs
+++ b/Data.TRAMS/Models/TramsProject.cs
@@ -1,37 +1,12 @@
-using Newtonsoft.Json;
-
 namespace Data.TRAMS.Models
 {
     public class TramsProject
     {
-        [JsonProperty("project_urn")] public string ProjectUrn { get; set; }
-        [JsonProperty("outgoing_trust_urn")] public string OutgoingTrustUrn { get; set; }
-
-        [JsonProperty("transferring_academies")]
+        public AcademyTransferProjectFeatures Features { get; set; }
+        public string OutgoingTrustUrn { get; set; }
+        public string ProjectUrn { get; set; }
+        public string State { get; set; }
+        public string Status { get; set; }
         public TransferringAcademy TransferringAcademies { get; set; }
-
-        [JsonProperty("features")] public AcademyTransferProjectFeatures Features { get; set; }
-        [JsonProperty("state")] public string State { get; set; }
-        [JsonProperty("status")] public string Status { get; set; }
-    }
-
-    public class AcademyTransferProjectFeatures
-    {
-        [JsonProperty("who_initiated_the_transfer")]
-        public string WhoInitiatedTheTransfer { get; set; }
-
-        [JsonProperty("rdd_or_esfa_intervention")]
-        public bool RddOrEsfaIntervention { get; set; }
-
-        [JsonProperty("rdd_or_esfa_intervention_detail")]
-        public string RddOrEsfaInterventionDetail { get; set; }
-
-        [JsonProperty("type_of_transfer")] public string TypeOfTransfer { get; set; }
-    }
-
-    public class TransferringAcademy
-    {
-        [JsonProperty("outgoing_academy_urn")] public string OutgoingAcademyUrn { get; set; }
-        [JsonProperty("incoming_trust_urn")] public string IncomingTrustUrn { get; set; }
     }
 }

--- a/Data.TRAMS/Models/TramsTrust.cs
+++ b/Data.TRAMS/Models/TramsTrust.cs
@@ -1,88 +1,11 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Data.TRAMS.Models
 {
     public class TramsTrust
     {
-        [JsonProperty("ifd_data")] public TramsTrustIfdData IfdData { get; set; }
-        [JsonProperty("gias_data")] public TramsTrustGiasData GiasData { get; set; }
-        [JsonProperty("academies")] public List<TramsAcademy> Academies { get; set; }
-    }
-
-
-    public class TramsTrustIfdData
-    {
-        [JsonProperty("trust_open_date")] public string TrustOpenDate { get; set; }
-        [JsonProperty("lead_RSC_region")] public string LeadRscRegion { get; set; }
-
-        [JsonProperty("trust_contact_phone_number")]
-        public string TrustContactPhoneNumber { get; set; }
-
-        [JsonProperty("performance_and_risk_date_of_meeting")]
-        public string PerformanceAndRiskDateOfMeeting { get; set; }
-
-        [JsonProperty("prioritised_area_of_review")]
-        public string PrioritisedAreaOfReview { get; set; }
-
-        [JsonProperty("current_single_list_grouping")]
-        public string CurrentSingleListGrouping { get; set; }
-
-        [JsonProperty("date_of_grouping_decision")]
-        public string DateOfGroupingDecision { get; set; }
-
-        [JsonProperty("date_entered_onto_single_list")]
-        public string DateEnteredOntoSingleList { get; set; }
-
-        [JsonProperty("trust_review_writeup")] public string TrustReviewWriteup { get; set; }
-
-        [JsonProperty("date_of_trust_review_meeting")]
-        public string DateOfTrustReviewMeeting { get; set; }
-
-        [JsonProperty("followup_letter_sent")] public string FollowupLetterSent { get; set; }
-
-        [JsonProperty("date_action_planned_for")]
-        public string DateActionPlannedFor { get; set; }
-
-        [JsonProperty("WIP_summary_goes_to_minister")]
-        public string WipSummaryGoesToMinister { get; set; }
-
-        [JsonProperty("external_governance_review_date")]
-        public string ExternalGovernanceReviewDate { get; set; }
-
-        [JsonProperty("efficiency_ICF_preview_completed")]
-        public string EfficiencyIcfPreviewCompleted { get; set; }
-
-        [JsonProperty("efficiency_ICF_preview_other")]
-        public string EfficiencyIcfPreviewOther { get; set; }
-
-        [JsonProperty("link_to_workplace_for_efficiency_ICF_review")]
-        public string LinkToWorkplaceForEfficiencyIcfReview { get; set; }
-
-        [JsonProperty("number_in_trust")] public string NumberInTrust { get; set; }
-    }
-
-    public class TramsTrustGiasData
-    {
-        [JsonProperty("group_id")] public string GroupId { get; set; }
-        [JsonProperty("group_name")] public string GroupName { get; set; }
-
-        [JsonProperty("companies_house_number")]
-        public string CompaniesHouseNumber { get; set; }
-
-        [JsonProperty("group_contact_address")]
-        public GroupContactAddress GroupContactAddress { get; set; }
-
-        [JsonProperty("ukprn")] public string Ukprn { get; set; }
-    }
-
-    public class GroupContactAddress
-    {
-        [JsonProperty("street")] public string Street { get; set; }
-        [JsonProperty("locality")] public string Locality { get; set; }
-        [JsonProperty("additional_line")] public string AdditionalLine { get; set; }
-        [JsonProperty("town")] public string Town { get; set; }
-        [JsonProperty("county")] public string County { get; set; }
-        [JsonProperty("postcode")] public string Postcode { get; set; }
+        public List<TramsAcademy> Academies { get; set; }
+        public TramsTrustGiasData GiasData { get; set; }
+        public TramsTrustIfdData IfdData { get; set; }
     }
 }

--- a/Data.TRAMS/Models/TramsTrustGiasData.cs
+++ b/Data.TRAMS/Models/TramsTrustGiasData.cs
@@ -1,0 +1,11 @@
+namespace Data.TRAMS.Models
+{
+    public class TramsTrustGiasData
+    {
+        public string CompaniesHouseNumber { get; set; }
+        public GroupContactAddress GroupContactAddress { get; set; }
+        public string GroupId { get; set; }
+        public string GroupName { get; set; }
+        public string Ukprn { get; set; }
+    }
+}

--- a/Data.TRAMS/Models/TramsTrustIfdData.cs
+++ b/Data.TRAMS/Models/TramsTrustIfdData.cs
@@ -1,0 +1,24 @@
+namespace Data.TRAMS.Models
+{
+    public class TramsTrustIfdData
+    {
+        public string CurrentSingleListGrouping { get; set; }
+        public string DateActionPlannedFor { get; set; }
+        public string DateEnteredOntoSingleList { get; set; }
+        public string DateOfGroupingDecision { get; set; }
+        public string DateOfTrustReviewMeeting { get; set; }
+        public string EfficiencyIcfPreviewCompleted { get; set; }
+        public string EfficiencyIcfPreviewOther { get; set; }
+        public string ExternalGovernanceReviewDate { get; set; }
+        public string FollowupLetterSent { get; set; }
+        public string LeadRscRegion { get; set; }
+        public string LinkToWorkplaceForEfficiencyIcfReview { get; set; }
+        public string NumberInTrust { get; set; }
+        public string PerformanceAndRiskDateOfMeeting { get; set; }
+        public string PrioritisedAreaOfReview { get; set; }
+        public string TrustContactPhoneNumber { get; set; }
+        public string TrustOpenDate { get; set; }
+        public string TrustReviewWriteup { get; set; }
+        public string WipSummaryGoesToMinister { get; set; }
+    }
+}

--- a/Data.TRAMS/Models/TramsTrustSearchAcademy.cs
+++ b/Data.TRAMS/Models/TramsTrustSearchAcademy.cs
@@ -1,8 +1,8 @@
 namespace Data.TRAMS.Models
 {
-    public class NameAndCode
+    public class TramsTrustSearchAcademy
     {
-        public string Code { get; set; }
         public string Name { get; set; }
+        public string Urn { get; set; }
     }
 }

--- a/Data.TRAMS/Models/TramsTrustSearchResult.cs
+++ b/Data.TRAMS/Models/TramsTrustSearchResult.cs
@@ -5,18 +5,9 @@ namespace Data.TRAMS.Models
 {
     public class TramsTrustSearchResult
     {
-        [JsonProperty("urn")] public string Urn { get; set; }
-        [JsonProperty("group_name")] public string GroupName { get; set; }
-
-        [JsonProperty("companies_house_number")]
+        public List<TramsTrustSearchAcademy> Academies { get; set; }
         public string CompaniesHouseNumber { get; set; }
-
-        [JsonProperty("academies")] public List<TramsTrustSearchAcademy> Academies { get; set; }
-    }
-
-    public class TramsTrustSearchAcademy
-    {
-        [JsonProperty("urn")] public string Urn { get; set; }
-        [JsonProperty("name")] public string Name { get; set; }
+        public string GroupName { get; set; }
+         public string Urn { get; set; }
     }
 }

--- a/Data.TRAMS/Models/TransferringAcademy.cs
+++ b/Data.TRAMS/Models/TransferringAcademy.cs
@@ -1,0 +1,8 @@
+namespace Data.TRAMS.Models
+{
+    public class TransferringAcademy
+    {
+        public string IncomingTrustUrn { get; set; }
+        public string OutgoingAcademyUrn { get; set; }
+    }
+}

--- a/Data.TRAMS/TramsAcademiesRepository.cs
+++ b/Data.TRAMS/TramsAcademiesRepository.cs
@@ -18,7 +18,7 @@ namespace Data.TRAMS
 
         public async Task<RepositoryResult<Academy>> GetAcademyByUkprn(string ukprn)
         {
-            using var response = await _httpClient.GetAsync($"academy/{ukprn}");
+            using var response = await _httpClient.GetAsync($"establishment/{ukprn}");
 
             var apiResponse = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<TramsAcademy>(apiResponse);

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -149,12 +149,13 @@ namespace Frontend
             else
             {
                 services.AddSingleton(new TramsHttpClient(tramsApiBase, tramsApiKey));
-                services.AddSingleton<ITramsHttpClient>(r => new TramsHttpClient(tramsApiBase, tramsApiBase));
+                services.AddSingleton<ITramsHttpClient>(r => new TramsHttpClient(tramsApiBase, tramsApiKey));
                 services.AddTransient<IMapper<TramsTrustSearchResult, TrustSearchResult>, TramsSearchResultMapper>();
                 services.AddTransient<IMapper<TramsTrust, Trust>, TramsTrustMapper>();
                 services.AddTransient<IMapper<TramsAcademy, Academy>, TramsAcademyMapper>();
                 services.AddTransient<ITrusts, TramsTrustsRepository>();
                 services.AddTransient<IAcademies, TramsAcademiesRepository>();
+                services.AddSingleton<IProjects, MockProjectRepository>();
             }
         }
 


### PR DESCRIPTION
### Context

The API spec changed recently to not be camel case, this PR brings the API classes in line with the new specification by removing the JSON Property fields

### Changes proposed in this pull request

- Fix TRAMS Api class setups
- Remove JSONProperties

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

