### PR TITLE
Change trust links to radio buttons on search-incoming-trust page

### DIFF
--- a/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
@@ -1,4 +1,4 @@
-@model Frontend.Views.Transfers.TrustSearch 
+@model Frontend.Views.Transfers.TrustSearch
 
 @{
     ViewBag.Title = "Select an incoming trust";
@@ -7,28 +7,40 @@
 
 @section BeforeMain
 {
-    @if ((bool) ViewData["ChangeLink"])
-    {
-        <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrust" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"]">Back</a>
-    }
-    else
-    {
-        <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrust" asp-route-query="@ViewData["Query"]">Back</a>
-    }
+    <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrust" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"]">Back</a>
 }
 
-<h1 class="govuk-heading-xl">Select an incoming trust</h1>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        @foreach (var trust in Model.Trusts)
-        {
-            <h2 class="govuk-heading-s">
-                <a class="govuk-link" asp-action="IncomingTrustDetails" asp-route-trustId="@trust.Ukprn" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"].ToString()">
-                    @trust.TrustName
-                </a>
-            </h2>
-            <p class="govuk-body">Companies House number: @trust.CompaniesHouseNumber</p>
-            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
-        }
+        <form class="govuk-form" asp-action="IncomingTrustDetails" method="get">
+            <input type="text" name="query" value="@ViewData["Query"]" hidden />
+            <input type="text" name="change" value="@ViewData["ChangeLink"].ToString()" hidden />
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                        <h1 class="govuk-fieldset__heading">
+                            Select an incoming trust
+                        </h1>
+                    </legend>
+                    <div class="govuk-radios">
+                        @foreach (var trust in Model.Trusts)
+                        {
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="@trust.Ukprn" name="trustId" type="radio" value="@trust.Ukprn" aria-describedby="@trust.Ukprn-hint" />
+                                <label class="govuk-label govuk-radios__label" for="@trust.Ukprn">
+                                    @trust.TrustName (@trust.Ukprn)
+                                </label>
+                                <div id="@trust.Ukprn-hint" class="govuk-hint govuk-radios__hint">
+                                    Companies House number: @trust.CompaniesHouseNumber
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </fieldset>
+            </div>
+            <button class="govuk-button" data-module="govuk-button">
+                Continue
+            </button>
+        </form>
     </div>
 </div>

--- a/Frontend/Views/Transfers/TrustSearch.cshtml
+++ b/Frontend/Views/Transfers/TrustSearch.cshtml
@@ -25,10 +25,6 @@
                     <div class="govuk-radios">
                         @foreach (var trust in Model.Trusts)
                         {
-                            <h2 class="govuk-heading-s">
-                                <a class="govuk-link" asp-action="OutgoingTrustDetails" asp-route-trustId="@trust.Ukprn" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"]">
-                                </a>
-                            </h2>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="@trust.Ukprn" name="trustId" type="radio" value="@trust.Ukprn" aria-describedby="@trust.Ukprn-hint">
                                 <label class="govuk-label govuk-radios__label" for="@trust.Ukprn">


### PR DESCRIPTION
### Context

Update the incoming trust links displayed on the search-incoming-trust page to be radio buttons

### Changes proposed in this pull request

- Update links to be radio buttons
- Amend title size
- Add URN in brackets after the trust name

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

