### PR TITLE
Correct formatting of dates on academy and trust information page

### DIFF
--- a/Frontend/Views/AcademyAndTrustInformation/Index.cshtml
+++ b/Frontend/Views/AcademyAndTrustInformation/Index.cshtml
@@ -79,7 +79,8 @@
                     }
                     else
                     {
-                        <span class="dfe-text-area-display">@Model.Project.Dates.Htb</span>
+                        var display = DatesHelper.DateStringToGovUkDate(Model.Project.Dates.Htb);
+                        @display
                     }
                 </dd>
                 <dd class="govuk-summary-list__value "/>
@@ -143,7 +144,8 @@
                     }
                     else
                     {
-                        <span class="dfe-text-area-display">@Model.Project.Dates.Target</span>
+                        var display = DatesHelper.DateStringToGovUkDate(Model.Project.Dates.Target);
+                        @display
                     }
                 </dd>
                 <dd class="govuk-summary-list__value "/>
@@ -159,7 +161,8 @@
                     }
                     else
                     {
-                        <span class="dfe-text-area-display">@Model.Project.Dates.FirstDiscussed</span>
+                        var display = DatesHelper.DateStringToGovUkDate(Model.Project.Dates.FirstDiscussed);
+                        @display
                     }
                 </dd>
                 <dd class="govuk-summary-list__value "/>


### PR DESCRIPTION
### Context

Correct formatting of dates on academy and trust information page

### Changes proposed in this pull request

When dates are shown on the page, display as D MMM YYYY (e.g. 1 September 2021) rather than 01/09/2021

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

