### PR TITLE
Add helper to format performance results

### DIFF
--- a/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
+++ b/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
@@ -1,0 +1,25 @@
+using Frontend.Helpers;
+using Xunit;
+
+namespace Frontend.Tests.HelpersTests
+{
+    public class PerformanceDataHelpersTests
+    {
+        public class GetFormattedResultTests
+        {
+            [Theory]
+            [InlineData(null, "no data")]
+            [InlineData("", "no data")]
+            [InlineData("3.45", "3.45")]
+            [InlineData("3.00", "3")]
+            [InlineData("3", "3")]
+            [InlineData("some text", "some text")]
+            public void GivenNull_ReturnsNoData(string result, string expectedResult)
+            {
+                var formattedResult = PerformanceDataHelpers.GetFormattedResult(result);
+
+                Assert.Equal(expectedResult, formattedResult);
+            }
+        }
+    }
+}

--- a/Frontend/Helpers/PerformanceDataHelpers.cs
+++ b/Frontend/Helpers/PerformanceDataHelpers.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace Frontend.Helpers
+{
+    public static class PerformanceDataHelpers
+    {
+        private const string NoDataText = "no data";
+        public static string GetFormattedResult(string result)
+        {
+            return string.IsNullOrEmpty(result) ? 
+                NoDataText : 
+                FormatStringAsDouble(result);
+        }
+        
+        private static string FormatStringAsDouble(string result)
+        {
+            var resultIsDouble = double.TryParse(result, NumberStyles.Number, CultureInfo.InvariantCulture, out var resultAsDouble);
+            return resultIsDouble ? $"{resultAsDouble}" : result;
+        }
+    }
+}

--- a/Frontend/Pages/KeyStage2Performance.cshtml
+++ b/Frontend/Pages/KeyStage2Performance.cshtml
@@ -1,4 +1,5 @@
 @page "/project/{id}/key-stage-2-performance"
+@using Frontend.Helpers
 @model Frontend.Pages.KeyStage2Performance
 
 @{
@@ -53,27 +54,27 @@
                 <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                    <td class="govuk-table__cell">@ks2Result.PercentageMeetingExpectedStdInRWM.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.PercentageAchievingHigherStdInRWM.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.ReadingProgressScore.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.WritingProgressScore.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.MathsProgressScore.NotDisadvantaged</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.PercentageMeetingExpectedStdInRWM.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.PercentageAchievingHigherStdInRWM.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.ReadingProgressScore.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.WritingProgressScore.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.MathsProgressScore.NotDisadvantaged)</td>
                 </tr>
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                    <td class="govuk-table__cell">@ks2Result.LAAveragePercentageMeetingExpectedStdInRWM.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.LAAveragePercentageAchievingHigherStdInRWM.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.LAAverageReadingProgressScore.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.LAAverageWritingProgressScore.NotDisadvantaged</td>
-                    <td class="govuk-table__cell">@ks2Result.LAAverageMathsProgressScore.NotDisadvantaged</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.LAAveragePercentageMeetingExpectedStdInRWM.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.LAAveragePercentageAchievingHigherStdInRWM.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.LAAverageReadingProgressScore.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.LAAverageWritingProgressScore.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.LAAverageMathsProgressScore.NotDisadvantaged)</td>
                 </tr>
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">National average</th>
-                    <td class="govuk-table__cell">@ks2Result.NationalAveragePercentageMeetingExpectedStdInRWM.NotDisadvantaged<br>(disadvantaged @string.Format(ks2Result.NationalAveragePercentageMeetingExpectedStdInRWM.Disadvantaged,"D"))</td>
-                    <td class="govuk-table__cell">@ks2Result.NationalAveragePercentageAchievingHigherStdInRWM.NotDisadvantaged<br>(disadvantaged @string.Format(ks2Result.NationalAveragePercentageAchievingHigherStdInRWM.Disadvantaged,"D"))</td>
-                    <td class="govuk-table__cell"></td>
-                    <td class="govuk-table__cell"></td>
-                    <td class="govuk-table__cell"></td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.NationalAveragePercentageMeetingExpectedStdInRWM.NotDisadvantaged)<br>(disadvantaged @PerformanceDataHelpers.GetFormattedResult(ks2Result.NationalAveragePercentageMeetingExpectedStdInRWM.Disadvantaged))</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.NationalAveragePercentageAchievingHigherStdInRWM.NotDisadvantaged)<br>(disadvantaged @PerformanceDataHelpers.GetFormattedResult(ks2Result.NationalAveragePercentageAchievingHigherStdInRWM.Disadvantaged))</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.NationalAverageReadingProgressScore.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.NationalAverageWritingProgressScore.NotDisadvantaged)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks2Result.NationalAverageMathsProgressScore.NotDisadvantaged)</td>
                 </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
### Context

Add helper to format performance results

### Changes proposed in this pull request

Format results so where no data is returned "no data" is displayed on the page
Show whole number decimals with no decimal places

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

