### PR TITLE
Allow users to manually enter an HTB Date

### DIFF
--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -197,32 +197,51 @@ namespace Frontend.Tests.ControllerTests.Projects
             public class PostTests : HtbDateTests
             {
                 [Theory]
-                [InlineData("01/01/2020")]
-                [InlineData("03/02/2020")]
-                public async void GivenUrnAndDate_UpdatesTheProjectWithTheCorrectDate(string htbDate)
+                [InlineData("01", "01", "2020", "01/01/2020")]
+                [InlineData("20", "02", "2021", "20/02/2021")]
+                [InlineData("2", "2", "2021", "02/02/2021")]
+                public async void GivenUrnAndFullDate_UpdatesTheProjectWithTheCorrectDate(string day, string month,
+                    string year, string expectedDate)
                 {
-                    await _subject.HtbDatePost("0001", htbDate);
+                    await _subject.HtbDatePost("0001", day, month, year);
 
                     _projectsRepository.Verify(r =>
-                        r.Update(It.Is<Project>(project => project.Dates.Htb == htbDate)));
+                        r.Update(It.Is<Project>(project => project.Dates.Htb == expectedDate)));
                 }
 
                 [Fact]
-                public async void GivenUrnAndDate_RedirectsToTheSummaryPage()
+                public async void GivenUrnAndFullDate_RedirectsToTheSummaryPage()
                 {
-                    var response = await _subject.HtbDatePost("0001", "03/02/2020");
+                    var response = await _subject.HtbDatePost("0001", "01", "01", "2020");
                     ControllerTestHelpers.AssertResultRedirectsToAction(response, "Index");
                 }
 
-                [Fact]
-                public async void GivenNoHtbDate_CreatesAnErrorOnTheModelAndSetsErrorIdToFirstHtbDate()
+                [Theory]
+                [InlineData(null, "1", "2020")]
+                [InlineData("1", null, "2020")]
+                [InlineData("1", "1", null)]
+                public async void GivenPartsOfDateMissing_SetErrorOnTheModel(string day, string month, string year)
                 {
-                    var response = await _subject.HtbDatePost("0001", "");
-                    var model = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+                    var response = await _subject.HtbDatePost("0001", day, month, year);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
-                    Assert.True(model.FormErrors.HasErrors);
-                    Assert.Equal("Please select an HTB date", model.FormErrors.Errors[0].ErrorMessage);
-                    Assert.Equal("01/01/2020", model.FormErrors.Errors[0].ErrorElementId);
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("Please enter the HTB date", responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
+
+                [Theory]
+                [InlineData("0", "1", "2020")]
+                [InlineData("32", "1", "2020")]
+                [InlineData("1", "0", "2020")]
+                [InlineData("1", "13", "2020")]
+                [InlineData("1", "13", "0")]
+                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year)
+                {
+                    var response = await _subject.HtbDatePost("0001", day, month, year);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("Please enter a valid date", responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
             }
         }

--- a/Frontend.Tests/ModelTests/TransferDatesViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/TransferDatesViewModelTests.cs
@@ -37,49 +37,18 @@ namespace Frontend.Tests.ModelTests
             Assert.Equal(expectedYear, model.TargetDate.Year);
         }
 
-        [Fact]
-        public void GivenDateInJanuary2020_GeneratesHTBDatesUntilJanuary2021()
+        [Theory]
+        [InlineData("", "", "", "")]
+        [InlineData("20/02/2020", "20", "02", "2020")]
+        [InlineData("13/01/2021", "13", "01", "2021")]
+        public void GivenHtbDate_ReturnsTheCorrectDateViewModel(string inputDate, string expectedDay,
+            string expectedMonth, string expectedYear)
         {
-            var expectedDateValues = new List<string>
-            {
-                "03/02/2020", "02/03/2020", "01/04/2020", "01/05/2020",
-                "01/06/2020", "01/07/2020", "03/08/2020", "01/09/2020",
-                "01/10/2020", "02/11/2020", "01/12/2020", "01/01/2021"
-            };
-
-            var expectedDateDisplay = new List<string>
-            {
-                "Monday 3 February 2020", "Monday 2 March 2020", "Wednesday 1 April 2020",
-                "Friday 1 May 2020", "Monday 1 June 2020", "Wednesday 1 July 2020",
-                "Monday 3 August 2020", "Tuesday 1 September 2020", "Thursday 1 October 2020",
-                "Monday 2 November 2020", "Tuesday 1 December 2020", "Friday 1 January 2021"
-            };
-
-            var project = new Project {Dates = new TransferDates {Htb = "03/08/2020"}};
+            var project = new Project {Dates = new TransferDates {Htb = inputDate}};
             var model = new TransferDatesViewModel {Project = project};
-            var htbDates = model.PotentialHtbDates("02/01/2020");
-
-            Assert.Equal(expectedDateValues, htbDates.Select(htbDate => htbDate.Value).ToList());
-            Assert.Equal(expectedDateDisplay, htbDates.Select(htbDate => htbDate.DisplayName).ToList());
-            Assert.Equal("03/08/2020", htbDates.Find(date => date.Checked)?.Value);
-        }
-
-        [Fact]
-        public void GivenStartingHtbDateIsFirstWorkingDayInMonth_GenerateHtbDatesIncludingThatDate()
-        {
-            var project = new Project {Dates = new TransferDates {Htb = "03/08/2020"}};
-            var model = new TransferDatesViewModel {Project = project};
-            var htbDates = model.PotentialHtbDates("03/02/2020");
-            Assert.Equal("03/02/2020", htbDates[0].Value);
-        }
-        
-        [Fact]
-        public void GivenStartingHtbDateIsNotFirstWorkingDayInMonth_GenerateHtbDatesExcludingThatDate()
-        {
-            var project = new Project {Dates = new TransferDates {Htb = "03/08/2020"}};
-            var model = new TransferDatesViewModel {Project = project};
-            var htbDates = model.PotentialHtbDates("07/02/2020");
-            Assert.Equal("02/03/2020", htbDates[0].Value);
+            Assert.Equal(expectedDay, model.HtbDate.Day);
+            Assert.Equal(expectedMonth, model.HtbDate.Month);
+            Assert.Equal(expectedYear, model.HtbDate.Year);
         }
     }
 }

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -97,17 +97,21 @@ namespace Frontend.Controllers.Projects
 
         [HttpPost("htb-date")]
         [ActionName("HtbDate")]
-        public async Task<IActionResult> HtbDatePost(string urn, string htbDate)
+        public async Task<IActionResult> HtbDatePost(string urn, string day, string month, string year)
         {
             var model = await GetModel(urn);
-            model.Project.Dates.Htb = htbDate;
+            var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
+            model.Project.Dates.Htb = dateString;
 
-            if (string.IsNullOrEmpty(htbDate))
+            if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
             {
-                var startDateString = DatesHelper.DateTimeToDateString(_dateTimeProvider.Today());
-                var htbDates = DatesHelper.GetFirstWorkingDaysOfTheTheMonthForTheNextYear(startDateString);
-                var errorId = DatesHelper.DateTimeToDateString(htbDates[0]);
-                model.FormErrors.AddError(errorId, "htbDate", "Please select an HTB date");
+                model.FormErrors.AddError("day", "day", "Please enter the HTB date");
+                return View(model);
+            }
+
+            if (!DatesHelper.IsValidDate(dateString))
+            {
+                model.FormErrors.AddError("day", "day", "Please enter a valid date");
                 return View(model);
             }
 

--- a/Frontend/Models/TransferDatesViewModel.cs
+++ b/Frontend/Models/TransferDatesViewModel.cs
@@ -18,23 +18,12 @@ namespace Frontend.Models
 
         public DateInputViewModel TransferFirstDiscussed => DateInputForField(Project.Dates.FirstDiscussed);
         public DateInputViewModel TargetDate => DateInputForField(Project.Dates.Target);
+        public DateInputViewModel HtbDate => DateInputForField(Project.Dates.Htb);
 
         private static DateInputViewModel DateInputForField(string transferDatesFirstDiscussed)
         {
             var splitDate = DatesHelper.DateStringToDayMonthYear(transferDatesFirstDiscussed);
             return new DateInputViewModel {Day = splitDate[0], Month = splitDate[1], Year = splitDate[2]};
-        }
-
-        public List<RadioButtonViewModel> PotentialHtbDates(string startDateString)
-        {
-            var htbDates = DatesHelper.GetFirstWorkingDaysOfTheTheMonthForTheNextYear(startDateString);
-
-            return htbDates.Select(htbDate => new RadioButtonViewModel
-            {
-                Name = "htbDate", Value = DatesHelper.DateTimeToDateString(htbDate),
-                DisplayName = htbDate.ToString("dddd d MMMM yyyy"),
-                Checked = Project.Dates.Htb == DatesHelper.DateTimeToDateString(htbDate)
-            }).ToList();
         }
     }
 }

--- a/Frontend/Views/TransferDates/HtbDate.cshtml
+++ b/Frontend/Views/TransferDates/HtbDate.cshtml
@@ -39,7 +39,32 @@
                         </span>
                     }
 
-                    @await Html.PartialAsync("_RadioButtons", Model.PotentialHtbDates(htbStartDate))
+                    <div class="govuk-date-input" id="htb-date">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-date-input__label" for="day">
+                                    Day
+                                </label>
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="day" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.HtbDate.Day">
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-date-input__label" for="month">
+                                    Month
+                                </label>
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="month" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.HtbDate.Month">
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-date-input__label" for="year">
+                                    Year
+                                </label>
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="year" type="text" pattern="[0-9]*" inputmode="numeric" value="@Model.HtbDate.Year">
+                            </div>
+                        </div>
+                    </div>
                 </fieldset>
             </div>
             <button class="govuk-button" data-module="govuk-button">


### PR DESCRIPTION
### Context

User research showed that pre-populated HTB Dates would be too restrictive, as they can differ per region. As such, we're moving to allow manual entry

### Changes proposed in this pull request

- Align HTB Date entry with other date entry fields

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

