### PR TITLE
Allow HTML text to be added to word documents

### DIFF
--- a/DocumentGeneration.Tests/DocumentBuilderTests.cs
+++ b/DocumentGeneration.Tests/DocumentBuilderTests.cs
@@ -551,10 +551,10 @@ namespace DocumentGeneration.Tests
 
                 Assert.Single(abstractNumDefinitions);
                 Assert.Equal(NumberFormatValues.Bullet, numberingFormats[0].Val.Value);
-                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Equal(1, abstractNumDefinitions[0].AbstractNumberId.Value);
                 Assert.Single(numberingInstances);
-                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
-                Assert.Equal(0, (int) paragraph.ParagraphProperties.NumberingProperties.NumberingId.Val);
+                Assert.Equal(1, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(1, (int) paragraph.ParagraphProperties.NumberingProperties.NumberingId.Val);
             }
 
             [Fact]
@@ -574,11 +574,31 @@ namespace DocumentGeneration.Tests
                 Assert.Equal(NumberFormatValues.Bullet, numberingFormats[0].Val.Value);
                 Assert.Equal(NumberFormatValues.Bullet, numberingFormats[1].Val.Value);
                 Assert.Equal(2, abstractNumDefinitions.Count);
-                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
-                Assert.Equal(1, abstractNumDefinitions[1].AbstractNumberId.Value);
+                Assert.Equal(1, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Equal(2, abstractNumDefinitions[1].AbstractNumberId.Value);
                 Assert.Equal(2, numberingInstances.Count);
-                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
-                Assert.Equal(1, (int) numberingInstances[1].AbstractNumId.Val);
+                Assert.Equal(1, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(2, (int) numberingInstances[1].AbstractNumId.Val);
+            }
+
+            [Fact]
+            public void GivenAddingTwoBulletedLists_CreatesTwoNumberingDefinitionsInTheCorrectOrder()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddBulletedList(lBuilder => { lBuilder.AddItem("One"); });
+                    builder.AddBulletedList(lBuilder => { lBuilder.AddItem("Two"); });
+                });
+
+                var numbering = response.Numbering;
+                var numberingFormats = numbering.Elements().ToList();
+                Assert.IsType<AbstractNum>(numberingFormats[0]);
+                Assert.IsType<AbstractNum>(numberingFormats[1]);
+
+                var abstractNumOne = Assert.IsType<NumberingInstance>(numberingFormats[2]);
+                Assert.Equal(1, (int) abstractNumOne.AbstractNumId.Val);
+                var abstractNumTwo = Assert.IsType<NumberingInstance>(numberingFormats[3]);
+                Assert.Equal(2, (int) abstractNumTwo.AbstractNumId.Val);
             }
 
             [Fact]
@@ -598,7 +618,7 @@ namespace DocumentGeneration.Tests
 
                 Assert.Equal(3, paragraphs.Count);
                 Assert.True(paragraphs.All(p =>
-                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 1));
                 Assert.Equal("One", paragraphs[0].InnerText);
                 Assert.Equal("Two", paragraphs[1].InnerText);
                 Assert.Equal("Three", paragraphs[2].InnerText);
@@ -621,7 +641,7 @@ namespace DocumentGeneration.Tests
 
                 Assert.Equal(3, paragraphs.Count);
                 Assert.True(paragraphs.All(p =>
-                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 1));
                 Assert.Equal("One", paragraphs[0].InnerText);
                 Assert.Equal("Two", paragraphs[1].InnerText);
                 Assert.Equal("Three", paragraphs[2].InnerText);
@@ -642,7 +662,7 @@ namespace DocumentGeneration.Tests
 
                 Assert.Single(paragraphs);
                 Assert.True(paragraphs.All(p =>
-                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 1));
                 Assert.Equal("OneTwo", paragraphs[0].InnerText);
             }
         }
@@ -665,10 +685,10 @@ namespace DocumentGeneration.Tests
 
                 Assert.Single(abstractNumDefinitions);
                 Assert.Equal(NumberFormatValues.Decimal, numberingFormats[0].Val.Value);
-                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Equal(1, abstractNumDefinitions[0].AbstractNumberId.Value);
                 Assert.Single(numberingInstances);
-                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
-                Assert.Equal(0, (int) paragraph.ParagraphProperties.NumberingProperties.NumberingId.Val);
+                Assert.Equal(1, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(1, (int) paragraph.ParagraphProperties.NumberingProperties.NumberingId.Val);
             }
 
             [Fact]
@@ -688,11 +708,31 @@ namespace DocumentGeneration.Tests
                 Assert.Equal(NumberFormatValues.Decimal, numberingFormats[0].Val.Value);
                 Assert.Equal(NumberFormatValues.Decimal, numberingFormats[1].Val.Value);
                 Assert.Equal(2, abstractNumDefinitions.Count);
-                Assert.Equal(0, abstractNumDefinitions[0].AbstractNumberId.Value);
-                Assert.Equal(1, abstractNumDefinitions[1].AbstractNumberId.Value);
+                Assert.Equal(1, abstractNumDefinitions[0].AbstractNumberId.Value);
+                Assert.Equal(2, abstractNumDefinitions[1].AbstractNumberId.Value);
                 Assert.Equal(2, numberingInstances.Count);
-                Assert.Equal(0, (int) numberingInstances[0].AbstractNumId.Val);
-                Assert.Equal(1, (int) numberingInstances[1].AbstractNumId.Val);
+                Assert.Equal(1, (int) numberingInstances[0].AbstractNumId.Val);
+                Assert.Equal(2, (int) numberingInstances[1].AbstractNumId.Val);
+            }
+
+            [Fact]
+            public void GivenAddingTwoNumberedLists_CreatesTwoNumberingDefinitionsInTheCorrectOrder()
+            {
+                var response = GenerateDocument(builder =>
+                {
+                    builder.AddNumberedList(lBuilder => { lBuilder.AddItem("One"); });
+                    builder.AddNumberedList(lBuilder => { lBuilder.AddItem("Two"); });
+                });
+
+                var numbering = response.Numbering;
+                var numberingFormats = numbering.Elements().ToList();
+                Assert.IsType<AbstractNum>(numberingFormats[0]);
+                Assert.IsType<AbstractNum>(numberingFormats[1]);
+
+                var abstractNumOne = Assert.IsType<NumberingInstance>(numberingFormats[2]);
+                Assert.Equal(1, (int) abstractNumOne.AbstractNumId.Val);
+                var abstractNumTwo = Assert.IsType<NumberingInstance>(numberingFormats[3]);
+                Assert.Equal(2, (int) abstractNumTwo.AbstractNumId.Val);
             }
 
             [Fact]
@@ -712,7 +752,7 @@ namespace DocumentGeneration.Tests
 
                 Assert.Equal(3, paragraphs.Count);
                 Assert.True(paragraphs.All(p =>
-                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 1));
                 Assert.Equal("One", paragraphs[0].InnerText);
                 Assert.Equal("Two", paragraphs[1].InnerText);
                 Assert.Equal("Three", paragraphs[2].InnerText);
@@ -735,7 +775,7 @@ namespace DocumentGeneration.Tests
 
                 Assert.Equal(3, paragraphs.Count);
                 Assert.True(paragraphs.All(p =>
-                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 1));
                 Assert.Equal("One", paragraphs[0].InnerText);
                 Assert.Equal("Two", paragraphs[1].InnerText);
                 Assert.Equal("Three", paragraphs[2].InnerText);
@@ -756,7 +796,7 @@ namespace DocumentGeneration.Tests
 
                 Assert.Single(paragraphs);
                 Assert.True(paragraphs.All(p =>
-                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 0));
+                    p.ParagraphProperties.Descendants<NumberingProperties>().First().NumberingId.Val == 1));
                 Assert.Equal("OneTwo", paragraphs[0].InnerText);
             }
         }

--- a/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
+++ b/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DocumentGeneration.Elements;
+using DocumentGeneration.Helpers;
+using DocumentGeneration.Interfaces;
+using Xunit;
+
+namespace DocumentGeneration.Tests.Helpers
+{
+    public class HtmlToDocumentTests
+    {
+        private readonly DocumentBuilderFake _builder;
+
+        public HtmlToDocumentTests()
+        {
+            _builder = new DocumentBuilderFake();
+        }
+
+        private static string GetParagraphText(List<TextElement> paragraphElements)
+        {
+            return paragraphElements.Select(t => t.Value).Aggregate((acc, t) => acc + t);
+        }
+
+        [Theory]
+        [InlineData("Meow woof quack")]
+        [InlineData("Moo quack cluck")]
+        public void GivenParagraph_GeneratesParagraph(string text)
+        {
+            var html = $"<p>{text}</p>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedParagraphs);
+            Assert.Equal(text, _builder.AddedParagraphs[0][0].Value);
+        }
+
+        [Fact]
+        public void GivenParagraphWithMixedFormatting_GeneratesParagraphs()
+        {
+            const string html = "<p>Meow <b>Woof <u>Quack <i>Moo</i></u></b></p>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedParagraphs);
+            var paragraphElements = _builder.AddedParagraphs[0];
+
+            Assert.Equal("Meow Woof Quack Moo", GetParagraphText(paragraphElements));
+            Assert.True(paragraphElements[1].Bold);
+            Assert.True(paragraphElements[2].Bold);
+            Assert.True(paragraphElements[2].Underline);
+            Assert.True(paragraphElements[3].Bold);
+            Assert.True(paragraphElements[3].Underline);
+            Assert.True(paragraphElements[3].Italic);
+        }
+
+        [Fact]
+        public void GivenParagraphContainsABreak_GenerateParagraphWithNewline()
+        {
+            const string html = "<p>Meow<br>Woof</p>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedParagraphs);
+            var paragraphElements = _builder.AddedParagraphs[0];
+
+            Assert.Equal("Meow\nWoof", GetParagraphText(paragraphElements));
+        }
+
+        [Fact]
+        public void GivenOrderedListWithSingleListItem_RendersNumberedList()
+        {
+            const string html = "<ol><li>Meow</li></ol>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedLists);
+            var list = _builder.AddedLists[0];
+            Assert.Equal("number", list.Type);
+            Assert.Single(list.AddedItems);
+            Assert.Single(list.AddedItems[0]);
+            Assert.Equal("Meow", list.AddedItems[0][0].Value);
+        }
+
+        [Fact]
+        public void GivenOrderedListWithSeveralListItems_RendersNumberedList()
+        {
+            const string html = "<ol><li>Meow</li><li>Woof</li><li>Quack</li></ol>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedLists);
+            var list = _builder.AddedLists[0];
+            Assert.Equal("number", list.Type);
+            Assert.Equal(3, list.AddedItems.Count);
+            Assert.Single(list.AddedItems[0]);
+            Assert.Single(list.AddedItems[1]);
+            Assert.Single(list.AddedItems[2]);
+            Assert.Equal("Meow", list.AddedItems[0][0].Value);
+            Assert.Equal("Woof", list.AddedItems[1][0].Value);
+            Assert.Equal("Quack", list.AddedItems[2][0].Value);
+        }
+
+        [Fact]
+        public void GivenOrderedListWithSeveralListItemsWithMixedFormatting_RendersNumberedList()
+        {
+            const string html =
+                "<ol><li><b>Me<i>ow</i></b></li><li>W<u>oo</u>f</li><li><b><u><i>Quack</b></u></i></li></ol>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedLists);
+            var list = _builder.AddedLists[0];
+            Assert.Equal("number", list.Type);
+            Assert.Equal(3, list.AddedItems.Count);
+
+            var firstItem = list.AddedItems[0];
+            Assert.Equal(2, firstItem.Count);
+            Assert.Equal("Me", firstItem[0].Value);
+            Assert.True(firstItem[0].Bold);
+            Assert.Equal("ow", firstItem[1].Value);
+            Assert.True(firstItem[1].Bold);
+            Assert.True(firstItem[1].Italic);
+
+            var secondItem = list.AddedItems[1];
+            Assert.Equal(3, secondItem.Count);
+            Assert.Equal("W", secondItem[0].Value);
+            Assert.Equal("oo", secondItem[1].Value);
+            Assert.True(secondItem[1].Underline);
+            Assert.Equal("f", secondItem[2].Value);
+
+            var thirdItem = list.AddedItems[2];
+            Assert.Single(thirdItem);
+            Assert.Equal("Quack", thirdItem[0].Value);
+            Assert.True(thirdItem[0].Bold);
+            Assert.True(thirdItem[0].Italic);
+            Assert.True(thirdItem[0].Underline);
+        }
+
+        [Fact]
+        public void GivenUnorderedListWithSingleListItem_RendersBulletList()
+        {
+            const string html = "<ul><li>Meow</li></ul>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedLists);
+            var list = _builder.AddedLists[0];
+            Assert.Equal("bullet", list.Type);
+            Assert.Single(list.AddedItems);
+            Assert.Single(list.AddedItems[0]);
+            Assert.Equal("Meow", list.AddedItems[0][0].Value);
+        }
+
+        [Fact]
+        public void GivenUnorderedListWithSeveralListItems_RendersBulletList()
+        {
+            const string html = "<ul><li>Meow</li><li>Woof</li><li>Quack</li></ul>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedLists);
+            var list = _builder.AddedLists[0];
+            Assert.Equal("bullet", list.Type);
+            Assert.Equal(3, list.AddedItems.Count);
+            Assert.Single(list.AddedItems[0]);
+            Assert.Single(list.AddedItems[1]);
+            Assert.Single(list.AddedItems[2]);
+            Assert.Equal("Meow", list.AddedItems[0][0].Value);
+            Assert.Equal("Woof", list.AddedItems[1][0].Value);
+            Assert.Equal("Quack", list.AddedItems[2][0].Value);
+        }
+
+        [Fact]
+        public void GivenUnorderedListWithSeveralListItemsWithMixedFormatting_RendersBulletList()
+        {
+            const string html =
+                "<ul><li><b>Me<i>ow</i></b></li><li>W<u>oo</u>f</li><li><b><u><i>Quack</b></u></i></li></ul>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedLists);
+            var list = _builder.AddedLists[0];
+            Assert.Equal("bullet", list.Type);
+            Assert.Equal(3, list.AddedItems.Count);
+
+            var firstItem = list.AddedItems[0];
+            Assert.Equal(2, firstItem.Count);
+            Assert.Equal("Me", firstItem[0].Value);
+            Assert.True(firstItem[0].Bold);
+            Assert.Equal("ow", firstItem[1].Value);
+            Assert.True(firstItem[1].Bold);
+            Assert.True(firstItem[1].Italic);
+
+            var secondItem = list.AddedItems[1];
+            Assert.Equal(3, secondItem.Count);
+            Assert.Equal("W", secondItem[0].Value);
+            Assert.Equal("oo", secondItem[1].Value);
+            Assert.True(secondItem[1].Underline);
+            Assert.Equal("f", secondItem[2].Value);
+
+            var thirdItem = list.AddedItems[2];
+            Assert.Single(thirdItem);
+            Assert.Equal("Quack", thirdItem[0].Value);
+            Assert.True(thirdItem[0].Bold);
+            Assert.True(thirdItem[0].Italic);
+            Assert.True(thirdItem[0].Underline);
+        }
+
+        [Fact]
+        public void GivenNoTopLevelElements_RendersItInParagraph()
+        {
+            const string html = "Meow<b>Woof<u>Quack<i>Moo</i></u></b>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Single(_builder.AddedParagraphs);
+            var textElements = _builder.AddedParagraphs[0];
+            Assert.Equal("MeowWoofQuackMoo", GetParagraphText(textElements));
+            Assert.True(textElements[1].Bold);
+            Assert.True(textElements[2].Bold);
+            Assert.True(textElements[2].Underline);
+            Assert.True(textElements[3].Bold);
+            Assert.True(textElements[3].Underline);
+            Assert.True(textElements[3].Italic);
+        }
+    }
+
+    public class ParagraphBuilderFake : IParagraphBuilder
+    {
+        public List<TextElement> AddedItems { get; }
+
+        public ParagraphBuilderFake()
+        {
+            AddedItems = new List<TextElement>();
+        }
+
+        public void AddText(string text)
+        {
+            AddedItems.Add(new TextElement(text));
+        }
+
+        public void AddText(TextElement textElement)
+        {
+            AddedItems.Add(textElement);
+        }
+
+        public void AddText(TextElement[] text)
+        {
+            foreach (var t in text)
+            {
+                AddedItems.Add(t);
+            }
+        }
+
+        public void AddNewLine()
+        {
+            AddedItems.Add(new TextElement("\n"));
+        }
+
+        public void Justify(ParagraphJustification paragraphJustification)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class ListBuilderFake : IListBuilder
+    {
+        public List<List<TextElement>> AddedItems { get; }
+
+        public ListBuilderFake()
+        {
+            AddedItems = new List<List<TextElement>>();
+        }
+
+        public void AddItem(TextElement item)
+        {
+            AddedItems.Add(new List<TextElement> {item});
+        }
+
+        public void AddItem(string item)
+        {
+            AddedItems.Add(new List<TextElement> {new TextElement(item)});
+        }
+
+        public void AddItem(TextElement[] elements)
+        {
+            AddedItems.Add(elements.ToList());
+        }
+
+        public void AddItem(Action<IParagraphBuilder> action)
+        {
+            var builder = new ParagraphBuilderFake();
+            action(builder);
+            AddedItems.Add(builder.AddedItems);
+        }
+    }
+
+    public class ListFake
+    {
+        public string Type { get; set; }
+        public List<List<TextElement>> AddedItems { get; set; }
+    }
+
+    public class DocumentBuilderFake : IDocumentBuilder
+    {
+        public List<List<TextElement>> AddedParagraphs { get; }
+        public List<ListFake> AddedLists { get; }
+
+        public DocumentBuilderFake()
+        {
+            AddedParagraphs = new List<List<TextElement>>();
+            AddedLists = new List<ListFake>();
+        }
+
+        public void AddTable(Action<ITableBuilder> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddTable(IEnumerable<TextElement[]> rows)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddParagraph(Action<IParagraphBuilder> action)
+        {
+            var builder = new ParagraphBuilderFake();
+            action(builder);
+            AddedParagraphs.Add(builder.AddedItems);
+        }
+
+        public void AddHeading(Action<IHeadingBuilder> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddNumberedList(Action<IListBuilder> action)
+        {
+            var listFake = new ListFake {Type = "number"};
+            var builder = new ListBuilderFake();
+            action(builder);
+            listFake.AddedItems = builder.AddedItems;
+            AddedLists.Add(listFake);
+        }
+
+        public void AddBulletedList(Action<IListBuilder> action)
+        {
+            var listFake = new ListFake {Type = "bullet"};
+            var builder = new ListBuilderFake();
+            action(builder);
+            listFake.AddedItems = builder.AddedItems;
+            AddedLists.Add(listFake);
+        }
+
+        public void AddHeader(Action<IHeaderBuilder> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Build()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
+++ b/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
@@ -214,6 +214,16 @@ namespace DocumentGeneration.Tests.Helpers
             Assert.True(textElements[3].Underline);
             Assert.True(textElements[3].Italic);
         }
+
+        [Fact]
+        public void GivenStartOfHtmlDoesntContainTopLevelElement_RendersItInAParagraph()
+        {
+            const string html = "Meow<b>Woof<u>Quack<i>Moo</i></u></b><p>Second paragraph</p>";
+            HtmlToDocument.Convert(_builder, html);
+            
+            Assert.Equal(2, _builder.AddedParagraphs.Count);
+            Assert.Equal("MeowWoofQuackMoo", GetParagraphText(_builder.AddedParagraphs[0]));
+        }
     }
 
     public class ParagraphBuilderFake : IParagraphBuilder
@@ -344,6 +354,11 @@ namespace DocumentGeneration.Tests.Helpers
         }
 
         public void AddHeader(Action<IHeaderBuilder> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddFooter(Action<IFooterBuilder> action)
         {
             throw new NotImplementedException();
         }

--- a/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
+++ b/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
@@ -236,6 +236,47 @@ namespace DocumentGeneration.Tests.Helpers
             Assert.Equal(2, _builder.AddedParagraphs.Count);
             Assert.Equal("MeowWoofQuackMoo", GetParagraphText(_builder.AddedParagraphs[0]));
         }
+
+        [Fact]
+        public void GivenTextNotContainedWithinParagraphMidText_RendersItInAParagraph()
+        {
+            const string html = "<p>Opening paragraph</p>Meow<b>Woof<u>Quack<i>Moo</i></u></b><p>Second paragraph</p>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Equal(3, _builder.AddedParagraphs.Count);
+            Assert.Equal("MeowWoofQuackMoo", GetParagraphText(_builder.AddedParagraphs[1]));
+        }
+
+        [Fact]
+        public void GivenDivsAsParagraphs_RenderAsParagraphs()
+        {
+            const string html = "<div>Meow</div><div>Woof</div>";
+            HtmlToDocument.Convert(_builder, html);
+
+            Assert.Equal(2, _builder.AddedParagraphs.Count);
+            Assert.Equal("Meow", GetParagraphText(_builder.AddedParagraphs[0]));
+            Assert.Equal("Woof", GetParagraphText(_builder.AddedParagraphs[1]));
+        }
+
+        [Fact]
+        public void GivenDivsWithNestedElements_RenderNestedElements()
+        {
+            const string html = "<div>meow</div><div><ul><li>woof</li></ul></div>";
+            HtmlToDocument.Convert(_builder, html);
+            Assert.Single(_builder.AddedParagraphs);
+            Assert.Single(_builder.AddedLists);
+            Assert.Single(_builder.AddedLists[0].AddedItems);
+            Assert.Equal("woof", _builder.AddedLists[0].AddedItems[0][0].Value);
+        }
+        
+        [Fact]
+        public void GivenSpanWithAttributesAroundText_RenderParagraphWithoutThem()
+        {
+            const string html = "<div><span style='color:#ff69b4'>meow</span></div>";
+            HtmlToDocument.Convert(_builder, html);
+            Assert.Single(_builder.AddedParagraphs);
+            Assert.Equal("meow", GetParagraphText(_builder.AddedParagraphs[0]));
+        }
     }
 
     public class ParagraphBuilderFake : IParagraphBuilder

--- a/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
+++ b/DocumentGeneration.Tests/Helpers/HtmlToDocumentTests.cs
@@ -23,8 +23,20 @@ namespace DocumentGeneration.Tests.Helpers
         }
 
         [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GivenEmptyOrNull_BuildsNothing(string text)
+        {
+            HtmlToDocument.Convert(_builder, text);
+
+            Assert.Empty(_builder.AddedParagraphs);
+            Assert.Empty(_builder.AddedLists);
+        }
+
+        [Theory]
         [InlineData("Meow woof quack")]
         [InlineData("Moo quack cluck")]
+        [InlineData("     ")]
         public void GivenParagraph_GeneratesParagraph(string text)
         {
             var html = $"<p>{text}</p>";
@@ -220,7 +232,7 @@ namespace DocumentGeneration.Tests.Helpers
         {
             const string html = "Meow<b>Woof<u>Quack<i>Moo</i></u></b><p>Second paragraph</p>";
             HtmlToDocument.Convert(_builder, html);
-            
+
             Assert.Equal(2, _builder.AddedParagraphs.Count);
             Assert.Equal("MeowWoofQuackMoo", GetParagraphText(_builder.AddedParagraphs[0]));
         }

--- a/DocumentGeneration/Builders/BulletedListBuilder.cs
+++ b/DocumentGeneration/Builders/BulletedListBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml;
@@ -19,6 +20,24 @@ namespace DocumentGeneration.Builders
             _parent = parent;
             _numberingDefinitionsPart = numberingDefinitionsPart;
             _numId = AddNumberingDefinitions();
+        }
+
+        public void AddItem(Action<IParagraphBuilder> action)
+        {
+            var paragraph = new Paragraph
+            {
+                ParagraphProperties = new ParagraphProperties
+                {
+                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
+                    {
+                        new NumberingLevelReference {Val = 0},
+                        new NumberingId {Val = _numId}
+                    })
+                }
+            };
+            var paragraphBuilder = new ParagraphBuilder(paragraph);
+            action(paragraphBuilder);
+            _parent.AppendChild(paragraph);
         }
 
         public void AddItem(string item)

--- a/DocumentGeneration/Builders/BulletedListBuilder.cs
+++ b/DocumentGeneration/Builders/BulletedListBuilder.cs
@@ -1,126 +1,57 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
-using DocumentGeneration.Elements;
-using DocumentGeneration.Interfaces;
 
 namespace DocumentGeneration.Builders
 {
-    public class BulletedListBuilder : IListBuilder
+    public class BulletedListBuilder : ListBuilder
     {
-        private readonly OpenXmlElement _parent;
-        private readonly NumberingDefinitionsPart _numberingDefinitionsPart;
-        private readonly int _numId;
-
         public BulletedListBuilder(OpenXmlElement parent, NumberingDefinitionsPart numberingDefinitionsPart)
         {
-            _parent = parent;
-            _numberingDefinitionsPart = numberingDefinitionsPart;
-            _numId = AddNumberingDefinitions();
-        }
-
-        public void AddItem(Action<IParagraphBuilder> action)
-        {
-            var paragraph = new Paragraph
-            {
-                ParagraphProperties = new ParagraphProperties
-                {
-                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
-                    {
-                        new NumberingLevelReference {Val = 0},
-                        new NumberingId {Val = _numId}
-                    })
-                }
-            };
-            var paragraphBuilder = new ParagraphBuilder(paragraph);
-            action(paragraphBuilder);
-            _parent.AppendChild(paragraph);
-        }
-
-        public void AddItem(string item)
-        {
-            AddItem(new TextElement(item));
-        }
-
-        public void AddItem(TextElement item)
-        {
-            var paragraph = new Paragraph
-            {
-                ParagraphProperties = new ParagraphProperties
-                {
-                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
-                    {
-                        new NumberingLevelReference {Val = 0},
-                        new NumberingId {Val = _numId}
-                    })
-                }
-            };
-            var paragraphBuilder = new ParagraphBuilder(paragraph);
-            paragraphBuilder.AddText(item);
-            _parent.AppendChild(paragraph);
-        }
-
-        public void AddItem(TextElement[] elements)
-        {
-            var paragraph = new Paragraph
-            {
-                ParagraphProperties = new ParagraphProperties
-                {
-                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
-                    {
-                        new NumberingLevelReference {Val = 0},
-                        new NumberingId {Val = _numId}
-                    })
-                }
-            };
-            var paragraphBuilder = new ParagraphBuilder(paragraph);
-            paragraphBuilder.AddText(elements);
-            _parent.AppendChild(paragraph);
+            Parent = parent;
+            NumberingDefinitionsPart = numberingDefinitionsPart;
+            NumId = AddNumberingDefinitions();
         }
 
         private int AddNumberingDefinitions()
         {
-            var numberingDefinitionCount = _numberingDefinitionsPart.Numbering.Descendants<AbstractNum>().Count();
+            var numberingDefinitionCount = NumberingDefinitionsPart.Numbering.Descendants<AbstractNum>().Count() + 1;
 
-            var numberingDefinition = new List<OpenXmlElement>
+            var abstractNum = new AbstractNum(
+                new Level(
+                    new List<OpenXmlElement>
+                    {
+                        new StartNumberingValue {Val = 1},
+                        new NumberingFormat
+                            {Val = new EnumValue<NumberFormatValues>(NumberFormatValues.Bullet)},
+                        new LevelText {Val = ""},
+                        new LevelJustification
+                            {Val = new EnumValue<LevelJustificationValues>(LevelJustificationValues.Left)},
+                        new ParagraphProperties(
+                            new Indentation {Left = "720", Hanging = "360"}
+                        ),
+                        new RunProperties(
+                            new RunFonts
+                            {
+                                Ascii = "Symbol", HighAnsi = "Symbol", ComplexScript = "Symbol",
+                                Hint = new EnumValue<FontTypeHintValues>(FontTypeHintValues.Default)
+                            }
+                        )
+                    }
+                ) {LevelIndex = 0}
+            )
             {
-                new AbstractNum(
-                    new Level(
-                        new List<OpenXmlElement>
-                        {
-                            new StartNumberingValue {Val = 1},
-                            new NumberingFormat
-                                {Val = new EnumValue<NumberFormatValues>(NumberFormatValues.Bullet)},
-                            new LevelText {Val = ""},
-                            new LevelJustification
-                                {Val = new EnumValue<LevelJustificationValues>(LevelJustificationValues.Left)},
-                            new ParagraphProperties(
-                                new Indentation {Left = "720", Hanging = "360"}
-                            ),
-                            new RunProperties(
-                                new RunFonts
-                                {
-                                    Ascii = "Symbol", HighAnsi = "Symbol", ComplexScript = "Symbol",
-                                    Hint = new EnumValue<FontTypeHintValues>(FontTypeHintValues.Default)
-                                }
-                            )
-                        }
-                    ) {LevelIndex = 0}
-                )
-                {
-                    AbstractNumberId = numberingDefinitionCount
-                },
-                new NumberingInstance(new AbstractNumId {Val = numberingDefinitionCount})
-                {
-                    NumberID = numberingDefinitionCount
-                }
+                AbstractNumberId = numberingDefinitionCount
             };
 
-            _numberingDefinitionsPart.Numbering.AppendChild(numberingDefinition[0]);
-            _numberingDefinitionsPart.Numbering.AppendChild(numberingDefinition[1]);
+            var numberingInstance = new NumberingInstance(new AbstractNumId {Val = numberingDefinitionCount})
+            {
+                NumberID = numberingDefinitionCount
+            };
+
+            AddNumberingDefinitions(abstractNum, numberingInstance);
 
             return numberingDefinitionCount;
         }

--- a/DocumentGeneration/Builders/ListBuilder.cs
+++ b/DocumentGeneration/Builders/ListBuilder.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentGeneration.Elements;
+using DocumentGeneration.Interfaces;
+
+namespace DocumentGeneration.Builders
+{
+    public abstract class ListBuilder : IListBuilder
+    {
+        protected OpenXmlElement Parent;
+        protected NumberingDefinitionsPart NumberingDefinitionsPart;
+        protected int NumId;
+
+        public void AddItem(Action<IParagraphBuilder> action)
+        {
+            var paragraph = new Paragraph
+            {
+                ParagraphProperties = new ParagraphProperties
+                {
+                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
+                    {
+                        new NumberingLevelReference {Val = 0},
+                        new NumberingId {Val = NumId}
+                    })
+                }
+            };
+            var paragraphBuilder = new ParagraphBuilder(paragraph);
+            action(paragraphBuilder);
+            Parent.AppendChild(paragraph);
+        }
+
+        public void AddItem(string item)
+        {
+            AddItem(new TextElement(item));
+        }
+
+
+        public void AddItem(TextElement item)
+        {
+            var paragraph = new Paragraph
+            {
+                ParagraphProperties = new ParagraphProperties
+                {
+                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
+                    {
+                        new NumberingLevelReference {Val = 0},
+                        new NumberingId {Val = NumId}
+                    })
+                }
+            };
+            var paragraphBuilder = new ParagraphBuilder(paragraph);
+            paragraphBuilder.AddText(item);
+            Parent.AppendChild(paragraph);
+        }
+
+        public void AddItem(TextElement[] elements)
+        {
+            var paragraph = new Paragraph
+            {
+                ParagraphProperties = new ParagraphProperties
+                {
+                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
+                    {
+                        new NumberingLevelReference {Val = 0},
+                        new NumberingId {Val = NumId}
+                    })
+                }
+            };
+            var paragraphBuilder = new ParagraphBuilder(paragraph);
+            paragraphBuilder.AddText(elements);
+            Parent.AppendChild(paragraph);
+        }
+        
+        protected void AddNumberingDefinitions(AbstractNum abstractNum, NumberingInstance numberingInstance)
+        {
+            var numberingDefinitionCount = NumberingDefinitionsPart.Numbering.Descendants<AbstractNum>().Count();
+
+            if (numberingDefinitionCount > 0)
+            {
+                var lastAbstract = NumberingDefinitionsPart.Numbering.Descendants<AbstractNum>().Last();
+                NumberingDefinitionsPart.Numbering.InsertAfter(abstractNum, lastAbstract);
+
+                var lastNumberingInstance = NumberingDefinitionsPart.Numbering.Descendants<NumberingInstance>().Last();
+                NumberingDefinitionsPart.Numbering.InsertAfter(numberingInstance, lastNumberingInstance);
+            }
+            else
+            {
+                NumberingDefinitionsPart.Numbering.AppendChild(abstractNum);
+                NumberingDefinitionsPart.Numbering.AppendChild(numberingInstance);
+            }
+        }
+    }
+}

--- a/DocumentGeneration/Builders/NumberedListBuilder.cs
+++ b/DocumentGeneration/Builders/NumberedListBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml;
@@ -19,6 +20,24 @@ namespace DocumentGeneration.Builders
             _parent = parent;
             _numberingDefinitionsPart = numberingDefinitionsPart;
             _numId = AddNumberingDefinitions();
+        }
+
+        public void AddItem(Action<IParagraphBuilder> action)
+        {
+            var paragraph = new Paragraph
+            {
+                ParagraphProperties = new ParagraphProperties
+                {
+                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
+                    {
+                        new NumberingLevelReference {Val = 0},
+                        new NumberingId {Val = _numId}
+                    })
+                }
+            };
+            var paragraphBuilder = new ParagraphBuilder(paragraph);
+            action(paragraphBuilder);
+            _parent.AppendChild(paragraph);
         }
 
         public void AddItem(string item)

--- a/DocumentGeneration/Builders/NumberedListBuilder.cs
+++ b/DocumentGeneration/Builders/NumberedListBuilder.cs
@@ -1,121 +1,51 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
-using DocumentGeneration.Elements;
-using DocumentGeneration.Interfaces;
 
 namespace DocumentGeneration.Builders
 {
-    public class NumberedListBuilder : IListBuilder
+    public class NumberedListBuilder : ListBuilder
     {
-        private readonly OpenXmlElement _parent;
-        private readonly NumberingDefinitionsPart _numberingDefinitionsPart;
-        private readonly int _numId;
-
         public NumberedListBuilder(OpenXmlElement parent, NumberingDefinitionsPart numberingDefinitionsPart)
         {
-            _parent = parent;
-            _numberingDefinitionsPart = numberingDefinitionsPart;
-            _numId = AddNumberingDefinitions();
-        }
-
-        public void AddItem(Action<IParagraphBuilder> action)
-        {
-            var paragraph = new Paragraph
-            {
-                ParagraphProperties = new ParagraphProperties
-                {
-                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
-                    {
-                        new NumberingLevelReference {Val = 0},
-                        new NumberingId {Val = _numId}
-                    })
-                }
-            };
-            var paragraphBuilder = new ParagraphBuilder(paragraph);
-            action(paragraphBuilder);
-            _parent.AppendChild(paragraph);
-        }
-
-        public void AddItem(string item)
-        {
-            AddItem(new TextElement(item));
-        }
-
-
-        public void AddItem(TextElement item)
-        {
-            var paragraph = new Paragraph
-            {
-                ParagraphProperties = new ParagraphProperties
-                {
-                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
-                    {
-                        new NumberingLevelReference {Val = 0},
-                        new NumberingId {Val = _numId}
-                    })
-                }
-            };
-            var paragraphBuilder = new ParagraphBuilder(paragraph);
-            paragraphBuilder.AddText(item);
-            _parent.AppendChild(paragraph);
-        }
-
-        public void AddItem(TextElement[] elements)
-        {
-            var paragraph = new Paragraph
-            {
-                ParagraphProperties = new ParagraphProperties
-                {
-                    NumberingProperties = new NumberingProperties(new List<OpenXmlElement>
-                    {
-                        new NumberingLevelReference {Val = 0},
-                        new NumberingId {Val = _numId}
-                    })
-                }
-            };
-            var paragraphBuilder = new ParagraphBuilder(paragraph);
-            paragraphBuilder.AddText(elements);
-            _parent.AppendChild(paragraph);
+            Parent = parent;
+            NumberingDefinitionsPart = numberingDefinitionsPart;
+            NumId = AddNumberingDefinitions();
         }
 
         private int AddNumberingDefinitions()
         {
-            var numberingDefinitionCount = _numberingDefinitionsPart.Numbering.Descendants<AbstractNum>().Count();
+            var numberingDefinitionCount = NumberingDefinitionsPart.Numbering.Descendants<AbstractNum>().Count() + 1;
 
-            var numberingDefinition = new List<OpenXmlElement>
+            var abstractNum = new AbstractNum(
+                new Level(
+                    new List<OpenXmlElement>
+                    {
+                        new StartNumberingValue {Val = 1},
+                        new NumberingFormat
+                            {Val = new EnumValue<NumberFormatValues>(NumberFormatValues.Decimal)},
+                        new LevelText {Val = "%1."},
+                        new LevelJustification
+                            {Val = new EnumValue<LevelJustificationValues>(LevelJustificationValues.Left)},
+                        new ParagraphProperties(
+                            new Indentation {Left = "720", Hanging = "360"}
+                        )
+                    }
+                ) {LevelIndex = 0}
+            )
             {
-                new AbstractNum(
-                    new Level(
-                        new List<OpenXmlElement>
-                        {
-                            new StartNumberingValue {Val = 1},
-                            new NumberingFormat
-                                {Val = new EnumValue<NumberFormatValues>(NumberFormatValues.Decimal)},
-                            new LevelText {Val = "%1."},
-                            new LevelJustification
-                                {Val = new EnumValue<LevelJustificationValues>(LevelJustificationValues.Left)},
-                            new ParagraphProperties(
-                                new Indentation {Left = "720", Hanging = "360"}
-                            )
-                        }
-                    ) {LevelIndex = 0}
-                )
-                {
-                    AbstractNumberId = numberingDefinitionCount
-                },
-                new NumberingInstance(new AbstractNumId {Val = numberingDefinitionCount})
-                {
-                    NumberID = numberingDefinitionCount
-                }
+                AbstractNumberId = numberingDefinitionCount
             };
 
-            _numberingDefinitionsPart.Numbering.AppendChild(numberingDefinition[0]);
-            _numberingDefinitionsPart.Numbering.AppendChild(numberingDefinition[1]);
+            var numberingInstance = new NumberingInstance(new AbstractNumId {Val = numberingDefinitionCount})
+            {
+                NumberID = numberingDefinitionCount
+            };
 
+            AddNumberingDefinitions(abstractNum, numberingInstance);
+            
             return numberingDefinitionCount;
         }
     }

--- a/DocumentGeneration/Builders/ParagraphBuilder.cs
+++ b/DocumentGeneration/Builders/ParagraphBuilder.cs
@@ -75,6 +75,11 @@ namespace DocumentGeneration.Builders
             }
         }
 
+        public void AddNewLine()
+        {
+            _parent.AppendChild(new Run(new Break()));
+        }
+
         public void Justify(ParagraphJustification paragraphJustification)
         {
             var justification = new Justification();

--- a/DocumentGeneration/Helpers/HtmlToDocument.cs
+++ b/DocumentGeneration/Helpers/HtmlToDocument.cs
@@ -56,12 +56,23 @@ namespace DocumentGeneration.Helpers
                 return res.Append(elementsToGroup.Prepend("<p>").ToList()).ToList();
             }
 
+            if (!Regex.IsMatch(elementsToGroup[0], TopLevelElementOpenPattern))
+            {
+                var nextElements = elementsToGroup
+                    .TakeWhile(element => !Regex.IsMatch(element, TopLevelElementOpenPattern))
+                    .Prepend("<p>").ToList();
+                res.Add(nextElements);
+                
+                elementsToGroup = elementsToGroup
+                    .SkipWhile(element => !Regex.IsMatch(element, TopLevelElementOpenPattern))
+                    .ToList();
+            }
 
             while (elementsToGroup.Count > 0)
             {
                 List<string> nextElement;
                 (nextElement, elementsToGroup) = ParseNextTopLevelElement(elementsToGroup);
-                res = res.Append(nextElement).ToList();
+                res.Add(nextElement);
             }
 
             return res;

--- a/DocumentGeneration/Helpers/HtmlToDocument.cs
+++ b/DocumentGeneration/Helpers/HtmlToDocument.cs
@@ -14,6 +14,11 @@ namespace DocumentGeneration.Helpers
 
         public static void Convert(IDocumentBuilder builder, string html)
         {
+            if (string.IsNullOrEmpty(html))
+            {
+                return;
+            }
+
             var res = SplitHtmlIntoTopLevelElements(html);
             BuildDocumentFromTopLevelElements(builder, res);
         }
@@ -62,7 +67,7 @@ namespace DocumentGeneration.Helpers
                     .TakeWhile(element => !Regex.IsMatch(element, TopLevelElementOpenPattern))
                     .Prepend("<p>").ToList();
                 res.Add(nextElements);
-                
+
                 elementsToGroup = elementsToGroup
                     .SkipWhile(element => !Regex.IsMatch(element, TopLevelElementOpenPattern))
                     .ToList();

--- a/DocumentGeneration/Helpers/HtmlToDocument.cs
+++ b/DocumentGeneration/Helpers/HtmlToDocument.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DocumentGeneration.Elements;
+using DocumentGeneration.Interfaces;
+using DocumentGeneration.Interfaces.Parents;
+
+namespace DocumentGeneration.Helpers
+{
+    public static class HtmlToDocument
+    {
+        private const string ElementPattern = @"(<\/?(?:ol|ul|b|i|u|p|li|br)>)";
+        private const string TopLevelElementOpenPattern = @"<(?:ol|ul|p)>";
+
+        public static void Convert(IDocumentBuilder builder, string html)
+        {
+            var res = SplitHtmlIntoTopLevelElements(html);
+            BuildDocumentFromTopLevelElements(builder, res);
+        }
+
+        private static void BuildDocumentFromTopLevelElements(IDocumentBuilder builder, List<List<string>> res)
+        {
+            foreach (var elementList in res)
+            {
+                switch (elementList[0])
+                {
+                    case "<p>":
+                        builder.AddParagraph(pBuilder =>
+                        {
+                            BuildParagraphFromElements(pBuilder, elementList.Skip(1).ToList());
+                        });
+                        break;
+                    case "<ul>":
+                        builder.AddBulletedList(lBuilder =>
+                        {
+                            BuildListFromElements(lBuilder, elementList.Skip(1).ToList());
+                        });
+                        break;
+                    case "<ol>":
+                        builder.AddNumberedList(lBuilder =>
+                        {
+                            BuildListFromElements(lBuilder, elementList.Skip(1).ToList());
+                        });
+                        break;
+                }
+            }
+        }
+
+        private static List<List<string>> SplitHtmlIntoTopLevelElements(string html)
+        {
+            var elementsToGroup = SplitHtmlIntoElements(html);
+            var res = new List<List<string>>();
+
+            if (!elementsToGroup.Any(element => Regex.IsMatch(element, TopLevelElementOpenPattern)))
+            {
+                return res.Append(elementsToGroup.Prepend("<p>").ToList()).ToList();
+            }
+
+
+            while (elementsToGroup.Count > 0)
+            {
+                List<string> nextElement;
+                (nextElement, elementsToGroup) = ParseNextTopLevelElement(elementsToGroup);
+                res = res.Append(nextElement).ToList();
+            }
+
+            return res;
+        }
+
+        private static List<string> SplitHtmlIntoElements(string html)
+        {
+            return Regex.Split(html, ElementPattern).Where(element => !string.IsNullOrEmpty(element)).ToList();
+        }
+
+        private static void BuildListFromElements(IListBuilder lBuilder, List<string> elements)
+        {
+            while (elements.Count > 0)
+            {
+                elements = GetNextListItem(lBuilder, elements);
+            }
+        }
+
+        private static List<string> GetNextListItem(IListBuilder listBuilder, List<string> elements)
+        {
+            var elementsToParse = elements.Skip(1).TakeWhile(element => element != "</li>").ToList();
+            var remaining = elements.SkipWhile(element => element != "</li>").Skip(1).ToList();
+            listBuilder.AddItem(pBuilder => { BuildParagraphFromElements(pBuilder, elementsToParse); });
+            return remaining;
+        }
+
+        private static void BuildParagraphFromElements(IParagraphBuilder pBuilder, List<string> elements)
+        {
+            var tagsEnabled = new List<string>();
+
+            foreach (var element in elements)
+            {
+                switch (element)
+                {
+                    case "<b>":
+                        tagsEnabled.Add("b");
+                        break;
+                    case "</b>":
+                        tagsEnabled.Remove("b");
+                        break;
+                    case "<u>":
+                        tagsEnabled.Add("u");
+                        break;
+                    case "</u>":
+                        tagsEnabled.Remove("u");
+                        break;
+                    case "<i>":
+                        tagsEnabled.Add("i");
+                        break;
+                    case "</i>":
+                        tagsEnabled.Remove("i");
+                        break;
+                    case "<br>":
+                        pBuilder.AddNewLine();
+                        break;
+                    default:
+                        AddTextElementToParagraph(pBuilder, element, tagsEnabled);
+                        break;
+                }
+            }
+        }
+
+        private static void AddTextElementToParagraph(ITextParent pBuilder, string toAdd,
+            List<string> tagsEnabled)
+        {
+            var textElement = TextElementWithFormatting(toAdd, tagsEnabled);
+            pBuilder.AddText(textElement);
+        }
+
+        private static TextElement TextElementWithFormatting(string toAdd, List<string> tagsEnabled)
+        {
+            var textElement = new TextElement(toAdd);
+            if (tagsEnabled.Contains("b")) textElement.Bold = true;
+            if (tagsEnabled.Contains("i")) textElement.Italic = true;
+            if (tagsEnabled.Contains("u")) textElement.Underline = true;
+            return textElement;
+        }
+
+        private static (List<string>, List<string>) ParseNextTopLevelElement(List<string> elements)
+        {
+            var next = elements[0];
+            var remaining = elements.Skip(1).ToList();
+            if (!Regex.IsMatch(next, TopLevelElementOpenPattern))
+            {
+                return (new List<string> {next}, remaining);
+            }
+
+            var closingTag = next.Insert(1, "/");
+            var res = remaining.TakeWhile(word => word != closingTag).Prepend(next);
+            return (res.ToList(), remaining.SkipWhile(word => word != closingTag).Skip(1).ToList());
+        }
+    }
+}

--- a/DocumentGeneration/Interfaces/IDocumentBuilder.cs
+++ b/DocumentGeneration/Interfaces/IDocumentBuilder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using DocumentGeneration.Interfaces.Parents;
 
 namespace DocumentGeneration.Interfaces
@@ -10,6 +9,7 @@ namespace DocumentGeneration.Interfaces
         public void AddNumberedList(Action<IListBuilder> action);
         public void AddBulletedList(Action<IListBuilder> action);
         public void AddHeader(Action<IHeaderBuilder> action);
+        public void AddFooter(Action<IFooterBuilder> action);
         public void Build();
     }
 }

--- a/DocumentGeneration/Interfaces/IListBuilder.cs
+++ b/DocumentGeneration/Interfaces/IListBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentGeneration.Elements;
 
 namespace DocumentGeneration.Interfaces
@@ -7,5 +8,6 @@ namespace DocumentGeneration.Interfaces
         public void AddItem(TextElement item);
         public void AddItem(string item);
         public void AddItem(TextElement[] elements);
+        public void AddItem(Action<IParagraphBuilder> action);
     }
 }

--- a/DocumentGeneration/Interfaces/IParagraphBuilder.cs
+++ b/DocumentGeneration/Interfaces/IParagraphBuilder.cs
@@ -5,6 +5,7 @@ namespace DocumentGeneration.Interfaces
 {
     public interface IParagraphBuilder : ITextParent
     {
+        public void AddNewLine();
         public void Justify(ParagraphJustification paragraphJustification);
     }
 }

--- a/DocumentGeneration/README.md
+++ b/DocumentGeneration/README.md
@@ -1,0 +1,210 @@
+# SDD Word Document Generation
+
+A library for aiding the generation of word documents in C# applications within SDD.
+
+
+## Live examples
+
+The [SDD Academy Transfers service](https://github.com/dfe-digital/academy-transfers-api) uses this for word document generation.
+
+## Technical documentation
+
+This is a .NET library which uses the [Open-XML SDK](https://github.com/OfficeDev/Open-XML-SDK) provided by microsoft in order to generate word documents. Its aim is to
+hide away some of the finer details of document creation to speed up the creation of word documents throughout SDD.
+
+### Example
+
+```c#
+class GenerateDocument {
+    public byte[] Execute(){
+        MemoryStream ms;
+
+        await using (ms = new MemoryStream())
+        {
+            var builder = new DocumentBuilder(ms);
+            builder.AddParagraph(pBuilder => {
+                pBuilder.AddText("This is some text");
+            }
+            builder.Build();
+        }
+
+        return ms.ToArray()
+    }
+}
+
+```
+
+### Usage
+
+#### `DocumentBuilder`
+
+The main class to interact with is the `DocumentBuilder`.
+
+`DocumentBuilder(Stream stream)`
+
+The `DocumentBuilder` takes a stream to write the created document to, once this has been created you can call
+the methods available to build up your document. 
+
+Once you have added your content, you call the `Build()` method and your document will be written to the stream.
+
+#### `TextElement`s
+
+Text elements allow you to create text with formatting applied. At the moment, the following formatting is supported:
+
+- Bold - true/false
+- Underline - true/false
+- Italic - true/false
+- FontSize - In half points
+- Colour - Colour hex code
+
+The content of the text element is stored inside the `Value` field, and can be passed in the contructor.
+
+Examples:
+
+```
+var boldText = new TextElement("Bold text") { Bold = true };
+var multipleFormatting = new TextElement("Multiple") { Bold = true, Italic = true, Color = "FF69B4" }
+```
+
+#### Paragraphs
+
+`DocumentBuilder.AddParagraph(Action<IParagraphBuilder> action)`
+
+To create a paragraph of text you must pass in a function that uses the `IParagraphBuilder` interface to
+build up a paragraph from the given text.
+
+**Adding content**
+
+The `ParagraphBuilder` lets you build paragraphs in the following ways:
+
+- `AddText(string text)`
+  - Adds text to the paragraph, this is the standard approach when no formatting is needed.
+- `AddText(TextElement textElement)`
+  - Adds a `TextElement` to the paragraph, this is the standard approach when adding an item of text that needs formatting.
+- `AddText(TextElement[] text)`
+  - Adds multiple `TextElements`s to the paragraph, this is useful when you want to add multiple pieces of text to the paragraph with mixed formatting between them.
+- `AddNewLine()`
+  - Adds a new line to the paragraph
+
+**Formatting**
+
+The `ParagraphBuilder` currently lets you format the paragraph in the following ways:
+
+- `Justify(ParagraphJustification)`
+  - Sets the justification of the paragraph to Left, center, or right.
+
+#### Headings
+
+`DocumentBuilder.AddHeading(Action<IHeadingBuilder> action)`
+
+To create a heading, you must pass in a function that uses the `IHeadingBuilder` interface to build up a heading.
+
+**Adding content**
+
+You can add a single element of text in the following ways:
+
+- `AddText(string text)`
+  - Used for adding an item of text with no formatting
+- `AddText(TextElement text)`
+  - Used for adding an item of text with formatting
+
+
+#### Lists
+
+`DocumentBuilder.AddNumberedList(Action<IListBuilder> action)`
+
+`DocumentBuilder.AddBulletedList(Action<IListBuilder> action)`
+
+To create a list of either type, you must pass in a function that uses the `IListBuilder` interface to build up
+a list.
+
+**Types of lists**
+
+- Numbered list
+- Bulleted list
+
+**Adding content**
+
+The `ListBuilder` lets you add list items in the following ways:
+
+- `AddItem(string item)`
+  - Adds a string as a list item, the standard approach when no formatting is needed.
+- `AddItem(TextElement item)`
+  - Adds a `TextElement` as a list item for when formatting is needed
+- `AddItem(TextElement[] elements)`
+  - Adds multiple `TextElement`s as a list item for when a mix of formatting is needed
+- `AddItem(Action<IParagraphBuilder> action)`
+  - Adds a paragraph built by a paragraph builder as a list item. This is useful if you need to create a list item that needs some features of the paragraph builder (e.g. Adding a new line, or any future formatting functionality)
+
+#### Tables
+
+**Adding a new table**
+
+Tables can be added to the document in the following ways:
+
+- `DocumentBuilder.AddTable(Action<ITableBuilder> action)`
+  - Lets you add a table via the `ITableBuilder` (see below)
+- `DocumentBuilder.AddTable(IEnumberable<TextElement[]> rows)`
+  - Lets you add a table quickly via a 2D array of `TextElement`s. This can be used when you want to quickly create a table made up of one `TextElement` each with no mixed formatting. This creates a table using the default styling (a black border)
+
+**Using the `ITableBuilder`**
+
+If you want more fine-grained control over creating your tables, you can use the `ITableBuilder` to build them.
+
+**Formatting**
+
+You can set the formatting of the table in the following ways:
+
+- `SetBorderStyle(TableBorderStyle style)`
+  - Sets the border style, currently two are available: `Solid` and `None`
+
+**Adding a row**
+
+`AddRow(Action<ITableRowBuilder> action)`
+
+Adding a row to the table uses the `ITableRowBuilder`, letting you have fine-grained control over how cells get added to the rows.
+
+The row builder allows you to add cells in the following ways:
+
+- `AddCell(string text)`
+  - Adds a single cell with the given text
+- `AddCell(TextElement textElement)`
+  - Adds a single cell with the given `TextElement`
+- `AddCells(string[] text)`
+  - Adds multiple cells with the given strings, useful for creating a whole row at once
+- `AddCells(TextElement[] text)`
+  - Adds multiple cells with the given `TextElements`s, useful for creating a whole row at once with differently formatted cells.
+
+#### Headers/Footers
+
+`DocumentBuilder.AddHeader(Action<IHeaderBuilder> action)`
+
+`DocumentBuilder.AddFooter(Action<IFooterBuilder> action)`
+
+Adds a header and footer using the given builders, these both expose the same interface.
+
+**Adding content**
+
+Headers and footers can both hold paragraphs and tables, as such using the builder you can add content using the methods given above under Paragraphs and Tables
+
+### Converting HTML content
+
+You can make use of the `HtmlToDocument.Convert` helper to convert HTML content into word document content with a given builder.
+
+```c#
+
+class GenerateDocument {
+    public byte[] Execute(){
+        MemoryStream ms;
+
+        await using (ms = new MemoryStream())
+        {
+            var builder = new DocumentBuilder(ms);
+            HtmlToDocument.Convert(builder, "<p>Some html content</p>");
+            builder.Build();
+        }
+
+        return ms.ToArray()
+    }
+}
+```

--- a/Frontend/Services/CreateHtbDocument.cs
+++ b/Frontend/Services/CreateHtbDocument.cs
@@ -5,10 +5,8 @@ using Data;
 using Data.Models;
 using DocumentGeneration;
 using DocumentGeneration.Elements;
-using DocumentGeneration.Helpers;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Frontend.Services
 {
@@ -190,13 +188,6 @@ namespace Frontend.Services
                 hBuilder.AddText("Rationale for the project");
             });
 
-            builder.AddParagraph(pBuilder =>
-            {
-                pBuilder.AddText("Meow");
-                pBuilder.AddNewLine();
-                pBuilder.AddText("Meow");
-            });
-
             builder.AddParagraph(pBuilder => pBuilder.AddText(project.Rationale.Project));
 
             builder.AddNumberedList(lBuilder =>
@@ -208,7 +199,6 @@ namespace Frontend.Services
                 {
                     new TextElement("Meow") {Bold = true},
                     new TextElement(" Woof ") {Bold = true, Italic = true},
-                    new TextElement("\n") {Bold = true, Italic = true},
                     new TextElement("Quack") {Bold = true, Italic = true, Underline = true}
                 });
             });
@@ -228,10 +218,6 @@ namespace Frontend.Services
                 hBuilder.AddText("Rationale for the trust or sponsor");
             });
 
-
-            var html =
-                "<ul><li><u><i>dad</i>w<i>ad<b>wa</b></i></u></li></ul><p><b>d</b>wdad<i>w</i>adaw</p><ol><li>ad<i>wa</i>wdaw<br></li></ol><p><br></p>";
-            HtmlToDocument.Convert(builder, html);
             builder.AddParagraph(pBuilder => pBuilder.AddText(project.Rationale.Trust));
         }
 

--- a/Frontend/Services/CreateHtbDocument.cs
+++ b/Frontend/Services/CreateHtbDocument.cs
@@ -5,8 +5,10 @@ using Data;
 using Data.Models;
 using DocumentGeneration;
 using DocumentGeneration.Elements;
+using DocumentGeneration.Helpers;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Frontend.Services
 {
@@ -188,6 +190,13 @@ namespace Frontend.Services
                 hBuilder.AddText("Rationale for the project");
             });
 
+            builder.AddParagraph(pBuilder =>
+            {
+                pBuilder.AddText("Meow");
+                pBuilder.AddNewLine();
+                pBuilder.AddText("Meow");
+            });
+
             builder.AddParagraph(pBuilder => pBuilder.AddText(project.Rationale.Project));
 
             builder.AddNumberedList(lBuilder =>
@@ -199,6 +208,7 @@ namespace Frontend.Services
                 {
                     new TextElement("Meow") {Bold = true},
                     new TextElement(" Woof ") {Bold = true, Italic = true},
+                    new TextElement("\n") {Bold = true, Italic = true},
                     new TextElement("Quack") {Bold = true, Italic = true, Underline = true}
                 });
             });
@@ -218,6 +228,10 @@ namespace Frontend.Services
                 hBuilder.AddText("Rationale for the trust or sponsor");
             });
 
+
+            var html =
+                "<ul><li><u><i>dad</i>w<i>ad<b>wa</b></i></u></li></ul><p><b>d</b>wdad<i>w</i>adaw</p><ol><li>ad<i>wa</i>wdaw<br></li></ol><p><br></p>";
+            HtmlToDocument.Convert(builder, html);
             builder.AddParagraph(pBuilder => pBuilder.AddText(project.Rationale.Trust));
         }
 


### PR DESCRIPTION
### Context

In the future services will use the [MOJ Rich Text editor](https://moj-design-system.herokuapp.com/components/rich-text-editor) to enter certain fields. This stores data as HTML and as such we need to supportt

### Changes proposed in this pull request

- Add HTML to document converter
- Add README for document generation
- Fix lists not displaying correctly in microsoft word

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

