### PR TITLE
Align content with Academy Conversions

### DIFF
--- a/Data.Mock/MockProjectRepository.cs
+++ b/Data.Mock/MockProjectRepository.cs
@@ -88,6 +88,7 @@ namespace Data.Mock
                     new TransferringAcademies
                     {
                         OutgoingAcademyUkprn = "10040290",
+                        OutgoingAcademyName = "Conyers School",
                         IncomingTrustUkprn = "10059766"
                     }
                 }
@@ -107,6 +108,7 @@ namespace Data.Mock
                     new TransferringAcademies
                     {
                         OutgoingAcademyUkprn = "10040290",
+                        OutgoingAcademyName = "Conyers School",
                         IncomingTrustUkprn = "10059766"
                     }
                 },

--- a/Data/Models/Project.cs
+++ b/Data/Models/Project.cs
@@ -26,5 +26,6 @@ namespace Data.Models
         public TransferDates Dates { get; set; }
         public TransferBenefits Benefits { get; set; }
         public TransferRationale Rationale { get; set; }
+        public string OutgoingAcademyName => TransferringAcademies[0].OutgoingAcademyName;
     }
 }

--- a/Data/Models/Projects/TransferringAcademies.cs
+++ b/Data/Models/Projects/TransferringAcademies.cs
@@ -3,6 +3,7 @@ namespace Data.Models.Projects
     public class TransferringAcademies
     {
         public string OutgoingAcademyUkprn { get; set; }
+        public string OutgoingAcademyName { get; set; }
         public string IncomingTrustUkprn { get; set; }
     }
 }

--- a/Frontend/Views/AcademyPerformance/Index.cshtml
+++ b/Frontend/Views/AcademyPerformance/Index.cshtml
@@ -12,7 +12,9 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-        <span class="govuk-caption-m">Reference number: @Model.Project.Name</span>
+        <span class="govuk-caption-m">
+            URN @Model.Project.Urn
+        </span>
         <h1 class="govuk-heading-l">Academy Performance</h1>
         <h2 class="govuk-heading-m">
             Outgoing trust: <span class="govuk-!-font-weight-regular govuk-!-font-size-24">@Model.Project.OutgoingTrustName</span>

--- a/Frontend/Views/AcademyPerformance/Index.cshtml
+++ b/Frontend/Views/AcademyPerformance/Index.cshtml
@@ -21,6 +21,6 @@
         </h2>
         <p class="govuk-body">This information is pre-populated from TRAMS and the school's application form</p>
         <partial name="_FormFieldSummaryList" model="Model.OutgoingAcademy.Performance.FieldsToDisplay()"/>
-        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Continue</a>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
     </div>
 </div>

--- a/Frontend/Views/Benefits/Index.cshtml
+++ b/Frontend/Views/Benefits/Index.cshtml
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <span class="govuk-caption-m">
-            Reference number: @Model.Project.Name
+            URN @Model.Project.Urn
         </span>
         <h1 class="govuk-heading-l">
             Benefits and other factors

--- a/Frontend/Views/Benefits/Index.cshtml
+++ b/Frontend/Views/Benefits/Index.cshtml
@@ -88,6 +88,6 @@
                 </dd>
             </div>
         </dl>
-        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Save and continue</a>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
     </div>
 </div>

--- a/Frontend/Views/Benefits/IntendedBenefits.cshtml
+++ b/Frontend/Views/Benefits/IntendedBenefits.cshtml
@@ -1,5 +1,4 @@
 @using Frontend.Helpers
-@using Data.Models
 @using Data.Models.Projects
 @model BenefitsViewModel
 
@@ -25,7 +24,7 @@
                     <legend class="govuk-fieldset__legend">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: @Model.Project.Name
+                                @Model.Project.OutgoingAcademyName
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">

--- a/Frontend/Views/Benefits/OtherFactors.cshtml
+++ b/Frontend/Views/Benefits/OtherFactors.cshtml
@@ -45,7 +45,7 @@
                     <legend class="govuk-fieldset__legend">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: @Model.Project.Name
+                                @Model.Project.OutgoingAcademyName
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">

--- a/Frontend/Views/Features/Index.cshtml
+++ b/Frontend/Views/Features/Index.cshtml
@@ -110,6 +110,6 @@
             </div>
         </dl>
 
-        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Save and continue</a>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
     </div>
 </div>

--- a/Frontend/Views/Features/Index.cshtml
+++ b/Frontend/Views/Features/Index.cshtml
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <span class="govuk-caption-m">
-            Reference number: @Model.Project.Name
+            URN @Model.Project.Urn
         </span>
         <h1 class="govuk-heading-l">
             Features of the transfer

--- a/Frontend/Views/Features/Initiated.cshtml
+++ b/Frontend/Views/Features/Initiated.cshtml
@@ -22,7 +22,7 @@
                     <legend class="govuk-fieldset__legend">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: @Model.Project.Name
+                                @Model.Project.OutgoingAcademyName
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">

--- a/Frontend/Views/Features/Reason.cshtml
+++ b/Frontend/Views/Features/Reason.cshtml
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-m">
-            Reference number: @Model.Project.Name
+            @Model.Project.OutgoingAcademyName
         </span>
         <h1 class="govuk-heading-l">
             Reason for transfer

--- a/Frontend/Views/Features/Type.cshtml
+++ b/Frontend/Views/Features/Type.cshtml
@@ -24,7 +24,7 @@
                     <legend class="govuk-fieldset__legend">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: @Model.Project.Name
+                                @Model.Project.OutgoingAcademyName
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">

--- a/Frontend/Views/Home/Index.cshtml
+++ b/Frontend/Views/Home/Index.cshtml
@@ -19,7 +19,7 @@
                     <h3 class="govuk-heading-m">
                         <a class="govuk-link govuk-link--no-visited-state" asp-controller="Project" asp-action="Index" asp-route-id="@project.Urn">
                             Outgoing academy name
-                        </a> <span class="govuk-caption-m dfe-inline-block">@project.Number</span>
+                        </a> <span class="govuk-caption-m dfe-inline-block">URN @project.Urn</span>
                     </h3>
                     <p class="govuk-body govuk-!-margin-bottom-1">Application to join Incoming Academy</p>
                     <p class="govuk-body-s">Local authority</p>

--- a/Frontend/Views/LatestOfstedJudgement/Index.cshtml
+++ b/Frontend/Views/LatestOfstedJudgement/Index.cshtml
@@ -12,7 +12,9 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-        <span class="govuk-caption-m">Reference number: @Model.Project.Name</span>
+        <span class="govuk-caption-m">
+            URN @Model.Project.Urn
+        </span>
         <h1 class="govuk-heading-l">Latest Ofsted judgement</h1>
         <h2 class="govuk-heading-m">
             Outgoing trust: <span class="govuk-!-font-weight-regular govuk-!-font-size-24">@Model.Project.OutgoingTrustName</span>

--- a/Frontend/Views/LatestOfstedJudgement/Index.cshtml
+++ b/Frontend/Views/LatestOfstedJudgement/Index.cshtml
@@ -21,6 +21,6 @@
         </h2>
         <p class="govuk-body">This information is pre-populated from TRAMS and the school's application form</p>
         <partial name="_FormFieldSummaryList" model="Model.Academy.LatestOfstedJudgement.FieldsToDisplay()"/>
-        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Continue</a>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
     </div>
 </div>

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -25,51 +25,49 @@
         <ol class="moj-task-list">
             <li>
                 <h2 class="moj-task-list__section">
-                    Create HTB template
+                    Create headteacher board (HTB) template
                 </h2>
                 <ul class="moj-task-list__items govuk-!-padding-left-0">
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="features" asp-controller="Features" asp-action="Index" asp-route-urn="@ViewData["ProjectId"]">Features of a transfer</a>
+                            <a aria-describedby="features" asp-controller="Features" asp-action="Index" asp-route-urn="@Model.Project.Urn">Features of a transfer</a>
                         </span><projectstatus id="features" status="@Model.FeatureTransferStatus"></projectstatus>
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="dates" asp-controller="TransferDates" asp-action="Index" asp-route-urn="@ViewData["ProjectId"]">Set transfer dates</a>
+                            <a aria-describedby="dates" asp-controller="TransferDates" asp-action="Index" asp-route-urn="@Model.Project.Urn">Set transfer dates</a>
                         </span><projectstatus id="dates" status="@Model.TransferDatesStatus"></projectstatus>
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="benefits" asp-controller="Benefits" asp-action="Index" asp-route-urn="@ViewData["ProjectId"]">Benefits and other factors</a>
-                        </span><projectstatus id="benefits", status="@Model.BenefitsAndOtherFactorsStatus"></projectstatus>
+                            <a aria-describedby="benefits" asp-controller="Benefits" asp-action="Index" asp-route-urn="@Model.Project.Urn">Benefits and other factors</a>
+                        </span><projectstatus id="benefits" status="@Model.BenefitsAndOtherFactorsStatus"></projectstatus>
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="rationale" asp-controller="Rationale" asp-action="Index" asp-route-urn="@ViewData["ProjectId"]">Rationale</a>
+                            <a aria-describedby="rationale" asp-controller="Rationale" asp-action="Index" asp-route-urn="@Model.Project.Urn">Rationale</a>
                         </span><projectstatus id="rationale" , status="@Model.RationaleStatus"></projectstatus>
                     </li>
-                </ul>
-            </li>
-            <li>
-                <h2 class="moj-task-list__section">
-                    Reference only
-                </h2>
-                <ul class="moj-task-list__items govuk-!-padding-left-0">
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="academy-performance" asp-controller="AcademyPerformance" asp-action="Index" asp-route-id="@ViewData["ProjectId"]">
+                            <a aria-describedby="general-information" href="#">Rationale</a>
+                        </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="general-information">TO DO</strong>
+                    </li>
+                    <li class="moj-task-list__item">
+                        <span class="moj-task-list__task-name">
+                            <a aria-describedby="academy-performance" asp-controller="AcademyPerformance" asp-action="Index" asp-route-id="@Model.Project.Urn">
                                 Academy performance
                             </a>
                         </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="academy-performance">Reference only</strong>
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="pupil-numbers" asp-controller="PupilNumbers" asp-action="Index" asp-route-id="@ViewData["ProjectId"]">Pupil numbers</a>
+                            <a aria-describedby="pupil-numbers" asp-controller="PupilNumbers" asp-action="Index" asp-route-id="@Model.Project.Urn">Pupil numbers</a>
                         </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="pupil-numbers">Reference only</strong>
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
-                            <a aria-describedby="ofsted-report" asp-controller="LatestOfstedJudgement" asp-action="Index" asp-route-id="@ViewData["ProjectId"]">Latest Ofsted report</a>
+                            <a aria-describedby="ofsted-report" asp-controller="LatestOfstedJudgement" asp-action="Index" asp-route-id="@Model.Project.Urn">Latest Ofsted report</a>
                         </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="ofsted-report">Reference only</strong>
                     </li>
                     <li class="moj-task-list__item">
@@ -79,21 +77,8 @@
                     </li>
                 </ul>
             </li>
-            <li>
-                <h2 class="moj-task-list__section">
-                    Trust/sponsor template
-                </h2>
-                <ul class="moj-task-list__items govuk-!-padding-left-0">
-                    <li class="moj-task-list__item">
-                        <span class="moj-task-list__task-name">
-                            Trust template
-                        </span>
-                        <strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="trust-template">Cannot edit yet</strong>
-                    </li>
-                </ul>
-            </li>
         </ol>
-        <a role="button" draggable="false" class="govuk-button" data-module="govuk-button" asp-controller="HeadteacherBoard" asp-action="Preview" asp-route-id="@ViewData["ProjectId"]">
+        <a role="button" draggable="false" class="govuk-button" data-module="govuk-button" asp-controller="HeadteacherBoard" asp-action="Preview" asp-route-id="@Model.Project.Urn">
             Preview HTB Template
         </a>
     </div>

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -1,7 +1,7 @@
 @model ProjectTaskListViewModel
 
 @{
-    ViewBag.Title = ViewData["ProjectName"];
+    ViewBag.Title = $"Project {Model.Project.Urn}";
     Layout = "_Layout";
 }
 
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
 
-        <span class="govuk-caption-xl">@Model.Project.Name</span>
+        <span class="govuk-caption-xl">URN @Model.Project.Urn</span>
         <h1 class="govuk-heading-xl">
             @Model.Project.OutgoingTrustName
         </h1>

--- a/Frontend/Views/PupilNumbers/Index.cshtml
+++ b/Frontend/Views/PupilNumbers/Index.cshtml
@@ -21,6 +21,6 @@
         </h2>
         <p class="govuk-body">This information is pre-populated from TRAMS and the school's application form</p>
         <partial name="_FormFieldSummaryList" model="Model.OutgoingAcademy.PupilNumbers.FieldsToDisplay()"/>
-        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Continue</a>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
     </div>
 </div>

--- a/Frontend/Views/PupilNumbers/Index.cshtml
+++ b/Frontend/Views/PupilNumbers/Index.cshtml
@@ -12,7 +12,9 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-        <span class="govuk-caption-m">Reference number: @Model.Project.Name</span>
+        <span class="govuk-caption-m">
+            URN @Model.Project.Urn
+        </span>
         <h1 class="govuk-heading-l">Pupil numbers</h1>
         <h2 class="govuk-heading-m">
             Outgoing trust: <span class="govuk-!-font-weight-regular govuk-!-font-size-24">@Model.Project.OutgoingTrustName</span>

--- a/Frontend/Views/Rationale/Index.cshtml
+++ b/Frontend/Views/Rationale/Index.cshtml
@@ -69,6 +69,6 @@
                 </dd>
             </div>
         </dl>
-        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Save and continue</a>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
     </div>
 </div>

--- a/Frontend/Views/Rationale/Index.cshtml
+++ b/Frontend/Views/Rationale/Index.cshtml
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <span class="govuk-caption-m">
-            Reference number: @Model.Project.Name
+            URN @Model.Project.Urn
         </span>
         <h1 class="govuk-heading-l">
             Confirm project and trust rationale

--- a/Frontend/Views/Rationale/Project.cshtml
+++ b/Frontend/Views/Rationale/Project.cshtml
@@ -19,7 +19,7 @@
             <div class="govuk-form-group @formClasses">
                 <label class="govuk-label govuk-!-font-weight-bold" for="rationale">
                     <span class="govuk-caption-m">
-                        Reference number: @Model.Project.Name
+                        @Model.Project.OutgoingAcademyName
                     </span>
                     <h1 class="govuk-heading-l">
                         Write the rationale for the project

--- a/Frontend/Views/Rationale/TrustOrSponsor.cshtml
+++ b/Frontend/Views/Rationale/TrustOrSponsor.cshtml
@@ -19,7 +19,7 @@
             <div class="govuk-form-group @formClasses">
                 <label class="govuk-label govuk-!-font-weight-bold" for="rationale">
                     <span class="govuk-caption-m">
-                        Reference number: @Model.Project.Name
+                        @Model.Project.OutgoingAcademyName
                     </span>
                     <h1 class="govuk-heading-l">
                         Write the rationale for the trust or sponsor

--- a/Frontend/Views/TransferDates/FirstDiscussed.cshtml
+++ b/Frontend/Views/TransferDates/FirstDiscussed.cshtml
@@ -21,7 +21,7 @@
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: @Model.Project.Name
+                                @Model.Project.OutgoingAcademyName
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">

--- a/Frontend/Views/TransferDates/HtbDate.cshtml
+++ b/Frontend/Views/TransferDates/HtbDate.cshtml
@@ -24,7 +24,7 @@
                     <legend class="govuk-fieldset__legend">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: @Model.Project.Name
+                                @Model.Project.OutgoingAcademyName
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <span class="govuk-caption-m">
-            Reference number: @Model.Project.Name
+            URN @Model.Project.Urn
         </span>
         <h1 class="govuk-heading-l">
             Set transfer dates

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -108,6 +108,6 @@
                 </dd>
             </div>
         </dl>
-        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Save and continue</a>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
     </div>
 </div>

--- a/Frontend/Views/TransferDates/TargetDate.cshtml
+++ b/Frontend/Views/TransferDates/TargetDate.cshtml
@@ -21,7 +21,7 @@
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">
                             <span class="govuk-caption-m">
-                                Reference number: AS_6759840
+                                @Model.Project.OutgoingAcademyName
                             </span>
                         </h1>
                         <h1 class="govuk-heading-l">


### PR DESCRIPTION
### Context

As we're developing these services in line with each other, we're updating our content to bring it inline with the Academy Conversions team

### Changes proposed in this pull request

- Display URN on Home page
- Display URN on the task list
- Add URNs to summary pages
- Add outgoing academy name to data entry pages
- Update continue button text on summary pages
- Update task list based on prototype

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

