### PR TITLE
Support lists in document generation

### DIFF
--- a/DocumentGeneration.Tests/DocumentBuilderTests.cs
+++ b/DocumentGeneration.Tests/DocumentBuilderTests.cs
@@ -105,6 +105,40 @@ namespace DocumentGeneration.Tests
             }
 
             [Fact]
+            public void GivenAddingParagraphWithItalicTextObject_GeneratesParagraphWithText()
+            {
+                var documentBody = GenerateDocumentBody(builder =>
+                {
+                    builder.AddParagraph(pBuilder =>
+                    {
+                        pBuilder.AddText(new TextElement {Value = "Woof", Italic = true});
+                    });
+                });
+
+                var paragraphs = documentBody.Descendants<Paragraph>().ToList();
+                Assert.Single(paragraphs);
+                Assert.Single(paragraphs[0].Descendants<Italic>());
+                Assert.Equal("Woof", paragraphs[0].InnerText);
+            }
+
+            [Fact]
+            public void GivenAddingParagraphWithUnderlineTextObject_GeneratesParagraphWithText()
+            {
+                var documentBody = GenerateDocumentBody(builder =>
+                {
+                    builder.AddParagraph(pBuilder =>
+                    {
+                        pBuilder.AddText(new TextElement {Value = "Woof", Underline = true});
+                    });
+                });
+
+                var paragraphs = documentBody.Descendants<Paragraph>().ToList();
+                Assert.Single(paragraphs);
+                Assert.Single(paragraphs[0].Descendants<Underline>());
+                Assert.Equal("Woof", paragraphs[0].InnerText);
+            }
+
+            [Fact]
             public void GivenAddingParagraphWithMultipleTextObjects_GeneratesParagraphWithText()
             {
                 var text = new[]
@@ -612,7 +646,7 @@ namespace DocumentGeneration.Tests
                 Assert.Equal("OneTwo", paragraphs[0].InnerText);
             }
         }
-        
+
         public class NumberedListTests : DocumentBuilderTests
         {
             [Fact]

--- a/DocumentGeneration.Tests/DocumentBuilderTests.cs
+++ b/DocumentGeneration.Tests/DocumentBuilderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml;
@@ -29,6 +30,32 @@ namespace DocumentGeneration.Tests
             }
 
             return documentBody;
+        }
+
+        private static GenerateDocumentResponse GenerateDocument(Action<IDocumentBuilder> action)
+        {
+            var ms = new MemoryStream();
+            var builder = new DocumentBuilder(ms);
+            action(builder);
+            builder.Build();
+
+            using var doc = WordprocessingDocument.Open(ms, false);
+
+            return new GenerateDocumentResponse
+            {
+                Numbering = doc.MainDocumentPart.NumberingDefinitionsPart.Numbering,
+                Headers = doc.MainDocumentPart.HeaderParts.Select(p => p.Header).ToList(),
+                FooterParts = doc.MainDocumentPart.FooterParts.Select(p => p.Footer).ToList(),
+                Body = doc.MainDocumentPart.Document.Body
+            };
+        }
+
+        private class GenerateDocumentResponse
+        {
+            public Body Body { get; set; }
+            public Numbering Numbering { get; set; }
+            public List<Header> Headers { get; set; }
+            public List<Footer> FooterParts { get; set; }
         }
 
         public class ParagraphTests : DocumentBuilderTests
@@ -345,16 +372,13 @@ namespace DocumentGeneration.Tests
             [Fact]
             public void GivenHeaderHasText_GeneratesHeaderForDocument()
             {
-                using var ms = new MemoryStream();
-                var builder = new DocumentBuilder(ms);
-                builder.AddHeader(hBuilder => { hBuilder.AddParagraph(pBuilder => pBuilder.AddText("Meow")); });
-                builder.Build();
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddHeader(hBuilder => { hBuilder.AddParagraph(pBuilder => pBuilder.AddText("Meow")); });
+                });
 
-                using var doc = WordprocessingDocument.Open(ms, false);
-                var headers = doc.MainDocumentPart.HeaderParts.ToList();
-
-                Assert.Single(headers);
-                var header = headers[0].Header;
+                Assert.Single(response.Headers);
+                var header = response.Headers[0];
                 Assert.Single(header.Descendants<Paragraph>());
                 Assert.Equal("Meow", header.InnerText);
             }
@@ -362,18 +386,17 @@ namespace DocumentGeneration.Tests
             [Fact]
             public void GivenHeaderHasTable_GeneratesHeaderForDocument()
             {
-                using var ms = new MemoryStream();
-                var builder = new DocumentBuilder(ms);
-                builder.AddHeader(hBuilder =>
+                var response = GenerateDocument(builder =>
                 {
-                    hBuilder.AddTable(tBuilder => tBuilder.AddRow(rBuilder => { rBuilder.AddCell("Meow"); }));
+                    builder.AddHeader(hBuilder =>
+                    {
+                        hBuilder.AddTable(
+                            tBuilder => tBuilder.AddRow(rBuilder => { rBuilder.AddCell("Meow"); }));
+                    });
                 });
-                builder.Build();
 
-                using var doc = WordprocessingDocument.Open(ms, false);
-                var headers = doc.MainDocumentPart.HeaderParts.ToList();
-                Assert.Single(headers);
-                var header = headers[0].Header;
+                Assert.Single(response.Headers);
+                var header = response.Headers[0];
                 Assert.Single(header.Descendants<Table>());
                 Assert.Single(header.Descendants<Paragraph>());
                 Assert.Equal("Meow", header.InnerText);
@@ -382,22 +405,20 @@ namespace DocumentGeneration.Tests
             [Fact]
             public void GivenAddingATableByRows_GeneratesTheCorrectTable()
             {
-                using var ms = new MemoryStream();
-                var builder = new DocumentBuilder(ms);
-                builder.AddHeader(hBuilder =>
+                var response = GenerateDocument(builder =>
                 {
-                    var textElements = new[]
+                    builder.AddHeader(hBuilder =>
                     {
-                        new[] {new TextElement {Value = "One"}, new TextElement {Value = "Two"}},
-                        new[] {new TextElement {Value = "Three"}, new TextElement {Value = "Four"}}
-                    };
-                    hBuilder.AddTable(textElements);
+                        var textElements = new[]
+                        {
+                            new[] {new TextElement {Value = "One"}, new TextElement {Value = "Two"}},
+                            new[] {new TextElement {Value = "Three"}, new TextElement {Value = "Four"}}
+                        };
+                        hBuilder.AddTable(textElements);
+                    });
                 });
-                builder.Build();
 
-                using var doc = WordprocessingDocument.Open(ms, false);
-                var headers = doc.MainDocumentPart.HeaderParts.ToList();
-                var header = headers[0].Header;
+                var header = response.Headers[0];
 
                 var tableRows = header.Descendants<TableRow>().ToList();
                 var tableCells = header.Descendants<TableCell>().ToList();
@@ -475,6 +496,234 @@ namespace DocumentGeneration.Tests
                 Assert.Equal(4, tableCells.Count);
                 Assert.Equal("OneTwo", tableRows[0].InnerText);
                 Assert.Equal("ThreeFour", tableRows[1].InnerText);
+            }
+        }
+
+        public class BulletedListTests : DocumentBuilderTests
+        {
+            [Fact]
+            public void GivenAddingOneBulletedList_CreatesASingleNumberingDefinitionAndAssignsThem()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddBulletedList(lBuilder => { lBuilder.AddItem("One"); });
+                });
+
+                var numbering = response.Numbering;
+                var numberingFormats = numbering.Descendants<NumberingFormat>().ToList();
+                var abstractNumDefinitions = numbering.Descendants<AbstractNum>().ToList();
+                var numberingInstances = numbering.Descendants<NumberingInstance>().ToList();
+                var paragraph = response.Body.Descendants<Paragraph>().First();
+
+                Assert.Single(abstractNumDefinitions);
+                Assert.Equal(NumberFormatValues.Bullet, numberingFormats[0].Val.Value);
+                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Single(numberingInstances);
+                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(0, (int) paragraph.ParagraphProperties.NumberingProperties.NumberingId.Val);
+            }
+
+            [Fact]
+            public void GivenAddingTwoBulletedLists_CreatesTwoNumberingDefinitions()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddBulletedList(lBuilder => { lBuilder.AddItem("One"); });
+                    builder.AddBulletedList(lBuilder => { lBuilder.AddItem("Two"); });
+                });
+
+                var numbering = response.Numbering;
+                var numberingFormats = numbering.Descendants<NumberingFormat>().ToList();
+                var abstractNumDefinitions = numbering.Descendants<AbstractNum>().ToList();
+                var numberingInstances = numbering.Descendants<NumberingInstance>().ToList();
+
+                Assert.Equal(NumberFormatValues.Bullet, numberingFormats[0].Val.Value);
+                Assert.Equal(NumberFormatValues.Bullet, numberingFormats[1].Val.Value);
+                Assert.Equal(2, abstractNumDefinitions.Count);
+                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Equal(1, abstractNumDefinitions[1].AbstractNumberId.Value);
+                Assert.Equal(2, numberingInstances.Count);
+                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(1, (int) numberingInstances[1].AbstractNumId.Val);
+            }
+
+            [Fact]
+            public void GivenAddingBulletedListWithStringItem_CreatesCorrectBulletedList()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddBulletedList(lBuilder =>
+                    {
+                        lBuilder.AddItem("One");
+                        lBuilder.AddItem("Two");
+                        lBuilder.AddItem("Three");
+                    });
+                });
+
+                var paragraphs = response.Body.Descendants<Paragraph>().ToList();
+
+                Assert.Equal(3, paragraphs.Count);
+                Assert.True(paragraphs.All(p =>
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                Assert.Equal("One", paragraphs[0].InnerText);
+                Assert.Equal("Two", paragraphs[1].InnerText);
+                Assert.Equal("Three", paragraphs[2].InnerText);
+            }
+
+            [Fact]
+            public void GivenAddingBulletedListWithTextElementItem_CreatesCorrectBulletedList()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddBulletedList(lBuilder =>
+                    {
+                        lBuilder.AddItem(new TextElement("One"));
+                        lBuilder.AddItem(new TextElement("Two"));
+                        lBuilder.AddItem(new TextElement("Three"));
+                    });
+                });
+
+                var paragraphs = response.Body.Descendants<Paragraph>().ToList();
+
+                Assert.Equal(3, paragraphs.Count);
+                Assert.True(paragraphs.All(p =>
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                Assert.Equal("One", paragraphs[0].InnerText);
+                Assert.Equal("Two", paragraphs[1].InnerText);
+                Assert.Equal("Three", paragraphs[2].InnerText);
+            }
+
+            [Fact]
+            public void GivenAddingBulletedListWithTextElementListItem_CreatesCorrectBulletedList()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddBulletedList(lBuilder =>
+                    {
+                        lBuilder.AddItem(new[] {new TextElement("One"), new TextElement("Two")});
+                    });
+                });
+
+                var paragraphs = response.Body.Descendants<Paragraph>().ToList();
+
+                Assert.Single(paragraphs);
+                Assert.True(paragraphs.All(p =>
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                Assert.Equal("OneTwo", paragraphs[0].InnerText);
+            }
+        }
+        
+        public class NumberedListTests : DocumentBuilderTests
+        {
+            [Fact]
+            public void GivenAddingOneNumberedList_CreatesASingleNumberingDefinitionAndAssignsThem()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddNumberedList(lBuilder => { lBuilder.AddItem("One"); });
+                });
+
+                var numbering = response.Numbering;
+                var numberingFormats = numbering.Descendants<NumberingFormat>().ToList();
+                var abstractNumDefinitions = numbering.Descendants<AbstractNum>().ToList();
+                var numberingInstances = numbering.Descendants<NumberingInstance>().ToList();
+                var paragraph = response.Body.Descendants<Paragraph>().First();
+
+                Assert.Single(abstractNumDefinitions);
+                Assert.Equal(NumberFormatValues.Decimal, numberingFormats[0].Val.Value);
+                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Single(numberingInstances);
+                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(0, (int) paragraph.ParagraphProperties.NumberingProperties.NumberingId.Val);
+            }
+
+            [Fact]
+            public void GivenAddingTwoNumberedLists_CreatesTwoNumberingDefinitions()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddNumberedList(lBuilder => { lBuilder.AddItem("One"); });
+                    builder.AddNumberedList(lBuilder => { lBuilder.AddItem("Two"); });
+                });
+
+                var numbering = response.Numbering;
+                var numberingFormats = numbering.Descendants<NumberingFormat>().ToList();
+                var abstractNumDefinitions = numbering.Descendants<AbstractNum>().ToList();
+                var numberingInstances = numbering.Descendants<NumberingInstance>().ToList();
+
+                Assert.Equal(NumberFormatValues.Decimal, numberingFormats[0].Val.Value);
+                Assert.Equal(NumberFormatValues.Decimal, numberingFormats[1].Val.Value);
+                Assert.Equal(2, abstractNumDefinitions.Count);
+                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Equal(1, abstractNumDefinitions[1].AbstractNumberId.Value);
+                Assert.Equal(2, numberingInstances.Count);
+                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(1, (int) numberingInstances[1].AbstractNumId.Val);
+            }
+
+            [Fact]
+            public void GivenAddingNumberedListWithStringItem_CreatesCorrectNumberedList()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddNumberedList(lBuilder =>
+                    {
+                        lBuilder.AddItem("One");
+                        lBuilder.AddItem("Two");
+                        lBuilder.AddItem("Three");
+                    });
+                });
+
+                var paragraphs = response.Body.Descendants<Paragraph>().ToList();
+
+                Assert.Equal(3, paragraphs.Count);
+                Assert.True(paragraphs.All(p =>
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                Assert.Equal("One", paragraphs[0].InnerText);
+                Assert.Equal("Two", paragraphs[1].InnerText);
+                Assert.Equal("Three", paragraphs[2].InnerText);
+            }
+
+            [Fact]
+            public void GivenAddingNumberedListWithTextElementItem_CreatesCorrectNumberedList()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddNumberedList(lBuilder =>
+                    {
+                        lBuilder.AddItem(new TextElement("One"));
+                        lBuilder.AddItem(new TextElement("Two"));
+                        lBuilder.AddItem(new TextElement("Three"));
+                    });
+                });
+
+                var paragraphs = response.Body.Descendants<Paragraph>().ToList();
+
+                Assert.Equal(3, paragraphs.Count);
+                Assert.True(paragraphs.All(p =>
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                Assert.Equal("One", paragraphs[0].InnerText);
+                Assert.Equal("Two", paragraphs[1].InnerText);
+                Assert.Equal("Three", paragraphs[2].InnerText);
+            }
+
+            [Fact]
+            public void GivenAddingNumberedListWithTextElementListItem_CreatesCorrectNumberedList()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddNumberedList(lBuilder =>
+                    {
+                        lBuilder.AddItem(new[] {new TextElement("One"), new TextElement("Two")});
+                    });
+                });
+
+                var paragraphs = response.Body.Descendants<Paragraph>().ToList();
+
+                Assert.Single(paragraphs);
+                Assert.True(paragraphs.All(p =>
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                Assert.Equal("OneTwo", paragraphs[0].InnerText);
             }
         }
     }

--- a/DocumentGeneration/Builders/BulletedListBuilder.cs
+++ b/DocumentGeneration/Builders/BulletedListBuilder.cs
@@ -8,13 +8,13 @@ using DocumentGeneration.Interfaces;
 
 namespace DocumentGeneration.Builders
 {
-    public class NumberedListBuilder : IListBuilder
+    public class BulletedListBuilder : IListBuilder
     {
         private readonly OpenXmlElement _parent;
         private readonly NumberingDefinitionsPart _numberingDefinitionsPart;
         private readonly int _numId;
 
-        public NumberedListBuilder(OpenXmlElement parent, NumberingDefinitionsPart numberingDefinitionsPart)
+        public BulletedListBuilder(OpenXmlElement parent, NumberingDefinitionsPart numberingDefinitionsPart)
         {
             _parent = parent;
             _numberingDefinitionsPart = numberingDefinitionsPart;
@@ -25,7 +25,6 @@ namespace DocumentGeneration.Builders
         {
             AddItem(new TextElement(item));
         }
-
 
         public void AddItem(TextElement item)
         {
@@ -75,12 +74,19 @@ namespace DocumentGeneration.Builders
                         {
                             new StartNumberingValue {Val = 1},
                             new NumberingFormat
-                                {Val = new EnumValue<NumberFormatValues>(NumberFormatValues.Decimal)},
-                            new LevelText {Val = "%1."},
+                                {Val = new EnumValue<NumberFormatValues>(NumberFormatValues.Bullet)},
+                            new LevelText {Val = ""},
                             new LevelJustification
                                 {Val = new EnumValue<LevelJustificationValues>(LevelJustificationValues.Left)},
                             new ParagraphProperties(
                                 new Indentation {Left = "720", Hanging = "360"}
+                            ),
+                            new RunProperties(
+                                new RunFonts
+                                {
+                                    Ascii = "Symbol", HighAnsi = "Symbol", ComplexScript = "Symbol",
+                                    Hint = new EnumValue<FontTypeHintValues>(FontTypeHintValues.Default)
+                                }
                             )
                         }
                     ) {LevelIndex = 0}

--- a/DocumentGeneration/Builders/NumberedListBuilder.cs
+++ b/DocumentGeneration/Builders/NumberedListBuilder.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentGeneration.Helpers;
+using DocumentGeneration.Interfaces;
+
+namespace DocumentGeneration.Builders
+{
+    public class NumberedListBuilder : IListBuilder
+    {
+        private readonly OpenXmlElement _parent;
+        private readonly NumberingDefinitionsPart _numberingDefinitionsPart;
+
+        public NumberedListBuilder(OpenXmlElement parent, NumberingDefinitionsPart numberingDefinitionsPart)
+        {
+            _parent = parent;
+            _numberingDefinitionsPart = numberingDefinitionsPart;
+        }
+
+        public void AddItems(string[] items)
+        {
+            var numId = AddNumberingDefinitions();
+            foreach (var item in items)
+            {
+                var paragraph = new Paragraph
+                {
+                    ParagraphProperties = new ParagraphProperties
+                    {
+                        NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
+                        {
+                            new NumberingLevelReference {Val = 0},
+                            new NumberingId {Val = numId}
+                        })
+                    }
+                };
+                var run = new Run();
+                DocumentBuilderHelpers.AddTextToElement(run, item);
+                paragraph.AppendChild(run);
+                _parent.AppendChild(paragraph);
+            }
+        }
+
+        private int AddNumberingDefinitions()
+        {
+            var numberingDefinitionCount = _numberingDefinitionsPart.Numbering.Descendants<AbstractNum>().Count();
+
+            var numberingDefinition = new List<OpenXmlElement>
+            {
+                new AbstractNum(
+                    new Level(
+                        new List<OpenXmlElement>
+                        {
+                            new StartNumberingValue {Val = 1},
+                            new NumberingFormat
+                                {Val = new EnumValue<NumberFormatValues>(NumberFormatValues.Decimal)},
+                            new LevelText {Val = "%1."},
+                            new LevelJustification
+                                {Val = new EnumValue<LevelJustificationValues>(LevelJustificationValues.Left)}
+                        }
+                    ) {LevelIndex = 0}
+                )
+                {
+                    AbstractNumberId = numberingDefinitionCount
+                },
+                new NumberingInstance(new AbstractNumId {Val = numberingDefinitionCount})
+                {
+                    NumberID = numberingDefinitionCount
+                }
+            };
+
+            _numberingDefinitionsPart.Numbering.AppendChild(numberingDefinition[0]);
+            _numberingDefinitionsPart.Numbering.AppendChild(numberingDefinition[1]);
+
+            return numberingDefinitionCount;
+        }
+    }
+}

--- a/DocumentGeneration/Builders/ParagraphBuilder.cs
+++ b/DocumentGeneration/Builders/ParagraphBuilder.cs
@@ -38,6 +38,17 @@ namespace DocumentGeneration.Builders
                 run.RunProperties.Bold = new Bold();
             }
 
+            if (text.Italic)
+            {
+                run.RunProperties.Italic = new Italic();
+            }
+
+            if (text.Underline)
+            {
+                run.RunProperties.Underline = new Underline
+                    {Val = new EnumValue<UnderlineValues>(UnderlineValues.Single), Color = "000000"};
+            }
+
             if (!string.IsNullOrEmpty(text.FontSize))
             {
                 run.RunProperties.FontSize = new FontSize {Val = text.FontSize};

--- a/DocumentGeneration/DocumentBuilder.cs
+++ b/DocumentGeneration/DocumentBuilder.cs
@@ -23,7 +23,20 @@ namespace DocumentGeneration
             _document.MainDocumentPart.Document = new Document(new Body());
             _body = _document.MainDocumentPart.Document.Body;
             SetCompatibilityMode();
+            AddNumberingDefinitions();
             AppendSectionProperties();
+        }
+
+        private void AddNumberingDefinitions()
+        {
+            var part = _document.MainDocumentPart.AddNewPart<NumberingDefinitionsPart>();
+            part.Numbering = new Numbering();
+        }
+
+        public void AddNumberedList(string[] items)
+        {
+            var builder = new NumberedListBuilder(_body, _document.MainDocumentPart.NumberingDefinitionsPart);
+            builder.AddItems(items);
         }
 
         public void AddParagraph(Action<IParagraphBuilder> action)

--- a/DocumentGeneration/DocumentBuilder.cs
+++ b/DocumentGeneration/DocumentBuilder.cs
@@ -33,10 +33,16 @@ namespace DocumentGeneration
             part.Numbering = new Numbering();
         }
 
-        public void AddNumberedList(string[] items)
+        public void AddNumberedList(Action<IListBuilder> action)
         {
             var builder = new NumberedListBuilder(_body, _document.MainDocumentPart.NumberingDefinitionsPart);
-            builder.AddItems(items);
+            action(builder);
+        }
+        
+        public void AddBulletedList(Action<IListBuilder> action)
+        {
+            var builder = new BulletedListBuilder(_body, _document.MainDocumentPart.NumberingDefinitionsPart);
+            action(builder);
         }
 
         public void AddParagraph(Action<IParagraphBuilder> action)

--- a/DocumentGeneration/Elements/TextElement.cs
+++ b/DocumentGeneration/Elements/TextElement.cs
@@ -2,12 +2,16 @@ namespace DocumentGeneration.Elements
 {
     public class TextElement
     {
+        public TextElement(string value = "")
+        {
+            Value = value;
+        }
+
         public bool Bold { get; set; }
         public string Colour { get; set; }
         public string FontSize { get; set; }
         public bool Italic { get; set; }
         public bool Underline { get; set; }
-        
         public string Value { get; set; }
     }
 }

--- a/DocumentGeneration/Interfaces/IDocumentBuilder.cs
+++ b/DocumentGeneration/Interfaces/IDocumentBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using DocumentGeneration.Interfaces.Parents;
 
 namespace DocumentGeneration.Interfaces
@@ -6,6 +7,8 @@ namespace DocumentGeneration.Interfaces
     public interface IDocumentBuilder : ITableParent, IParagraphParent
     {
         public void AddHeading(Action<IHeadingBuilder> action);
+        public void AddNumberedList(Action<IListBuilder> action);
+        public void AddBulletedList(Action<IListBuilder> action);
         public void AddHeader(Action<IHeaderBuilder> action);
         public void Build();
     }

--- a/DocumentGeneration/Interfaces/IListBuilder.cs
+++ b/DocumentGeneration/Interfaces/IListBuilder.cs
@@ -1,7 +1,11 @@
+using DocumentGeneration.Elements;
+
 namespace DocumentGeneration.Interfaces
 {
     public interface IListBuilder
     {
-        public void AddItems(string[] items);
+        public void AddItem(TextElement item);
+        public void AddItem(string item);
+        public void AddItem(TextElement[] elements);
     }
 }

--- a/DocumentGeneration/Interfaces/IListBuilder.cs
+++ b/DocumentGeneration/Interfaces/IListBuilder.cs
@@ -1,0 +1,7 @@
+namespace DocumentGeneration.Interfaces
+{
+    public interface IListBuilder
+    {
+        public void AddItems(string[] items);
+    }
+}

--- a/Frontend/Services/CreateHtbDocument.cs
+++ b/Frontend/Services/CreateHtbDocument.cs
@@ -189,6 +189,7 @@ namespace Frontend.Services
             });
 
             builder.AddParagraph(pBuilder => pBuilder.AddText(project.Rationale.Project));
+            builder.AddNumberedList(new[] {"One", "Two", "Three", "Four"});
 
             builder.AddHeading(hBuilder =>
             {

--- a/Frontend/Services/CreateHtbDocument.cs
+++ b/Frontend/Services/CreateHtbDocument.cs
@@ -196,9 +196,13 @@ namespace Frontend.Services
                 lBuilder.AddItem(new TextElement {Value = "Two"});
                 lBuilder.AddItem(new TextElement {Bold = true, Value = "Three"});
                 lBuilder.AddItem(new[]
-                    {new TextElement("Meow"), new TextElement(" Woof ") {Bold = true}, new TextElement("Quack")});
+                {
+                    new TextElement("Meow") {Bold = true},
+                    new TextElement(" Woof ") {Bold = true, Italic = true},
+                    new TextElement("Quack") {Bold = true, Italic = true, Underline = true}
+                });
             });
-            
+
             builder.AddBulletedList(lBuilder =>
             {
                 lBuilder.AddItem(new TextElement {Bold = true, Value = "One"});

--- a/Frontend/Services/CreateHtbDocument.cs
+++ b/Frontend/Services/CreateHtbDocument.cs
@@ -189,7 +189,24 @@ namespace Frontend.Services
             });
 
             builder.AddParagraph(pBuilder => pBuilder.AddText(project.Rationale.Project));
-            builder.AddNumberedList(new[] {"One", "Two", "Three", "Four"});
+
+            builder.AddNumberedList(lBuilder =>
+            {
+                lBuilder.AddItem(new TextElement {Bold = true, Value = "One"});
+                lBuilder.AddItem(new TextElement {Value = "Two"});
+                lBuilder.AddItem(new TextElement {Bold = true, Value = "Three"});
+                lBuilder.AddItem(new[]
+                    {new TextElement("Meow"), new TextElement(" Woof ") {Bold = true}, new TextElement("Quack")});
+            });
+            
+            builder.AddBulletedList(lBuilder =>
+            {
+                lBuilder.AddItem(new TextElement {Bold = true, Value = "One"});
+                lBuilder.AddItem(new TextElement {Value = "Two"});
+                lBuilder.AddItem(new TextElement {Bold = true, Value = "Three"});
+                lBuilder.AddItem(new[]
+                    {new TextElement("Meow"), new TextElement(" Woof ") {Bold = true}, new TextElement("Quack")});
+            });
 
             builder.AddHeading(hBuilder =>
             {


### PR DESCRIPTION
### Context

Future iterations of HTB templates will be using the MOJ Rich text editor, which supports users adding lists (with bold/italic/underlined text), as such we wanted to add support in now

### Changes proposed in this pull request

- Add support for single level numbered lists
- Add support for single level bulleted lists

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

