### PR TITLE
Remove intro paragraphs from summary pages

### DIFF
--- a/Frontend/Views/Benefits/Index.cshtml
+++ b/Frontend/Views/Benefits/Index.cshtml
@@ -21,9 +21,6 @@
         <h2 class="govuk-heading-m">
             Outgoing trust: <span class="govuk-!-font-weight-regular govuk-!-font-size-24">@Model.Project.OutgoingTrustName</span>
         </h2>
-        <p class="govuk-body">
-            This information is pre-populated from TRAMS and the school's application form.
-        </p>
         <hr class="govuk-section-break govuk-section-break--l">
     </div>
 </div>

--- a/Frontend/Views/Features/Index.cshtml
+++ b/Frontend/Views/Features/Index.cshtml
@@ -23,9 +23,6 @@
         <h2 class="govuk-heading-m">
             Outgoing trust: <span class="govuk-!-font-weight-regular govuk-!-font-size-24">@Model.Project.OutgoingTrustName</span>
         </h2>
-        <p class="govuk-body">
-            This information is wpre-populated from TRAMS and the school's application form.
-        </p>
         <hr class="govuk-section-break govuk-section-break--l">
     </div>
 </div>

--- a/Frontend/Views/TransferDates/Index.cshtml
+++ b/Frontend/Views/TransferDates/Index.cshtml
@@ -23,9 +23,6 @@
         <h2 class="govuk-heading-m">
             Outgoing trust: <span class="govuk-!-font-weight-regular govuk-!-font-size-24">@Model.Project.OutgoingTrustName</span>
         </h2>
-        <p class="govuk-body">
-            This information is pre-populated from TRAMS and the school's application form.
-        </p>
         <hr class="govuk-section-break govuk-section-break--l">
     </div>
 </div>


### PR DESCRIPTION
### Context

This is old content that is no longer relevant and as such has been removed

### Changes proposed in this pull request

- Remove intro paragraphs from summary pages

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

