### PR TITLE
Adjust style in Ofsted summary page

### DIFF
--- a/Frontend/Views/LatestOfstedJudgement/Index.cshtml
+++ b/Frontend/Views/LatestOfstedJudgement/Index.cshtml
@@ -85,19 +85,15 @@
             </div>
         </dl>
     </div>
-    <div class="govuk-grid-row">
-        <partial name="_AdditionalInformation" model="Model.AdditionalInformationModel"/>
-        @if (!Model.AdditionalInformationModel.AddOrEditAdditionalInformation)
-        {
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <form asp-controller="Project" asp-route-id="@Model.Project.Urn">
-                        <button class="govuk-button" data-module="govuk-button">
-                            Confirm and continue
-                        </button>
-                    </form>
-                </div>
-            </div>
-        }
-    </div>
+    <partial name="_AdditionalInformation" model="Model.AdditionalInformationModel"/>
+    @if (!Model.AdditionalInformationModel.AddOrEditAdditionalInformation)
+    {
+        <div class="govuk-grid-column-two-thirds">
+            <form asp-controller="Project" asp-route-id="@Model.Project.Urn">
+                <button class="govuk-button" data-module="govuk-button">
+                    Confirm and continue
+                </button>
+            </form>
+        </div>
+    }
 </div>


### PR DESCRIPTION
### Context

Some sections of the page were displayed with different margins

### Changes proposed in this pull request

Adjust style margins in Ofsted summary page

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

