### PR TITLE
Add academy and trust information page

### DIFF
--- a/Data.Mock/MockProjectRepository.cs
+++ b/Data.Mock/MockProjectRepository.cs
@@ -151,6 +151,11 @@ namespace Data.Mock
                 {
                     Project = "This is the rationale for the project",
                     Trust = "This is the rationale for the trust or sponsor"
+                },
+                AcademyAndTrustInformation = new TransferAcademyAndTrustInformation
+                {
+                    Author = "Author",
+                    Recommendation = TransferAcademyAndTrustInformation.RecommendationResult.Approve
                 }
             };
         }

--- a/Data.TRAMS.Tests/Mappers/Request/InternalProjectToUpdateMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Request/InternalProjectToUpdateMapperTests.cs
@@ -61,7 +61,12 @@ namespace Data.TRAMS.Tests.Mappers.Request
                     new TransferringAcademies {IncomingTrustUkprn = "1234", OutgoingAcademyUkprn = "4321"}
                 },
                 OutgoingTrustName = "Outgoing trust name",
-                OutgoingTrustUkprn = "Outgoing trust Ukprn"
+                OutgoingTrustUkprn = "Outgoing trust Ukprn",
+                AcademyAndTrustInformation = new TransferAcademyAndTrustInformation
+                {
+                    Author = "Author",
+                    Recommendation = TransferAcademyAndTrustInformation.RecommendationResult.Empty
+                }
             };
 
             var result = subject.Map(toMap);
@@ -76,6 +81,13 @@ namespace Data.TRAMS.Tests.Mappers.Request
             AssertDatesAreCorrect(toMap, result);
             AssertFeaturesAreCorrect(toMap, result);
             AssertRationaleIsCorrect(toMap, result);
+            AssertGeneralInformationIsCorrect(toMap, result);
+        }
+
+        private static void AssertGeneralInformationIsCorrect(Project toMap, TramsProjectUpdate result)
+        {
+            Assert.Equal(toMap.AcademyAndTrustInformation.Author, result.GeneralInformation.Author);
+            Assert.Equal(toMap.AcademyAndTrustInformation.Recommendation.ToString(), result.GeneralInformation.Recommendation);
         }
 
         private static void AssertRationaleIsCorrect(Project toMap, TramsProjectUpdate result)

--- a/Data.TRAMS.Tests/Mappers/Response/TramsProjectMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsProjectMapperTests.cs
@@ -57,6 +57,11 @@ namespace Data.TRAMS.Tests.Mappers.Response
                     ProjectRationale = "Project rationale",
                     TrustSponsorRationale = "Trust rationale"
                 },
+                GeneralInformation = new AcademyTransferProjectAcademyAndTrustInformation
+                {
+                    Author = "Author",
+                    Recommendation = TransferAcademyAndTrustInformation.RecommendationResult.Approve.ToString()
+                },
                 State = "State",
                 Status = "Status",
                 OutgoingTrust = new TrustSummary
@@ -98,7 +103,16 @@ namespace Data.TRAMS.Tests.Mappers.Response
             AssertDatesCorrect(toMap, result);
             AssertFeaturesCorrect(toMap, result);
             AssertRationaleCorrect(toMap, result);
+            AssertGeneralInformationCorrect(toMap, result);
             AssertTransferringAcademiesCorrect(toMap, result);
+        }
+
+        private void AssertGeneralInformationCorrect(TramsProject toMap, Project result)
+        {
+            Assert.Equal(toMap.GeneralInformation.Author, result.AcademyAndTrustInformation.Author);
+            var expectedRecommendation =
+                EnumHelpers<TransferAcademyAndTrustInformation.RecommendationResult>.Parse(toMap.GeneralInformation.Recommendation);
+            Assert.Equal(expectedRecommendation, result.AcademyAndTrustInformation.Recommendation);
         }
 
         private static void AssertTransferringAcademiesCorrect(TramsProject toMap, Project result)

--- a/Data.TRAMS/Mappers/Request/InternalProjectToUpdateMapper.cs
+++ b/Data.TRAMS/Mappers/Request/InternalProjectToUpdateMapper.cs
@@ -21,7 +21,17 @@ namespace Data.TRAMS.Mappers.Request
                 Benefits = Benefits(input),
                 Dates = Dates(input),
                 Features = Features(input),
-                Rationale = Rationale(input)
+                Rationale = Rationale(input),
+                GeneralInformation = GeneralInformation(input)
+            };
+        }
+
+        private AcademyTransferProjectAcademyAndTrustInformation GeneralInformation(Project input)
+        {
+            return new AcademyTransferProjectAcademyAndTrustInformation
+            {
+                Author = input.AcademyAndTrustInformation.Author,
+                Recommendation = input.AcademyAndTrustInformation.Recommendation.ToString()
             };
         }
 

--- a/Data.TRAMS/Mappers/Response/TramsProjectMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsProjectMapper.cs
@@ -17,12 +17,23 @@ namespace Data.TRAMS.Mappers.Response
                 Dates = Dates(input),
                 Features = Features(input),
                 Rationale = Rationale(input),
+                AcademyAndTrustInformation = AcademyAndTrustInformation(input),
                 State = input.State,
                 Status = input.Status,
                 Urn = input.ProjectUrn,
                 TransferringAcademies = TransferringAcademies(input),
                 OutgoingTrustName = input.OutgoingTrust.GroupName,
-                OutgoingTrustUkprn = input.OutgoingTrust.Ukprn
+                OutgoingTrustUkprn = input.OutgoingTrust.Ukprn,
+                Name = input.TransferringAcademies[0]?.OutgoingAcademy?.Name
+            };
+        }
+
+        private static TransferAcademyAndTrustInformation AcademyAndTrustInformation(TramsProject input)
+        {
+            return new TransferAcademyAndTrustInformation
+            {
+                Author = input.GeneralInformation.Author,
+                Recommendation = EnumHelpers<TransferAcademyAndTrustInformation.RecommendationResult>.Parse(input.GeneralInformation.Recommendation) 
             };
         }
 

--- a/Data.TRAMS/Models/AcademyTransferProject/AcademyTransferProjectAcademyAndTrustInformation.cs
+++ b/Data.TRAMS/Models/AcademyTransferProject/AcademyTransferProjectAcademyAndTrustInformation.cs
@@ -1,0 +1,8 @@
+namespace Data.TRAMS.Models.AcademyTransferProject
+{
+    public class AcademyTransferProjectAcademyAndTrustInformation
+    {
+        public string Author { get; set; }
+        public string Recommendation { get; set; }
+    }
+}

--- a/Data.TRAMS/Models/TramsProject.cs
+++ b/Data.TRAMS/Models/TramsProject.cs
@@ -11,6 +11,7 @@ namespace Data.TRAMS.Models
             Dates = new AcademyTransferProjectDates();
             Features = new AcademyTransferProjectFeatures();
             Rationale = new AcademyTransferProjectRationale();
+            GeneralInformation = new AcademyTransferProjectAcademyAndTrustInformation();
             TransferringAcademies = new List<TransferringAcademy>();
             OutgoingTrust = new TrustSummary();
         }
@@ -21,6 +22,7 @@ namespace Data.TRAMS.Models
         public string ProjectNumber { get; set; }
         public string ProjectUrn { get; set; }
         public AcademyTransferProjectRationale Rationale { get; set; }
+        public AcademyTransferProjectAcademyAndTrustInformation GeneralInformation { get; set; }
         public string State { get; set; }
         public string Status { get; set; }
         public List<TransferringAcademy> TransferringAcademies { get; set; }

--- a/Data.TRAMS/Models/TramsProjectUpdate.cs
+++ b/Data.TRAMS/Models/TramsProjectUpdate.cs
@@ -11,6 +11,7 @@ namespace Data.TRAMS.Models
         public string OutgoingTrustUkprn { get; set; }
         public string ProjectUrn { get; set; }
         public AcademyTransferProjectRationale Rationale { get; set; }
+        public AcademyTransferProjectAcademyAndTrustInformation GeneralInformation { get; set; }
         public string State { get; set; }
         public string Status { get; set; }
         public List<TransferringAcademyUpdate> TransferringAcademies { get; set; }

--- a/Data/Models/Project.cs
+++ b/Data/Models/Project.cs
@@ -12,6 +12,7 @@ namespace Data.Models
             Dates = new TransferDates();
             Benefits = new TransferBenefits();
             Rationale = new TransferRationale();
+            AcademyAndTrustInformation = new TransferAcademyAndTrustInformation();
         }
 
         public string Urn { get; set; }
@@ -26,10 +27,14 @@ namespace Data.Models
         public TransferDates Dates { get; set; }
         public TransferBenefits Benefits { get; set; }
         public TransferRationale Rationale { get; set; }
+        public TransferAcademyAndTrustInformation AcademyAndTrustInformation { get; set; }
         public string AcademyPerformanceAdditionalInformation { get; set; }
         public string PupilNumbersAdditionalInformation { get; set; }
         public string LatestOfstedAdditionalInformation { get; set; }
         public string OutgoingAcademyName => TransferringAcademies[0].OutgoingAcademyName;
         public string OutgoingAcademyUrn => TransferringAcademies[0].OutgoingAcademyUrn;
+        public string IncomingTrustUkprn => TransferringAcademies[0].IncomingTrustUkprn;
+        public string IncomingTrustName => TransferringAcademies[0].IncomingTrustName;
+        
     }
 }

--- a/Data/Models/Projects/TransferAcademyAndTrustInformation.cs
+++ b/Data/Models/Projects/TransferAcademyAndTrustInformation.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Data.Models.Projects
+{
+    public class TransferAcademyAndTrustInformation
+    {
+        public enum RecommendationResult
+        {
+            Empty = 0,
+            
+            [Display(Name = "Approve")]
+            Approve,
+            
+            [Display(Name = "Defer")]
+            Defer,
+            
+            [Display(Name="Decline")]
+            Decline
+        }
+        
+        public RecommendationResult Recommendation { get; set; }
+        public string Author { get; set; }
+    }
+    
+}

--- a/Frontend.Tests/ControllerTests/Projects/AcademyAndTrustInformationControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/AcademyAndTrustInformationControllerTests.cs
@@ -1,0 +1,139 @@
+using Data;
+using Data.Models;
+using Data.Models.Projects;
+using Frontend.Controllers.Projects;
+using Frontend.Tests.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Frontend.Tests.ControllerTests.Projects
+{
+    public class AcademyAndTrustInformationControllerTests
+    {
+        private const string ErrorWithGetByUrn = "errorUrn";
+        private readonly AcademyAndTrustInformationController _subject;
+        private readonly Mock<IProjects> _projectRepository;
+
+        public AcademyAndTrustInformationControllerTests()
+        {
+            _projectRepository = new Mock<IProjects>();
+            _projectRepository.Setup(r => r.GetByUrn(It.IsAny<string>()))
+                .ReturnsAsync(new RepositoryResult<Project> { Result = new Project() });
+            _projectRepository.Setup(s => s.GetByUrn(ErrorWithGetByUrn))
+                .ReturnsAsync(
+                    new RepositoryResult<Project>
+                    {
+                        Error = new RepositoryResultBase.RepositoryError
+                        {
+                            ErrorMessage = "Error"
+                        }
+                    });
+            _projectRepository.Setup(r => r.Update(It.IsAny<Project>()))
+                .ReturnsAsync(new RepositoryResult<Project>());
+            _subject = new AcademyAndTrustInformationController(_projectRepository.Object);
+        }
+
+        public class IndexTests : AcademyAndTrustInformationControllerTests
+        {
+            [Fact]
+            public async void GivenUrn_FetchesProjectFromTheRepository()
+            {
+                await _subject.Index("0001");
+
+                _projectRepository.Verify(r => r.GetByUrn("0001"), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenGetByUrnReturnsError_DisplayErrorPage()
+            {
+                var response = await _subject.Index(ErrorWithGetByUrn);
+                var viewResult = Assert.IsType<ViewResult>(response);
+
+                Assert.Equal("ErrorPage", viewResult.ViewName);
+                Assert.Equal("Error", viewResult.Model);
+            }
+        }
+
+        public class RecommendationTests : AcademyAndTrustInformationControllerTests
+        {
+            public class GetTests : RecommendationTests
+            {
+                [Fact]
+                public async void GivenUrn_FetchesProjectFromTheRepository()
+                {
+                    await _subject.Recommendation("0001");
+
+                    _projectRepository.Verify(r => r.GetByUrn("0001"), Times.Once);
+                }
+
+                [Fact]
+                public async void GivenGetByUrnReturnsError_DisplayErrorPage()
+                {
+                    var response = await _subject.Recommendation(ErrorWithGetByUrn);
+                    var viewResult = Assert.IsType<ViewResult>(response);
+
+                    Assert.Equal("ErrorPage", viewResult.ViewName);
+                    Assert.Equal("Error", viewResult.Model);
+                }
+            }
+
+            public class PostTests : RecommendationTests
+            {
+                [Fact]
+                public async void GivenUrnAndRecommendationAndAuthor_UpdatesTheProject()
+                {
+                    const string author = "test author";
+                    var recommendation = TransferAcademyAndTrustInformation.RecommendationResult.Approve;
+                    await _subject.Recommendation("0001", recommendation, author);
+
+                    _projectRepository.Verify(r =>
+                        r.Update(It.Is<Project>(project => project.AcademyAndTrustInformation.Recommendation == recommendation && 
+                                                           project.AcademyAndTrustInformation.Author == author)), Times.Once);
+                }
+
+                [Fact]
+                public async void GivenUrnAndRecommendationAndAuthor_RedirectsBackToTheSummary()
+                {
+                    const string author = "test author";
+                    const TransferAcademyAndTrustInformation.RecommendationResult recommendation = TransferAcademyAndTrustInformation.RecommendationResult.Approve;
+                    var result = await _subject.Recommendation("0001", recommendation, author);
+
+                    ControllerTestHelpers.AssertResultRedirectsToAction(result, "Index");
+                }
+                
+                [Fact]
+                public async void GivenGetByUrnReturnsError_DisplayErrorPage()
+                {
+                    const string author = "test author";
+                    var recommendation = TransferAcademyAndTrustInformation.RecommendationResult.Approve;
+                    var response = await _subject.Recommendation(ErrorWithGetByUrn, recommendation, author);
+                    var viewResult = Assert.IsType<ViewResult>(response);
+
+                    Assert.Equal("ErrorPage", viewResult.ViewName);
+                    Assert.Equal("Error", viewResult.Model);
+                }
+                
+                [Fact]
+                public async void GivenUpdateReturnsError_DisplayErrorPage()
+                {
+                    _projectRepository.Setup(s => s.Update(It.IsAny<Project>())).ReturnsAsync(
+                        new RepositoryResult<Project>
+                        {
+                            Error = new RepositoryResultBase.RepositoryError
+                            {
+                                ErrorMessage = "Update error"
+                            }
+                        });
+
+                    var recommendation = TransferAcademyAndTrustInformation.RecommendationResult.Approve;
+                    var response = await _subject.Recommendation("0001", recommendation, null);
+                    var viewResult = Assert.IsType<ViewResult>(response);
+
+                    Assert.Equal("ErrorPage", viewResult.ViewName);
+                    Assert.Equal("Update error", viewResult.Model);
+                }
+            }
+        }
+    }
+}

--- a/Frontend.Tests/ModelTests/ProjectTaskListViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/ProjectTaskListViewModelTests.cs
@@ -145,7 +145,8 @@ namespace Frontend.Tests.ModelTests
             [InlineData("", "", "test")]
             [InlineData("", "test", "")]
             [InlineData("", "test", "test")]
-            public void GivenTransferDatesArePartiallyCompleted_ReturnInProgress(string firstDiscussed, string targetDate, string htbDate)
+            public void GivenTransferDatesArePartiallyCompleted_ReturnInProgress(string firstDiscussed,
+                string targetDate, string htbDate)
             {
                 // Arrange
                 var project = new Project
@@ -199,8 +200,8 @@ namespace Frontend.Tests.ModelTests
                 {
                     Benefits = new TransferBenefits
                     {
-                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit> (),
-                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string> () 
+                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit>(),
+                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string>()
                     }
                 };
                 var model = new ProjectTaskListViewModel { Project = project };
@@ -221,7 +222,7 @@ namespace Frontend.Tests.ModelTests
                     Benefits = new TransferBenefits
                     {
                         IntendedBenefits = new List<TransferBenefits.IntendedBenefit> { TransferBenefits.IntendedBenefit.CentralFinanceTeamAndSupport },
-                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string> ()
+                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string>()
                     }
                 };
                 var model = new ProjectTaskListViewModel { Project = project };
@@ -241,7 +242,7 @@ namespace Frontend.Tests.ModelTests
                 {
                     Benefits = new TransferBenefits
                     {
-                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit> (),
+                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit>(),
                         OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string> { { TransferBenefits.OtherFactor.HighProfile, "test" } }
                     }
                 };
@@ -364,6 +365,32 @@ namespace Frontend.Tests.ModelTests
 
                 // Assert
                 Assert.Equal(ProjectStatuses.Completed, result);
+            }
+        }
+
+        public class AcademyAndTrustInformationTests
+        {
+            [Theory]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Empty, null, ProjectStatuses.NotStarted)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Approve, "test author", ProjectStatuses.Completed)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Empty, "test author", ProjectStatuses.InProgress)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Decline, null, ProjectStatuses.InProgress)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Decline, "", ProjectStatuses.InProgress)]
+            public void GivenRelevantData_ReturnCorrectStatus(
+                TransferAcademyAndTrustInformation.RecommendationResult recommendation, string author, ProjectStatuses expectedStatus)
+            {
+                var project = new Project
+                {
+                    AcademyAndTrustInformation = new TransferAcademyAndTrustInformation
+                    {
+                        Recommendation = recommendation,
+                        Author = author
+                    }
+                };
+                var model = new ProjectTaskListViewModel {Project = project};
+                var result = model.AcademyAndTrustInformationStatus();
+                
+                Assert.Equal(expectedStatus, result);
             }
         }
     }

--- a/Frontend/Controllers/Projects/AcademyAndTrustInformationController.cs
+++ b/Frontend/Controllers/Projects/AcademyAndTrustInformationController.cs
@@ -1,0 +1,84 @@
+using System.Threading.Tasks;
+using Data;
+using Data.Models.Projects;
+using Frontend.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Frontend.Controllers.Projects
+{
+    [Authorize]
+    [Route("project/{urn}/academy-and-trust-information")]
+    public class AcademyAndTrustInformationController : Controller
+    {
+        private readonly IProjects _projectsRepository;
+
+        public AcademyAndTrustInformationController(IProjects projectsRepository)
+        {
+            _projectsRepository = projectsRepository;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index(string urn)
+        {
+            var project = await _projectsRepository.GetByUrn(urn);
+            if (!project.IsValid)
+            {
+                return View("ErrorPage", project.Error.ErrorMessage);
+            }
+
+            var model = new AcademyAndTrustInformationViewModel
+            {
+                Project = project.Result
+            };
+
+            return View(model);
+        }
+
+        [HttpGet("recommendation")]
+        public async Task<IActionResult> Recommendation(string urn)
+        {
+            var project = await _projectsRepository.GetByUrn(urn);
+            if (!project.IsValid)
+            {
+                return View("ErrorPage", project.Error.ErrorMessage);
+            }
+
+            var model = new AcademyAndTrustInformationViewModel
+            {
+                Project = project.Result
+            };
+
+            return View(model);
+        }
+
+        [HttpPost("recommendation")]
+        public async Task<IActionResult> Recommendation(string urn, TransferAcademyAndTrustInformation.RecommendationResult recommendation, string author)
+        {
+            var project = await _projectsRepository.GetByUrn(urn);
+            if (!project.IsValid)
+            {
+                return View("ErrorPage", project.Error.ErrorMessage);
+            }
+
+            var model = new AcademyAndTrustInformationViewModel
+            {
+                Project = project.Result
+            };
+
+            model.Project.AcademyAndTrustInformation = new TransferAcademyAndTrustInformation
+            {
+                Recommendation = recommendation,
+                Author = author
+            };
+            
+            var result = await _projectsRepository.Update(model.Project);
+            if (!result.IsValid)
+            {
+                return View("ErrorPage", result.Error.ErrorMessage);
+            }
+
+            return RedirectToAction("Index", new {urn});
+        }
+    }
+}

--- a/Frontend/Models/AcademyAndTrustInformationViewModel.cs
+++ b/Frontend/Models/AcademyAndTrustInformationViewModel.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+using Data.Models.Projects;
+using Frontend.Models.Forms;
+using Helpers;
+
+namespace Frontend.Models
+{
+    public class AcademyAndTrustInformationViewModel : ProjectViewModel
+    {
+        public static List<RadioButtonViewModel> RecommendedRadioButtons(TransferAcademyAndTrustInformation.RecommendationResult selected)
+        {
+            var values =
+                EnumHelpers<TransferAcademyAndTrustInformation.RecommendationResult>.GetDisplayableValues(TransferAcademyAndTrustInformation.RecommendationResult
+                    .Empty);
+
+            var result = values.Select(value => new RadioButtonViewModel
+            {
+                Value = value.ToString(), Name = "recommendation",
+                DisplayName = value.ToString(),
+                Checked = selected == value
+            }).ToList();
+
+            return result;
+        }
+    }
+}

--- a/Frontend/Models/ProjectTaskListViewModel.cs
+++ b/Frontend/Models/ProjectTaskListViewModel.cs
@@ -7,12 +7,20 @@ namespace Frontend.Models
     public class ProjectTaskListViewModel : ProjectViewModel
     {
         public ProjectStatuses FeatureTransferStatus => GetFeatureTransferStatus();
-
         public ProjectStatuses TransferDatesStatus => GetTransferDatesStatus();
-
         public ProjectStatuses BenefitsAndOtherFactorsStatus => GetBenefitsAndOtherFactorsStatus();
-
         public ProjectStatuses RationaleStatus => GetRationaleStatus();
+        public ProjectStatuses AcademyAndTrustInformationStatus() => GetAcademyAndTrustInformationStatus();
+
+        private ProjectStatuses GetAcademyAndTrustInformationStatus()
+        {
+            var academyAndTrustInformation = Project.AcademyAndTrustInformation;
+            return (string.IsNullOrEmpty(academyAndTrustInformation.Author) && 
+                    (academyAndTrustInformation.Recommendation == TransferAcademyAndTrustInformation.RecommendationResult.Empty)) ? ProjectStatuses.NotStarted
+                : (!string.IsNullOrEmpty(academyAndTrustInformation.Author) &&
+                   (academyAndTrustInformation.Recommendation != TransferAcademyAndTrustInformation.RecommendationResult.Empty)) ? ProjectStatuses.Completed
+                : ProjectStatuses.InProgress;
+        }
 
         private ProjectStatuses GetFeatureTransferStatus()
         {
@@ -61,11 +69,11 @@ namespace Frontend.Models
         {
             if (string.IsNullOrEmpty(Project.Rationale.Project) &&
                 string.IsNullOrEmpty(Project.Rationale.Trust))
-            return ProjectStatuses.NotStarted;
+                return ProjectStatuses.NotStarted;
 
             if (!string.IsNullOrEmpty(Project.Rationale.Project) &&
                 !string.IsNullOrEmpty(Project.Rationale.Trust))
-            return ProjectStatuses.Completed;
+                return ProjectStatuses.Completed;
 
             return ProjectStatuses.InProgress;
         }

--- a/Frontend/Views/AcademyAndTrustInformation/Index.cshtml
+++ b/Frontend/Views/AcademyAndTrustInformation/Index.cshtml
@@ -1,0 +1,163 @@
+@using Data.Models.Projects
+@using Helpers
+@model AcademyAndTrustInformationViewModel
+
+@{
+    ViewBag.Title = "Academy and trust information and project dates";
+    Layout = "_Layout";
+}
+
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Back to task list</a>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+        <span class="govuk-caption-l">
+            URN @Model.Project.OutgoingAcademyUrn
+        </span>
+        <h1 class="govuk-heading-l">
+            Academy and trust information and project dates
+        </h1>
+        <hr class="govuk-section-break govuk-section-break--l">
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Recommendation
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @if (Model.Project.AcademyAndTrustInformation.Recommendation == TransferAcademyAndTrustInformation.RecommendationResult.Empty)
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        var displayName = EnumHelpers<TransferAcademyAndTrustInformation.RecommendationResult>.GetDisplayValue(Model.Project.AcademyAndTrustInformation.Recommendation);
+                        @displayName
+                    }
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" asp-action="Recommendation" asp-route-urn="@Model.Project.Urn">
+                        Change<span class="govuk-visually-hidden">recommendation</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Author
+                </dt>
+                <dd class="govuk-summary-list__value ">
+                    @if (string.IsNullOrEmpty(Model.Project.AcademyAndTrustInformation.Author))
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        <span class="dfe-text-area-display">@Model.Project.AcademyAndTrustInformation.Author</span>
+                    }
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" asp-action="Recommendation" asp-route-urn="@Model.Project.Urn">
+                        Change<span class="govuk-visually-hidden">author</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    HTB date
+                </dt>
+                <dd class="govuk-summary-list__value ">
+                    @if (string.IsNullOrEmpty(Model.Project.Dates.Htb))
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        <span class="dfe-text-area-display">@Model.Project.Dates.Htb</span>
+                    }
+                </dd>
+                <dd class="govuk-summary-list__value "/>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Project name
+                </dt>
+                <dd class="govuk-summary-list__value ">
+                    @if (string.IsNullOrEmpty(Model.Project.Name))
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        <span class="dfe-text-area-display">@Model.Project.Name</span>
+                    }
+                </dd>
+                <dd class="govuk-summary-list__value "/>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Sponsor name
+                </dt>
+                <dd class="govuk-summary-list__value ">
+                    @if (string.IsNullOrEmpty(Model.Project.Name))
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        <span class="dfe-text-area-display">@Model.Project.IncomingTrustName</span>
+                    }
+                </dd>
+                <dd class="govuk-summary-list__value "/>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Academy type and route
+                </dt>
+                <dd class="govuk-summary-list__value ">
+                    @if (string.IsNullOrEmpty(Model.TransferringAcademy?.Performance?.SchoolType))
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        <span class="dfe-text-area-display">@Model.TransferringAcademy?.Performance?.SchoolType</span>
+                    }
+                </dd>
+                <dd class="govuk-summary-list__value "/>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Proposed academy transfer
+                </dt>
+                <dd class="govuk-summary-list__value ">
+                    <span class="dfe-text-area-display">Placeholder</span>
+                </dd>
+                <dd class="govuk-summary-list__value "/>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Date the transfer was discussed with outgoing trust
+                </dt>
+                <dd class="govuk-summary-list__value ">
+                    @if (string.IsNullOrEmpty(Model.Project.Dates.FirstDiscussed))
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        <span class="dfe-text-area-display">@Model.Project.Dates.FirstDiscussed</span>
+                    }
+                </dd>
+                <dd class="govuk-summary-list__value "/>
+            </div>
+        </dl>
+        <a class="govuk-button" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Confirm and continue</a>
+    </div>
+</div>

--- a/Frontend/Views/AcademyAndTrustInformation/Recommendation.cshtml
+++ b/Frontend/Views/AcademyAndTrustInformation/Recommendation.cshtml
@@ -1,0 +1,81 @@
+@model AcademyAndTrustInformationViewModel
+
+@{
+    ViewBag.Title = "Recommendation";
+    Layout = "_Layout";
+    var radioButtons = AcademyAndTrustInformationViewModel.RecommendedRadioButtons(Model.Project.AcademyAndTrustInformation.Recommendation);
+}
+
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l">
+            URN @Model.Project.OutgoingAcademyUrn
+        </span>
+        <h1 class="govuk-heading-l">
+            Recommendation
+        </h1>
+        <form asp-action="Recommendation" method="post" novalidate="">
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                        What is the recommendation for this project?
+                    </legend>
+                    @await Html.PartialAsync("_RadioButtons", radioButtons)
+                </fieldset>
+            </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label govuk-label--m" for="author">
+                    Enter the full name of the author of this headteacher board (HTB) template
+                </label>
+                <input class="govuk-input govuk-!-width-two-thirds" id="author" name="author" type="text" value="@Model.Project.AcademyAndTrustInformation.Author">
+            </div>
+            <button class="govuk-button" data-module="govuk-button">
+                Save and continue
+            </button>
+        </form>
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <aside class="app-related-items" role="complementary">
+            <h2 class="govuk-heading-s" id="subsection-title-1">
+                Useful information
+            </h2>
+            <nav role="navigation" aria-labelledby="subsection-title-1">
+                <ul class="govuk-list govuk-!-font-size-16">
+                    <li>
+                        <a class="govuk-link" href="#">
+                            View full application
+                        </a>
+                    </li>
+                    <li>
+                        <a class="govuk-link" href="#">
+                            School information on TRAMS
+                        </a>
+                    </li>
+                    <hr class="govuk-grid-one-third govuk-section-break govuk-section-break--m govuk-section-break--visible">
+                </ul>
+            </nav>
+            <h2 class="govuk-heading-s" id="subsection-title-2">
+                Guidance
+            </h2>
+            <nav role="navigation" aria-labelledby="subsection-title-2">
+                <ul class="govuk-list govuk-!-font-size-16">
+                    <li>
+                        <a class="govuk-link" href="#">
+                            Guidance for setting an HTB date
+                        </a>
+                    </li>
+                    <li>
+                        <a class="govuk-link" href="#">
+                            Full Guidance
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </aside>
+    </div>
+</div>

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -56,6 +56,13 @@
                     </li>
                     <li class="moj-task-list__item">
                         <span class="moj-task-list__task-name">
+                            <a class="govuk-link" aria-describedby="academyandtrustinformation" asp-controller="AcademyAndTrustInformation" asp-action="Index" asp-route-urn="@Model.Project.Urn">
+                                Academy and trust information and project dates
+                            </a>
+                        </span><projectstatus id="academyandtrustinformation" , status="@Model.AcademyAndTrustInformationStatus()"></projectstatus>
+                    </li>
+                    <li class="moj-task-list__item">
+                        <span class="moj-task-list__task-name">
                             <a class="govuk-link" aria-describedby="academy-performance" asp-controller="AcademyPerformance" asp-action="Index" asp-route-id="@Model.Project.Urn">
                                 Academy performance
                             </a>


### PR DESCRIPTION
### Context

Add academy and trust information page

### Changes proposed in this pull request

Add fields to project and trams api models to support author and recommendation fields
Add academy and trust information page
Add ability to edit recommendation and author

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

