### PR TITLE
Add reference fields to academy and trust information page

### DIFF
--- a/Data.TRAMS/TramsProjectsRepository.cs
+++ b/Data.TRAMS/TramsProjectsRepository.cs
@@ -95,9 +95,15 @@ namespace Data.TRAMS
                 project.OutgoingTrust = new TrustSummary { Ukprn = project.OutgoingTrustUkprn };
                 project.TransferringAcademies = project.TransferringAcademies.Select(async transferring =>
                     {
+                        var incomingTrust = await _trusts.GetByUkprn(transferring.IncomingTrustUkprn);
                         var outgoingAcademy = await _academies.GetAcademyByUkprn(transferring.OutgoingAcademyUkprn);
 
-                        transferring.IncomingTrust = new TrustSummary() { Ukprn = transferring.IncomingTrustUkprn };
+                        transferring.IncomingTrust = new TrustSummary
+                        {
+                            GroupName = incomingTrust.Result.Name,
+                            GroupId = incomingTrust.Result.GiasGroupId,
+                            Ukprn = transferring.IncomingTrustUkprn
+                        };
                         transferring.OutgoingAcademy = new AcademySummary
                         {
                             Name = outgoingAcademy.Result.Name,

--- a/Frontend.Tests/ModelTests/AcademyAndTrustInformationViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/AcademyAndTrustInformationViewModelTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Data.Models.Projects;
+using Frontend.Models;
+using Xunit;
+
+namespace Frontend.Tests.ModelTests
+{
+    public class AcademyAndTrustInformationViewModelTests
+    {
+        public class RecommendedRadioButtonsTests : AcademyAndTrustInformationViewModelTests
+        {
+            [Fact]
+            public void GivenEmptySelectedValue_GeneratesListWithNoItemsChecked()
+            {
+                const TransferAcademyAndTrustInformation.RecommendationResult recommendationResult = 
+                    TransferAcademyAndTrustInformation.RecommendationResult.Empty;
+
+                var result = AcademyAndTrustInformationViewModel.RecommendedRadioButtons(recommendationResult);
+
+                Assert.All(result, item => Assert.False(item.Checked));
+            }
+            
+            [Fact]
+            public void GivenASelectedValue_GeneratesListWithRelevantItemChecked()
+            {
+                const TransferAcademyAndTrustInformation.RecommendationResult recommendationResult = 
+                    TransferAcademyAndTrustInformation.RecommendationResult.Approve;
+
+                var result = AcademyAndTrustInformationViewModel.RecommendedRadioButtons(recommendationResult);
+
+                Assert.Single(result.Where(item => item.Value == recommendationResult.ToString() && item.Checked));
+            }
+        }
+    }
+}

--- a/Frontend/Controllers/Projects/AcademyAndTrustInformationController.cs
+++ b/Frontend/Controllers/Projects/AcademyAndTrustInformationController.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Data;
 using Data.Models.Projects;
 using Frontend.Models;
+using Frontend.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,25 +12,29 @@ namespace Frontend.Controllers.Projects
     [Route("project/{urn}/academy-and-trust-information")]
     public class AcademyAndTrustInformationController : Controller
     {
+        private readonly IGetInformationForProject _getInformationForProject;
         private readonly IProjects _projectsRepository;
 
-        public AcademyAndTrustInformationController(IProjects projectsRepository)
+        public AcademyAndTrustInformationController(IProjects projectsRepository, IGetInformationForProject getInformationForProject)
         {
             _projectsRepository = projectsRepository;
+            _getInformationForProject = getInformationForProject;
         }
 
         [HttpGet]
         public async Task<IActionResult> Index(string urn)
         {
-            var project = await _projectsRepository.GetByUrn(urn);
-            if (!project.IsValid)
+            var projectInformation = await _getInformationForProject.Execute(urn);
+
+            if (!projectInformation.IsValid)
             {
-                return View("ErrorPage", project.Error.ErrorMessage);
+                return View("ErrorPage", projectInformation.ResponseError.ErrorMessage);
             }
 
             var model = new AcademyAndTrustInformationViewModel
             {
-                Project = project.Result
+                Project = projectInformation.Project,
+                TransferringAcademy = projectInformation.OutgoingAcademy
             };
 
             return View(model);

--- a/Frontend/Views/AcademyAndTrustInformation/Index.cshtml
+++ b/Frontend/Views/AcademyAndTrustInformation/Index.cshtml
@@ -121,13 +121,13 @@
                     Academy type and route
                 </dt>
                 <dd class="govuk-summary-list__value ">
-                    @if (string.IsNullOrEmpty(Model.TransferringAcademy?.Performance?.SchoolType))
+                    @if (string.IsNullOrEmpty(Model.TransferringAcademy?.EstablishmentType))
                     {
                         <span class="dfe-empty-tag">Empty</span>
                     }
                     else
                     {
-                        <span class="dfe-text-area-display">@Model.TransferringAcademy?.Performance?.SchoolType</span>
+                        <span class="dfe-text-area-display">@Model.TransferringAcademy?.EstablishmentType</span>
                     }
                 </dd>
                 <dd class="govuk-summary-list__value "/>
@@ -137,7 +137,14 @@
                     Proposed academy transfer
                 </dt>
                 <dd class="govuk-summary-list__value ">
-                    <span class="dfe-text-area-display">Placeholder</span>
+                    @if (string.IsNullOrEmpty(Model.Project.Dates.Target))
+                    {
+                        <span class="dfe-empty-tag">Empty</span>
+                    }
+                    else
+                    {
+                        <span class="dfe-text-area-display">@Model.Project.Dates.Target</span>
+                    }
                 </dd>
                 <dd class="govuk-summary-list__value "/>
             </div>

--- a/Frontend/wwwroot/src/css/site.scss
+++ b/Frontend/wwwroot/src/css/site.scss
@@ -60,3 +60,8 @@ for details on configuring this project to bundle and minify static web assets. 
     width: 50%;
   }
 }
+
+aside.app-related-items {
+  border-top: 2px solid #1d70b8;
+  padding-top: 10px;
+}


### PR DESCRIPTION
### Context

Link the reference fields to the TRAMS API for the reference section of the academy and trust information page

### Changes proposed in this pull request

Add correct TRAMS API fields to the reference data displayed in the academy and trust information page

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

