### PR TITLE
Search by UKPRN Workaround

### DIFF
--- a/Data.TRAMS/TramsProjectsRepository.cs
+++ b/Data.TRAMS/TramsProjectsRepository.cs
@@ -152,7 +152,8 @@ namespace Data.TRAMS
         public async Task<RepositoryResult<Project>> Create(Project project)
         {
             var externalProject = _internalToUpdateMapper.Map(project);
-            var content = new StringContent(JsonConvert.SerializeObject(externalProject));
+            var content = new StringContent(JsonConvert.SerializeObject(externalProject), Encoding.Default,
+                "application/json");
             var response = await _httpClient.PostAsync("academyTransferProject", content);
             var apiResponse = await response.Content.ReadAsStringAsync();
             var createdProject = JsonConvert.DeserializeObject<TramsProject>(apiResponse);

--- a/Data.TRAMS/TramsTrustsRepository.cs
+++ b/Data.TRAMS/TramsTrustsRepository.cs
@@ -22,7 +22,54 @@ namespace Data.TRAMS
             _trustMapper = trustMapper;
         }
 
+        #region API Interim
+
         public async Task<RepositoryResult<List<TrustSearchResult>>> SearchTrusts(string searchQuery = "")
+        {
+            var url = $"trust/{searchQuery}";
+            using var response = await _httpClient.GetAsync(url);
+            Trust trust;
+
+            if (response.IsSuccessStatusCode)
+            {
+                var apiResponse = await response.Content.ReadAsStringAsync();
+                var result = JsonConvert.DeserializeObject<TramsTrust>(apiResponse);
+                trust = _trustMapper.Map(result);
+            }
+            else
+            {
+                return new RepositoryResult<List<TrustSearchResult>>()
+                {
+                    Result = new List<TrustSearchResult>()
+                };
+            }
+
+            return new RepositoryResult<List<TrustSearchResult>>
+            {
+                Result = new List<TrustSearchResult>
+                {
+                    new TrustSearchResult
+                    {
+                        Ukprn = trust.Ukprn,
+                        TrustName = trust.Name,
+                        CompaniesHouseNumber = trust.CompaniesHouseNumber,
+                        Academies = trust.Academies
+                            .Select(
+                                academy =>
+                                    new TrustSearchAcademy
+                                    {
+                                        Name = academy.Name,
+                                        Ukprn = academy.Ukprn,
+                                        Urn = academy.Urn
+                                    }
+                            )
+                            .ToList()
+                    }
+                }
+            };
+        }
+
+        public async Task<RepositoryResult<List<TrustSearchResult>>> SearchTrustsOriginal(string searchQuery = "")
         {
             var url = $"trusts?group_name={searchQuery}&urn={searchQuery}&companies_house_number={searchQuery}";
             using var response = await _httpClient.GetAsync(url);
@@ -37,6 +84,8 @@ namespace Data.TRAMS
                 Result = mappedResult
             };
         }
+
+        #endregion
 
         public async Task<RepositoryResult<Trust>> GetByUkprn(string ukprn)
         {

--- a/Frontend/Views/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrust.cshtml
@@ -45,7 +45,16 @@
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                         <h1 class="govuk-fieldset__heading">Add the incoming trust name for @ViewData["OutgoingAcademyName"]</h1>
                     </legend>
-                    <label class="govuk-hint" for="query" id="query-hint">Search by name, UKPRN or companies house number</label>
+
+                    @* <div id="query-hint" class="govuk-hint"> *@
+                    @*     Search by name, UKPRN or companies house number *@
+                    @* </div> *@
+
+                    <div id="query-hint" class="govuk-hint">
+                        Search by Trust UKPRN<br/>
+                        If you're unsure of the UKPRN of the trust, you can find it on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk/">Get Information about Schools</a>
+                    </div>
+
                     @if (errorExists)
                     {
                         <span id="query-error" class="govuk-error-message">

--- a/Frontend/Views/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrust.cshtml
@@ -51,8 +51,7 @@
                     @* </div> *@
 
                     <div id="query-hint" class="govuk-hint">
-                        Search by Trust UKPRN<br/>
-                        If you're unsure of the UKPRN of the trust, you can find it on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk/">Get Information about Schools</a>
+                        Search by Trust UKPRN. If you're unsure of the UKPRN of the trust, you can find it on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk/">Get Information about Schools</a>
                     </div>
 
                     @if (errorExists)

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -45,9 +45,16 @@
                         Add the outgoing trust name
                     </label>
                 </h1>
+
+                @* <div id="query-hint" class="govuk-hint"> *@
+                @*     Search by name, UKPRN or companies house number *@
+                @* </div> *@
+
                 <div id="query-hint" class="govuk-hint">
-                    Search by name, UKPRN or companies house number
+                    Search by Trust UKPRN<br />
+                    If you're unsure of the UKPRN of the trust, you can find it on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk/">Get Information about Schools</a>
                 </div>
+
                 @if (errorExists)
                 {
                     <span id="query-error" class="govuk-error-message">

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -51,8 +51,7 @@
                 @* </div> *@
 
                 <div id="query-hint" class="govuk-hint">
-                    Search by Trust UKPRN<br />
-                    If you're unsure of the UKPRN of the trust, you can find it on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk/">Get Information about Schools</a>
+                    Search by Trust UKPRN. If you're unsure of the UKPRN of the trust, you can find it on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk/">Get Information about Schools</a>
                 </div>
 
                 @if (errorExists)


### PR DESCRIPTION
### Context

The TRAMS API currently does not have an implemented trust search with the performance necessary to use. To allow us to launch in case this isn't ready in time, we decided to implement a "Search by UKPRN" only workaround utalising the `trust/ukprn` endpoint

### Changes proposed in this pull request

- Add interim workaround for searching trusts
- Update content to reflect current search info

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

