### PR TITLE
Map TRAMS trusts from API

### DIFF
--- a/Data.TRAMS.Tests/Mappers/Response/TramsEstablishmentMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsEstablishmentMapperTests.cs
@@ -8,19 +8,19 @@ using Xunit;
 
 namespace Data.TRAMS.Tests.Mappers.Response
 {
-    public class TramsAcademyMapperTests
+    public class TramsEstablishmentMapperTests
     {
-        private readonly TramsAcademyMapper _subject;
+        private readonly TramsEstablishmentMapper _subject;
 
-        public TramsAcademyMapperTests()
+        public TramsEstablishmentMapperTests()
         {
-            _subject = new TramsAcademyMapper();
+            _subject = new TramsEstablishmentMapper();
         }
 
         [Fact]
         public void GivenTramsAcademy_MapsToInternalAcademySuccessfully()
         {
-            var academyToMap = new TramsAcademy
+            var academyToMap = new TramsEstablishment
             {
                 Address = new Address
                 {
@@ -46,7 +46,8 @@ namespace Data.TRAMS.Tests.Mappers.Response
                     OverallEffectiveness = "1",
                     PersonalDevelopment = "3",
                     QualityOfEducation = "4",
-                    SixthFormProvision = "1",
+                    ReligiousEthos = "Does not apply",
+                    SixthFormProvision = "1"
                 },
                 SchoolCapacity = "1000",
                 StatutoryLowAge = "4",
@@ -54,13 +55,15 @@ namespace Data.TRAMS.Tests.Mappers.Response
                 OfstedLastInspection = "01-01-2020",
                 OfstedRating = "Good",
                 PhaseOfEducation = new NameAndCode {Name = "Primary"},
-                Ukprn = "Ukprn"
+                Ukprn = "Ukprn",
+                Urn = "Urn"
             };
 
             var result = _subject.Map(academyToMap);
             var expectedAddress = new List<string> {"Example street", "Town", "Fakeshire", "FA11 1KE"};
 
             Assert.Equal(academyToMap.Ukprn, result.Ukprn);
+            Assert.Equal(academyToMap.Urn, result.Urn);
             Assert.Equal(academyToMap.EstablishmentName, result.Name);
             Assert.Equal(expectedAddress, result.Address);
             Assert.Equal(academyToMap.LocalAuthorityName, result.LocalAuthorityName);
@@ -86,29 +89,29 @@ namespace Data.TRAMS.Tests.Mappers.Response
             Assert.Equal("01-01-2020", latestOfstedJudgement.InspectionDate);
         }
 
-        private static void AssertAcademyPerformanceCorrect(Academy result, TramsAcademy academyToMap)
+        private static void AssertAcademyPerformanceCorrect(Academy result, TramsEstablishment establishmentToMap)
         {
-            var expectedAgeRange = $"{academyToMap.StatutoryLowAge} to {academyToMap.StatutoryHighAge}";
-            var expectedPercentageFull = ExpectedPercentageFull(academyToMap);
+            var expectedAgeRange = $"{establishmentToMap.StatutoryLowAge} to {establishmentToMap.StatutoryHighAge}";
+            var expectedPercentageFull = ExpectedPercentageFull(establishmentToMap);
             var performance = result.Performance;
-            Assert.Equal(academyToMap.PhaseOfEducation.Name, performance.SchoolPhase);
+            Assert.Equal(establishmentToMap.PhaseOfEducation.Name, performance.SchoolPhase);
             Assert.Equal(expectedAgeRange, performance.AgeRange);
-            Assert.Equal(academyToMap.SchoolCapacity, performance.Capacity);
-            Assert.Equal(academyToMap.Census.NumberOfPupils, performance.NumberOnRoll);
+            Assert.Equal(establishmentToMap.SchoolCapacity, performance.Capacity);
+            Assert.Equal(establishmentToMap.Census.NumberOfPupils, performance.NumberOnRoll);
             Assert.Equal(expectedPercentageFull, performance.PercentageFull);
-            Assert.Equal(academyToMap.EstablishmentType.Name, performance.SchoolType);
-            Assert.Equal(academyToMap.OfstedRating, performance.OfstedRating);
-            Assert.Equal(academyToMap.OfstedLastInspection, performance.OfstedJudgementDate);
+            Assert.Equal(establishmentToMap.EstablishmentType.Name, performance.SchoolType);
+            Assert.Equal(establishmentToMap.OfstedRating, performance.OfstedRating);
+            Assert.Equal(establishmentToMap.OfstedLastInspection, performance.OfstedJudgementDate);
             Assert.Equal("Requires improvement", performance.AchievementOfPupil);
             Assert.Equal("Inadequate", performance.QualityOfTeaching);
             Assert.Equal("Outstanding", performance.BehaviourAndSafetyOfPupil);
             Assert.Equal("Good", performance.LeadershipAndManagement);
         }
 
-        private static string ExpectedPercentageFull(TramsAcademy academyToMap)
+        private static string ExpectedPercentageFull(TramsEstablishment establishmentToMap)
         {
-            return Math.Round(decimal.Parse(academyToMap.Census.NumberOfPupils) /
-                decimal.Parse(academyToMap.SchoolCapacity) * 100, 1).ToString(CultureInfo.InvariantCulture);
+            return Math.Round(decimal.Parse(establishmentToMap.Census.NumberOfPupils) /
+                decimal.Parse(establishmentToMap.SchoolCapacity) * 100, 1).ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Data.TRAMS.Tests/Mappers/Response/TramsSearchResultMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsSearchResultMapperTests.cs
@@ -12,15 +12,15 @@ namespace Data.TRAMS.Tests.Mappers.Response
         {
             var subject = new TramsSearchResultMapper();
 
-            var resultToMap = new TramsTrustSearchResult()
+            var resultToMap = new TramsTrustSearchResult
             {
                 Urn = "1234",
                 GroupName = "Group name",
                 CompaniesHouseNumber = "12345",
-                Academies = new List<TramsTrustSearchAcademy>()
+                Establishments = new List<TramsTrustSearchEstablishment>
                 {
-                    new TramsTrustSearchAcademy() {Name = "Academy 1 name", Urn = "0001"},
-                    new TramsTrustSearchAcademy() {Name = "Academy 2 name", Urn = "0002"}
+                    new TramsTrustSearchEstablishment {Name = "Academy 1 name", Urn = "0001", Ukprn = "1001"},
+                    new TramsTrustSearchEstablishment {Name = "Academy 2 name", Urn = "0002", Ukprn = "2001"}
                 }
             };
 
@@ -30,14 +30,16 @@ namespace Data.TRAMS.Tests.Mappers.Response
             Assert.Equal(resultToMap.GroupName, result.TrustName);
             Assert.Equal(resultToMap.CompaniesHouseNumber, result.CompaniesHouseNumber);
 
-            AssertAcademyMappedCorrectly(resultToMap.Academies[0], result.Academies[0]);
-            AssertAcademyMappedCorrectly(resultToMap.Academies[1], result.Academies[1]);
+            AssertAcademyMappedCorrectly(resultToMap.Establishments[0], result.Academies[0]);
+            AssertAcademyMappedCorrectly(resultToMap.Establishments[1], result.Academies[1]);
         }
 
-        private static void AssertAcademyMappedCorrectly(TramsTrustSearchAcademy academyToMap, Data.Models.TrustSearchAcademy mappedAcademy)
+        private static void AssertAcademyMappedCorrectly(TramsTrustSearchEstablishment establishmentToMap,
+            Data.Models.TrustSearchAcademy mappedAcademy)
         {
-            Assert.Equal(academyToMap.Name, mappedAcademy.Name);
-            Assert.Equal(academyToMap.Urn, mappedAcademy.Ukprn);
+            Assert.Equal(establishmentToMap.Name, mappedAcademy.Name);
+            Assert.Equal(establishmentToMap.Urn, mappedAcademy.Urn);
+            Assert.Equal(establishmentToMap.Ukprn, mappedAcademy.Ukprn);
         }
     }
 }

--- a/Data.TRAMS.Tests/Mappers/Response/TramsTrustMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsTrustMapperTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using Data.Models;
+using Data.TRAMS.Mappers.Response;
+using Data.TRAMS.Models;
+using Moq;
+using Xunit;
+
+namespace Data.TRAMS.Tests.Mappers.Response
+{
+    public class TramsTrustMapperTests
+    {
+        private readonly TramsTrustMapper _subject;
+        private readonly Mock<IMapper<TramsEstablishment, Academy>> _establishmentMapper;
+
+        public TramsTrustMapperTests()
+        {
+            _establishmentMapper = new Mock<IMapper<TramsEstablishment, Academy>>();
+            _subject = new TramsTrustMapper(_establishmentMapper.Object);
+        }
+
+        [Fact]
+        public void GivenTramsTrust_ItMapsTrustFieldsCorrectly()
+        {
+            var trustToMap = new TramsTrust
+            {
+                GiasData = new TramsTrustGiasData
+                {
+                    CompaniesHouseNumber = "1231231",
+                    GroupContactAddress = new GroupContactAddress
+                    {
+                        AdditionalLine = "Extra line",
+                        County = "County",
+                        Locality = "Locality",
+                        Postcode = "Postcode",
+                        Street = "Street",
+                        Town = "Town"
+                    },
+                    GroupId = "0001",
+                    GroupName = "Trust name",
+                    Ukprn = "1001"
+                }
+            };
+
+            var result = _subject.Map(trustToMap);
+            var expectedAddress = new List<string> {"Trust name", "Street", "Town", "County, Postcode"};
+
+            Assert.Equal(trustToMap.GiasData.CompaniesHouseNumber, result.CompaniesHouseNumber);
+            Assert.Equal(trustToMap.GiasData.GroupId, result.GiasGroupId);
+            Assert.Equal(trustToMap.GiasData.GroupName, result.Name);
+            Assert.Equal(trustToMap.GiasData.Ukprn, result.Ukprn);
+            Assert.Equal("Not available", result.EstablishmentType);
+            Assert.Equal(expectedAddress, result.Address);
+        }
+
+        [Fact]
+        public void GivenTrustWithOneAcademy_MapASingleAcademy()
+        {
+            _establishmentMapper.Setup(m => m.Map(It.IsAny<TramsEstablishment>()))
+                .Returns<TramsEstablishment>(input => new Academy {Ukprn = $"Mapped {input.Ukprn}"});
+
+            var trustToMap = new TramsTrust
+            {
+                GiasData = new TramsTrustGiasData(),
+                Establishments = new List<TramsEstablishment>
+                {
+                    new TramsEstablishment {Ukprn = "001"}
+                }
+            };
+
+            var result = _subject.Map(trustToMap);
+            _establishmentMapper.Verify(m =>
+                m.Map(It.Is<TramsEstablishment>(establishment => establishment.Ukprn == "001")));
+            Assert.Equal("Mapped 001", result.Academies[0].Ukprn);
+        }
+        
+        [Fact]
+        public void GivenTrustWithTwoAcademies_MapAcademies()
+        {
+            _establishmentMapper.Setup(m => m.Map(It.IsAny<TramsEstablishment>()))
+                .Returns<TramsEstablishment>(input => new Academy {Ukprn = $"Mapped {input.Ukprn}"});
+
+            var trustToMap = new TramsTrust
+            {
+                GiasData = new TramsTrustGiasData(),
+                Establishments = new List<TramsEstablishment>
+                {
+                    new TramsEstablishment {Ukprn = "001"},
+                    new TramsEstablishment {Ukprn = "002"}
+                }
+            };
+
+            var result = _subject.Map(trustToMap);
+            _establishmentMapper.Verify(m =>
+                m.Map(It.Is<TramsEstablishment>(establishment => establishment.Ukprn == "001")));
+            _establishmentMapper.Verify(m =>
+                m.Map(It.Is<TramsEstablishment>(establishment => establishment.Ukprn == "002")));
+            Assert.Equal("Mapped 001", result.Academies[0].Ukprn);
+            Assert.Equal("Mapped 002", result.Academies[1].Ukprn);
+        }
+    }
+}

--- a/Data.TRAMS.Tests/TestFixtures/Establishments.cs
+++ b/Data.TRAMS.Tests/TestFixtures/Establishments.cs
@@ -2,11 +2,11 @@ using Data.TRAMS.Models;
 
 namespace Data.TRAMS.Tests.TestFixtures
 {
-    public class Academies
+    public static class Establishments
     {
-        public static TramsAcademy SingleAcademy()
+        public static TramsEstablishment SingleEstablishment()
         {
-            return new TramsAcademy
+            return new TramsEstablishment
             {
                 Ukprn = "12345",
                 EstablishmentName = "Academy name"

--- a/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
+++ b/Data.TRAMS.Tests/TestFixtures/TrustSearchResults.cs
@@ -16,7 +16,7 @@ namespace Data.TRAMS.Tests.TestFixtures
                 searchResults.Add(
                     new TramsTrustSearchResult
                     {
-                        Academies = new List<TramsTrustSearchAcademy>(),
+                        Establishments = new List<TramsTrustSearchEstablishment>(),
                         CompaniesHouseNumber = counter.ToString(),
                         GroupName = $"Trust {counter}",
                         Urn = counter.ToString()

--- a/Data.TRAMS.Tests/TestFixtures/Trusts.cs
+++ b/Data.TRAMS.Tests/TestFixtures/Trusts.cs
@@ -9,7 +9,7 @@ namespace Data.TRAMS.Tests.TestFixtures
         {
             return new TramsTrust
             {
-                Academies = new List<TramsAcademy>(),
+                Establishments = new List<TramsEstablishment>(),
                 GiasData = new TramsTrustGiasData
                 {
                     Ukprn = "00001",

--- a/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsAcademiesRepositoryTests.cs
@@ -11,14 +11,14 @@ namespace Data.TRAMS.Tests
     public class TramsAcademiesRepositoryTests
     {
         private readonly Mock<ITramsHttpClient> _client;
-        private readonly Mock<IMapper<TramsAcademy, Academy>> _mapper;
-        private readonly TramsAcademiesRepository _subject;
+        private readonly Mock<IMapper<TramsEstablishment, Academy>> _mapper;
+        private readonly TramsEstablishmentRepository _subject;
 
         public TramsAcademiesRepositoryTests()
         {
             _client = new Mock<ITramsHttpClient>();
-            _mapper = new Mock<IMapper<TramsAcademy, Academy>>();
-            _subject = new TramsAcademiesRepository(_client.Object, _mapper.Object);
+            _mapper = new Mock<IMapper<TramsEstablishment, Academy>>();
+            _subject = new TramsEstablishmentRepository(_client.Object, _mapper.Object);
         }
 
         public class GetAcademyByUkprnTests : TramsAcademiesRepositoryTests
@@ -28,7 +28,7 @@ namespace Data.TRAMS.Tests
             {
                 _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
-                    Content = new StringContent(JsonConvert.SerializeObject(Academies.SingleAcademy()))
+                    Content = new StringContent(JsonConvert.SerializeObject(Establishments.SingleEstablishment()))
                 });
 
                 await _subject.GetAcademyByUkprn("12345");
@@ -39,7 +39,7 @@ namespace Data.TRAMS.Tests
             [Fact]
             public async void GivenUkprn_MapFoundAcademy()
             {
-                var academy = Academies.SingleAcademy();
+                var academy = Establishments.SingleEstablishment();
                 _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(JsonConvert.SerializeObject(academy))
@@ -47,20 +47,20 @@ namespace Data.TRAMS.Tests
 
                 await _subject.GetAcademyByUkprn("12345");
 
-                _mapper.Verify(m => m.Map(It.Is<TramsAcademy>(mappedAcademy => mappedAcademy.Ukprn == academy.Ukprn)),
+                _mapper.Verify(m => m.Map(It.Is<TramsEstablishment>(mappedAcademy => mappedAcademy.Ukprn == academy.Ukprn)),
                     Times.Once);
             }
 
             [Fact]
             public async void GivenUkprn_ReturnsMappedAcademy()
             {
-                var academy = Academies.SingleAcademy();
+                var academy = Establishments.SingleEstablishment();
                 _client.Setup(c => c.GetAsync(It.IsAny<string>())).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(JsonConvert.SerializeObject(academy))
                 });
 
-                _mapper.Setup(m => m.Map(It.IsAny<TramsAcademy>())).Returns<TramsAcademy>(input => new Academy
+                _mapper.Setup(m => m.Map(It.IsAny<TramsEstablishment>())).Returns<TramsEstablishment>(input => new Academy
                 {
                     Ukprn = $"Mapped {academy.Ukprn}"
                 });

--- a/Data.TRAMS/Mappers/Response/TramsEstablishmentMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsEstablishmentMapper.cs
@@ -7,14 +7,15 @@ using Data.TRAMS.Models;
 
 namespace Data.TRAMS.Mappers.Response
 {
-    public class TramsAcademyMapper : IMapper<TramsAcademy, Academy>
+    public class TramsEstablishmentMapper : IMapper<TramsEstablishment, Academy>
     {
-        public Academy Map(TramsAcademy input)
+        public Academy Map(TramsEstablishment input)
         {
             return new Academy
             {
                 Address = Address(input),
                 EstablishmentType = input.EstablishmentType.Name,
+                FaithSchool = input.MisEstablishment.ReligiousEthos,
                 LatestOfstedJudgement = LatestOfstedJudgement(input),
                 LocalAuthorityName = input.LocalAuthorityName,
                 Name = input.EstablishmentName,
@@ -24,11 +25,12 @@ namespace Data.TRAMS.Mappers.Response
                     BoysOnRoll = input.Census.NumberOfBoys,
                     GirlsOnRoll = input.Census.NumberOfGirls
                 },
-                Ukprn = input.Ukprn
+                Ukprn = input.Ukprn,
+                Urn = input.Urn
             };
         }
 
-        private static LatestOfstedJudgement LatestOfstedJudgement(TramsAcademy input)
+        private static LatestOfstedJudgement LatestOfstedJudgement(TramsEstablishment input)
         {
             return new LatestOfstedJudgement
             {
@@ -57,7 +59,7 @@ namespace Data.TRAMS.Mappers.Response
             };
         }
 
-        private static AcademyPerformance Performance(TramsAcademy input)
+        private static AcademyPerformance Performance(TramsEstablishment input)
         {
             return new AcademyPerformance
             {
@@ -77,13 +79,13 @@ namespace Data.TRAMS.Mappers.Response
             };
         }
 
-        private static List<string> Address(TramsAcademy input)
+        private static List<string> Address(TramsEstablishment input)
         {
             return new List<string>
                 {input.Address.Street, input.Address.Town, input.Address.County, input.Address.Postcode};
         }
 
-        private static string PercentageFull(TramsAcademy input)
+        private static string PercentageFull(TramsEstablishment input)
         {
             return Math.Round(
                     decimal.Parse(input.Census.NumberOfPupils) / decimal.Parse(input.SchoolCapacity) * 100,

--- a/Data.TRAMS/Mappers/Response/TramsSearchResultMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsSearchResultMapper.cs
@@ -13,9 +13,9 @@ namespace Data.TRAMS.Mappers.Response
                 Ukprn = input.Urn,
                 TrustName = input.GroupName,
                 CompaniesHouseNumber = input.CompaniesHouseNumber,
-                Academies = input.Academies.Select(academy => new TrustSearchAcademy
+                Academies = input.Establishments.Select(establishment => new TrustSearchAcademy
                 {
-                    Name = academy.Name, Ukprn = academy.Urn
+                    Name = establishment.Name, Ukprn = establishment.Ukprn, Urn = establishment.Urn
                 }).ToList()
             };
         }

--- a/Data.TRAMS/Mappers/Response/TramsTrustMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsTrustMapper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Data.Models;
 using Data.TRAMS.Models;
 
@@ -6,23 +7,31 @@ namespace Data.TRAMS.Mappers.Response
 {
     public class TramsTrustMapper : IMapper<TramsTrust, Trust>
     {
+        private IMapper<TramsEstablishment, Academy> _establishmentMapper;
+
+        public TramsTrustMapper(IMapper<TramsEstablishment, Academy> establishmentMapper)
+        {
+            _establishmentMapper = establishmentMapper;
+        }
+
         public Trust Map(TramsTrust input)
         {
             var address = input.GiasData.GroupContactAddress;
             return new Trust
             {
-                Ukprn = input.GiasData.Ukprn,
-                Name = input.GiasData.GroupName,
-                CompaniesHouseNumber = input.GiasData.CompaniesHouseNumber,
-                GiasGroupId = input.GiasData.GroupId,
-                EstablishmentType = "Not available yet",
+                Academies = input.Establishments.Select(e => _establishmentMapper.Map(e)).ToList(),
                 Address = new List<string>
                 {
                     input.GiasData.GroupName,
                     address.Street,
                     address.Town,
-                    $"{address.County}, ${address.Postcode}"
-                }
+                    $"{address.County}, {address.Postcode}"
+                },
+                CompaniesHouseNumber = input.GiasData.CompaniesHouseNumber,
+                EstablishmentType = "Not available",
+                GiasGroupId = input.GiasData.GroupId,
+                Name = input.GiasData.GroupName,
+                Ukprn = input.GiasData.Ukprn
             };
         }
     }

--- a/Data.TRAMS/Models/TramsEstablishment.cs
+++ b/Data.TRAMS/Models/TramsEstablishment.cs
@@ -1,6 +1,6 @@
 namespace Data.TRAMS.Models
 {
-    public class TramsAcademy
+    public class TramsEstablishment
     {
         public Address Address { get; set; }
         public NameAndCode AdministrativeWard { get; set; }

--- a/Data.TRAMS/Models/TramsTrust.cs
+++ b/Data.TRAMS/Models/TramsTrust.cs
@@ -4,7 +4,13 @@ namespace Data.TRAMS.Models
 {
     public class TramsTrust
     {
-        public List<TramsAcademy> Academies { get; set; }
+        public TramsTrust()
+        {
+            Establishments = new List<TramsEstablishment>();
+            GiasData = new TramsTrustGiasData();
+            IfdData = new TramsTrustIfdData();
+        }
+        public List<TramsEstablishment> Establishments { get; set; }
         public TramsTrustGiasData GiasData { get; set; }
         public TramsTrustIfdData IfdData { get; set; }
     }

--- a/Data.TRAMS/Models/TramsTrustGiasData.cs
+++ b/Data.TRAMS/Models/TramsTrustGiasData.cs
@@ -2,6 +2,11 @@ namespace Data.TRAMS.Models
 {
     public class TramsTrustGiasData
     {
+        public TramsTrustGiasData()
+        {
+            GroupContactAddress = new GroupContactAddress();
+        }
+        
         public string CompaniesHouseNumber { get; set; }
         public GroupContactAddress GroupContactAddress { get; set; }
         public string GroupId { get; set; }

--- a/Data.TRAMS/Models/TramsTrustSearchEstablishment.cs
+++ b/Data.TRAMS/Models/TramsTrustSearchEstablishment.cs
@@ -1,8 +1,9 @@
 namespace Data.TRAMS.Models
 {
-    public class TramsTrustSearchAcademy
+    public class TramsTrustSearchEstablishment
     {
         public string Name { get; set; }
+        public string Ukprn { get; set; }
         public string Urn { get; set; }
     }
 }

--- a/Data.TRAMS/Models/TramsTrustSearchResult.cs
+++ b/Data.TRAMS/Models/TramsTrustSearchResult.cs
@@ -5,9 +5,9 @@ namespace Data.TRAMS.Models
 {
     public class TramsTrustSearchResult
     {
-        public List<TramsTrustSearchAcademy> Academies { get; set; }
+        public List<TramsTrustSearchEstablishment> Establishments { get; set; }
         public string CompaniesHouseNumber { get; set; }
         public string GroupName { get; set; }
-         public string Urn { get; set; }
+        public string Urn { get; set; }
     }
 }

--- a/Data.TRAMS/TramsEstablishmentRepository.cs
+++ b/Data.TRAMS/TramsEstablishmentRepository.cs
@@ -5,12 +5,12 @@ using Newtonsoft.Json;
 
 namespace Data.TRAMS
 {
-    public class TramsAcademiesRepository : IAcademies
+    public class TramsEstablishmentRepository : IAcademies
     {
         private readonly ITramsHttpClient _httpClient;
-        private readonly IMapper<TramsAcademy, Academy> _academyMapper;
+        private readonly IMapper<TramsEstablishment, Academy> _academyMapper;
 
-        public TramsAcademiesRepository(ITramsHttpClient httpClient, IMapper<TramsAcademy, Academy> academyMapper)
+        public TramsEstablishmentRepository(ITramsHttpClient httpClient, IMapper<TramsEstablishment, Academy> academyMapper)
         {
             _httpClient = httpClient;
             _academyMapper = academyMapper;
@@ -21,7 +21,7 @@ namespace Data.TRAMS
             using var response = await _httpClient.GetAsync($"establishment/{ukprn}");
 
             var apiResponse = await response.Content.ReadAsStringAsync();
-            var result = JsonConvert.DeserializeObject<TramsAcademy>(apiResponse);
+            var result = JsonConvert.DeserializeObject<TramsEstablishment>(apiResponse);
             var mappedResult = _academyMapper.Map(result);
 
             return new RepositoryResult<Academy> {Result = mappedResult};

--- a/Data/Models/TrustSearchResult.cs
+++ b/Data/Models/TrustSearchResult.cs
@@ -15,6 +15,7 @@ namespace Data.Models
 
     public class TrustSearchAcademy
     {
+        public string Urn { get; set; }
         public string Ukprn { get; set; }
         public string Name { get; set; }
     }

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -152,9 +152,9 @@ namespace Frontend
                 services.AddSingleton<ITramsHttpClient>(r => new TramsHttpClient(tramsApiBase, tramsApiKey));
                 services.AddTransient<IMapper<TramsTrustSearchResult, TrustSearchResult>, TramsSearchResultMapper>();
                 services.AddTransient<IMapper<TramsTrust, Trust>, TramsTrustMapper>();
-                services.AddTransient<IMapper<TramsAcademy, Academy>, TramsAcademyMapper>();
+                services.AddTransient<IMapper<TramsEstablishment, Academy>, TramsEstablishmentMapper>();
                 services.AddTransient<ITrusts, TramsTrustsRepository>();
-                services.AddTransient<IAcademies, TramsAcademiesRepository>();
+                services.AddTransient<IAcademies, TramsEstablishmentRepository>();
                 services.AddSingleton<IProjects, MockProjectRepository>();
             }
         }


### PR DESCRIPTION
### Context

The TRAMS API is now available and as such we can begin the work to map trusts against available data and populate it where required.

In addition, this update some naming conventions to be in line with the TRAMS API

### Changes proposed in this pull request

- Rename TRAMS Academy references to Establishments
- Map TRAMS Trust data

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

