### PR TITLE
Key stage 5 performance information

### DIFF
--- a/Data.TRAMS.Tests/Mappers/Response/TramsEducationPerformanceMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsEducationPerformanceMapperTests.cs
@@ -17,25 +17,66 @@ namespace Data.TRAMS.Tests.Mappers.Response
             var tramsEducationPerformanceToMap = EducationPerformance.GetSingleTramsEducationPerformance();
 
             var mappedInternalEducationPerformance = _subject.Map(tramsEducationPerformanceToMap);
+            AssertKs2MappedCorrectly(mappedInternalEducationPerformance, tramsEducationPerformanceToMap);
+            var mappedKs5Results = mappedInternalEducationPerformance.KeyStage5Performance;
+            var tramsKs5Results = tramsEducationPerformanceToMap.KeyStage5;
+
+            Assert.Equal(tramsKs5Results[0].Year, mappedKs5Results[0].Year);
+            Assert.Equal(tramsKs5Results[0].AcademicQualificationAverage, mappedKs5Results[0].Academy.AcademicAverage);
+            Assert.Equal(tramsKs5Results[0].AppliedGeneralQualificationAverage,
+                mappedKs5Results[0].Academy.AppliedGeneralAverage);
+            Assert.Equal(tramsKs5Results[0].NationalAcademicQualificationAverage,
+                mappedKs5Results[0].National.AcademicAverage);
+            Assert.Equal(tramsKs5Results[0].NationalAppliedGeneralQualificationAverage,
+                mappedKs5Results[0].National.AppliedGeneralAverage);
+            Assert.Equal(tramsKs5Results[1].Year, mappedKs5Results[1].Year);
+            Assert.Equal(tramsKs5Results[1].AcademicQualificationAverage, mappedKs5Results[1].Academy.AcademicAverage);
+            Assert.Equal(tramsKs5Results[1].AppliedGeneralQualificationAverage,
+                mappedKs5Results[1].Academy.AppliedGeneralAverage);
+            Assert.Equal(tramsKs5Results[1].NationalAcademicQualificationAverage,
+                mappedKs5Results[1].National.AcademicAverage);
+            Assert.Equal(tramsKs5Results[1].NationalAppliedGeneralQualificationAverage,
+                mappedKs5Results[1].National.AppliedGeneralAverage);
+        }
+
+        private void AssertKs2MappedCorrectly(
+            Data.Models.KeyStagePerformance.EducationPerformance mappedInternalEducationPerformance,
+            TramsEducationPerformance tramsEducationPerformanceToMap)
+        {
             var mappedKs2Result = mappedInternalEducationPerformance.KeyStage2Performance.First();
             var tramsKs2Result = tramsEducationPerformanceToMap.KeyStage2.First();
-            
+
             Assert.Equal(tramsKs2Result.Year, mappedKs2Result.Year);
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.MathsProgressScore, mappedKs2Result.MathsProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.ReadingProgressScore, mappedKs2Result.ReadingProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.WritingProgressScore, mappedKs2Result.WritingProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageMathsProgressScore, mappedKs2Result.NationalAverageMathsProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageReadingProgressScore, mappedKs2Result.NationalAverageReadingProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAverageMathsProgressScore, mappedKs2Result.LAAverageMathsProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAverageReadingProgressScore, mappedKs2Result.LAAverageReadingProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAverageWritingProgressScore, mappedKs2Result.LAAverageWritingProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAveragePercentageAchievingHigherStdInRWM, mappedKs2Result.LAAveragePercentageAchievingHigherStdInRWM));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAveragePercentageMeetingExpectedStdInRWM, mappedKs2Result.LAAveragePercentageMeetingExpectedStdInRWM));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageMathsProgressScore, mappedKs2Result.NationalAverageMathsProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageReadingProgressScore, mappedKs2Result.NationalAverageReadingProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageWritingProgressScore, mappedKs2Result.NationalAverageWritingProgressScore));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAveragePercentageAchievingHigherStdInRWM, mappedKs2Result.NationalAveragePercentageAchievingHigherStdInRWM));
-            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAveragePercentageMeetingExpectedStdInRWM, mappedKs2Result.NationalAveragePercentageMeetingExpectedStdInRWM));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.MathsProgressScore,
+                mappedKs2Result.MathsProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.ReadingProgressScore,
+                mappedKs2Result.ReadingProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.WritingProgressScore,
+                mappedKs2Result.WritingProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageMathsProgressScore,
+                mappedKs2Result.NationalAverageMathsProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageReadingProgressScore,
+                mappedKs2Result.NationalAverageReadingProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAverageMathsProgressScore,
+                mappedKs2Result.LAAverageMathsProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAverageReadingProgressScore,
+                mappedKs2Result.LAAverageReadingProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAverageWritingProgressScore,
+                mappedKs2Result.LAAverageWritingProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAveragePercentageAchievingHigherStdInRWM,
+                mappedKs2Result.LAAveragePercentageAchievingHigherStdInRWM));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.LAAveragePercentageMeetingExpectedStdInRWM,
+                mappedKs2Result.LAAveragePercentageMeetingExpectedStdInRWM));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageMathsProgressScore,
+                mappedKs2Result.NationalAverageMathsProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageReadingProgressScore,
+                mappedKs2Result.NationalAverageReadingProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAverageWritingProgressScore,
+                mappedKs2Result.NationalAverageWritingProgressScore));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAveragePercentageAchievingHigherStdInRWM,
+                mappedKs2Result.NationalAveragePercentageAchievingHigherStdInRWM));
+            Assert.True(AssertPupilCategoryResponse(tramsKs2Result.NationalAveragePercentageMeetingExpectedStdInRWM,
+                mappedKs2Result.NationalAveragePercentageMeetingExpectedStdInRWM));
         }
         
         [Fact]

--- a/Data.TRAMS.Tests/TestFixtures/EducationPerformance.cs
+++ b/Data.TRAMS.Tests/TestFixtures/EducationPerformance.cs
@@ -74,6 +74,25 @@ namespace Data.TRAMS.Tests.TestFixtures
                         LAAverageP8Maths = GetTestResult(),
                         LAAverageP8Ebacc = GetTestResult(),
                     }
+                }, 
+                KeyStage5 = new List<KeyStage5>()
+                {
+                    new KeyStage5
+                    {
+                        Year = "2018-2019",
+                        AcademicQualificationAverage = "12.12",
+                        AppliedGeneralQualificationAverage = "21.21",
+                        NationalAcademicQualificationAverage = "11.11",
+                        NationalAppliedGeneralQualificationAverage = "22.22"
+                    },
+                    new KeyStage5
+                    {
+                        Year = "2019-2020",
+                        AcademicQualificationAverage = "12.12",
+                        AppliedGeneralQualificationAverage = "21.21",
+                        NationalAcademicQualificationAverage = "11.11",
+                        NationalAppliedGeneralQualificationAverage = "22.22"
+                    }
                 }
             };
         }

--- a/Data.TRAMS/Mappers/Response/TramsEducationPerformanceMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsEducationPerformanceMapper.cs
@@ -3,6 +3,7 @@ using Data.Models.KeyStagePerformance;
 using Data.TRAMS.Models.EducationPerformance;
 using KeyStage2 = Data.Models.KeyStagePerformance.KeyStage2;
 using KeyStage4 = Data.Models.KeyStagePerformance.KeyStage4;
+using KeyStage5 = Data.Models.KeyStagePerformance.KeyStage5;
 using Trams = Data.TRAMS.Models;
 
 namespace Data.TRAMS.Mappers.Response
@@ -241,7 +242,23 @@ namespace Data.TRAMS.Mappers.Response
                 },
                 LAAverageP8LowerConfidence = ks4Result.LAAverageP8LowerConfidence,
                 LAAverageP8UpperConfidence = ks4Result.LAAverageP8UpperConfidence
-                    }).ToList() 
+                    }).ToList() ,
+                KeyStage5Performance = input.KeyStage5.Select(ks5Result =>
+                    new KeyStage5
+                    {
+                        Year = ks5Result.Year,
+                        Academy = new KeyStage5Result
+                        {
+                            AcademicAverage = ks5Result.AcademicQualificationAverage,
+                            AppliedGeneralAverage = ks5Result.AppliedGeneralQualificationAverage,
+                        },
+                        National = new KeyStage5Result
+                        {
+                            AcademicAverage = ks5Result.NationalAcademicQualificationAverage,
+                            AppliedGeneralAverage = ks5Result.NationalAppliedGeneralQualificationAverage
+                        }
+                    }
+                ).ToList()
             };
         }
     }

--- a/Data.TRAMS/Models/EducationPerformance/KeyStage5.cs
+++ b/Data.TRAMS/Models/EducationPerformance/KeyStage5.cs
@@ -1,0 +1,13 @@
+namespace Data.TRAMS.Models.EducationPerformance
+{
+    public class KeyStage5
+    {
+        public string AcademicQualificationAverage { get; set; }
+        public string AppliedGeneralQualificationAverage { get; set; }
+        public string LaAcademicQualificationAverage { get; set; }
+        public string LaAppliedGeneralQualificationAverage { get; set; }
+        public string NationalAcademicQualificationAverage { get; set; }
+        public string NationalAppliedGeneralQualificationAverage { get; set; }
+        public string Year { get; set; }
+    }
+}

--- a/Data.TRAMS/Models/EducationPerformance/TramsEducationPerformance.cs
+++ b/Data.TRAMS/Models/EducationPerformance/TramsEducationPerformance.cs
@@ -6,5 +6,6 @@ namespace Data.TRAMS.Models.EducationPerformance
     {
         public List<KeyStage2> KeyStage2 { get; set; }
         public List<KeyStage4> KeyStage4 { get; set; }
+        public List<KeyStage5> KeyStage5 { get; set; }
     }
 }

--- a/Data/Models/KeyStagePerformance/EducationPerformance.cs
+++ b/Data/Models/KeyStagePerformance/EducationPerformance.cs
@@ -6,5 +6,6 @@ namespace Data.Models.KeyStagePerformance
     {
         public List<KeyStage2> KeyStage2Performance { get; set; }
         public List<KeyStage4> KeyStage4Performance { get; set; }
+        public List<KeyStage5> KeyStage5Performance { get; set; }
     }
 }

--- a/Data/Models/KeyStagePerformance/KeyStage5.cs
+++ b/Data/Models/KeyStagePerformance/KeyStage5.cs
@@ -1,0 +1,9 @@
+namespace Data.Models.KeyStagePerformance
+{
+    public class KeyStage5
+    {
+        public string Year { get; set; }
+        public KeyStage5Result Academy { get; set; }
+        public KeyStage5Result National { get; set; }
+    }
+}

--- a/Data/Models/KeyStagePerformance/KeyStage5Result.cs
+++ b/Data/Models/KeyStagePerformance/KeyStage5Result.cs
@@ -1,0 +1,10 @@
+namespace Data.Models.KeyStagePerformance
+{
+    public class KeyStage5Result
+    {
+        public string AcademicProgress { get; set; }
+        public string AcademicAverage { get; set; }
+        public string AppliedGeneralProgress { get; set; }
+        public string AppliedGeneralAverage { get; set; }
+    }
+}

--- a/Frontend.Tests/ModelTests/ProjectTaskListViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/ProjectTaskListViewModelTests.cs
@@ -2,6 +2,9 @@
 using Data.Models.Projects;
 using Frontend.Models;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Data.Models.KeyStagePerformance;
+using DocumentFormat.OpenXml.Office2013.PowerPoint.Roaming;
 using Xunit;
 using static Data.Models.Projects.TransferFeatures;
 
@@ -27,7 +30,7 @@ namespace Frontend.Tests.ModelTests
                         TypeOfTransfer = TransferFeatures.TransferTypes.Empty
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.FeatureTransferStatus;
@@ -52,7 +55,7 @@ namespace Frontend.Tests.ModelTests
                         TypeOfTransfer = TransferFeatures.TransferTypes.MatClosure
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.FeatureTransferStatus;
@@ -68,7 +71,8 @@ namespace Frontend.Tests.ModelTests
             [InlineData(ProjectInitiators.Empty, null, TransferTypes.JoiningToFormMat)]
             [InlineData(ProjectInitiators.Empty, true, TransferTypes.Empty)]
             [InlineData(ProjectInitiators.Empty, true, TransferTypes.JoiningToFormMat)]
-            public void GivenTransferFeatureDataIsPartiallyCompleted_ReturnInProgress(ProjectInitiators projectInitiator,
+            public void GivenTransferFeatureDataIsPartiallyCompleted_ReturnInProgress(
+                ProjectInitiators projectInitiator,
                 bool? isSubjectToRddOrEsfaIntervention,
                 TransferTypes transferType)
             {
@@ -78,17 +82,47 @@ namespace Frontend.Tests.ModelTests
                     Features = new TransferFeatures
                     {
                         WhoInitiatedTheTransfer = projectInitiator,
-                        ReasonForTransfer = new ReasonForTransfer { IsSubjectToRddOrEsfaIntervention = isSubjectToRddOrEsfaIntervention },
+                        ReasonForTransfer = new ReasonForTransfer
+                            {IsSubjectToRddOrEsfaIntervention = isSubjectToRddOrEsfaIntervention},
                         TypeOfTransfer = transferType
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.FeatureTransferStatus;
 
                 // Assert
                 Assert.Equal(ProjectStatuses.InProgress, result);
+            }
+        }
+
+        public class HasKeyStage5PerformanceDataTests
+        {
+            [Fact]
+            public void GivenNull_ReturnFalse()
+            {
+                var model = new ProjectTaskListViewModel {EducationPerformance = new EducationPerformance()};
+                Assert.False(model.HasKeyStage5PerformanceInformation);
+            }
+
+            [Fact]
+            public void GivenEmptyList_ReturnFalse()
+            {
+                var model = new ProjectTaskListViewModel
+                    {EducationPerformance = new EducationPerformance() {KeyStage5Performance = new List<KeyStage5>()}};
+                Assert.False(model.HasKeyStage5PerformanceInformation);
+            }
+
+            [Fact]
+            public void GivenListWithItem_ReturnTrue()
+            {
+                var model = new ProjectTaskListViewModel
+                {
+                    EducationPerformance = new EducationPerformance
+                        {KeyStage5Performance = new List<KeyStage5> {new KeyStage5()}}
+                };
+                Assert.True(model.HasKeyStage5PerformanceInformation);
             }
         }
 
@@ -107,7 +141,7 @@ namespace Frontend.Tests.ModelTests
                         Htb = string.Empty
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.TransferDatesStatus;
@@ -129,7 +163,7 @@ namespace Frontend.Tests.ModelTests
                         Htb = null
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.TransferDatesStatus;
@@ -158,7 +192,7 @@ namespace Frontend.Tests.ModelTests
                         Htb = htbDate
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.TransferDatesStatus;
@@ -180,7 +214,7 @@ namespace Frontend.Tests.ModelTests
                         Htb = "test"
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.TransferDatesStatus;
@@ -204,7 +238,7 @@ namespace Frontend.Tests.ModelTests
                         OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string>()
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.BenefitsAndOtherFactorsStatus;
@@ -221,11 +255,12 @@ namespace Frontend.Tests.ModelTests
                 {
                     Benefits = new TransferBenefits
                     {
-                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit> { TransferBenefits.IntendedBenefit.CentralFinanceTeamAndSupport },
+                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit>
+                            {TransferBenefits.IntendedBenefit.CentralFinanceTeamAndSupport},
                         OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string>()
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.BenefitsAndOtherFactorsStatus;
@@ -243,10 +278,11 @@ namespace Frontend.Tests.ModelTests
                     Benefits = new TransferBenefits
                     {
                         IntendedBenefits = new List<TransferBenefits.IntendedBenefit>(),
-                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string> { { TransferBenefits.OtherFactor.HighProfile, "test" } }
+                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string>
+                            {{TransferBenefits.OtherFactor.HighProfile, "test"}}
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.BenefitsAndOtherFactorsStatus;
@@ -267,7 +303,7 @@ namespace Frontend.Tests.ModelTests
                         OtherFactors = null
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.BenefitsAndOtherFactorsStatus;
@@ -284,11 +320,13 @@ namespace Frontend.Tests.ModelTests
                 {
                     Benefits = new TransferBenefits
                     {
-                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit> { TransferBenefits.IntendedBenefit.CentralFinanceTeamAndSupport },
-                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string> { { TransferBenefits.OtherFactor.HighProfile, "test" } }
+                        IntendedBenefits = new List<TransferBenefits.IntendedBenefit>
+                            {TransferBenefits.IntendedBenefit.CentralFinanceTeamAndSupport},
+                        OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string>
+                            {{TransferBenefits.OtherFactor.HighProfile, "test"}}
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.BenefitsAndOtherFactorsStatus;
@@ -312,7 +350,7 @@ namespace Frontend.Tests.ModelTests
                         Trust = string.Empty
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.RationaleStatus;
@@ -337,7 +375,7 @@ namespace Frontend.Tests.ModelTests
                         Trust = trustValue
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.RationaleStatus;
@@ -358,7 +396,7 @@ namespace Frontend.Tests.ModelTests
                         Trust = "some value"
                     }
                 };
-                var model = new ProjectTaskListViewModel { Project = project };
+                var model = new ProjectTaskListViewModel {Project = project};
 
                 // Act
                 var result = model.RationaleStatus;
@@ -371,13 +409,19 @@ namespace Frontend.Tests.ModelTests
         public class AcademyAndTrustInformationTests
         {
             [Theory]
-            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Empty, null, ProjectStatuses.NotStarted)]
-            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Approve, "test author", ProjectStatuses.Completed)]
-            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Empty, "test author", ProjectStatuses.InProgress)]
-            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Decline, null, ProjectStatuses.InProgress)]
-            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Decline, "", ProjectStatuses.InProgress)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Empty, null,
+                ProjectStatuses.NotStarted)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Approve, "test author",
+                ProjectStatuses.Completed)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Empty, "test author",
+                ProjectStatuses.InProgress)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Decline, null,
+                ProjectStatuses.InProgress)]
+            [InlineData(TransferAcademyAndTrustInformation.RecommendationResult.Decline, "",
+                ProjectStatuses.InProgress)]
             public void GivenRelevantData_ReturnCorrectStatus(
-                TransferAcademyAndTrustInformation.RecommendationResult recommendation, string author, ProjectStatuses expectedStatus)
+                TransferAcademyAndTrustInformation.RecommendationResult recommendation, string author,
+                ProjectStatuses expectedStatus)
             {
                 var project = new Project
                 {
@@ -389,7 +433,7 @@ namespace Frontend.Tests.ModelTests
                 };
                 var model = new ProjectTaskListViewModel {Project = project};
                 var result = model.AcademyAndTrustInformationStatus();
-                
+
                 Assert.Equal(expectedStatus, result);
             }
         }

--- a/Frontend.Tests/PagesTests/KeyStage5PerformanceTests.cs
+++ b/Frontend.Tests/PagesTests/KeyStage5PerformanceTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using Data;
+using Data.Models;
+using Data.Models.KeyStagePerformance;
+using Frontend.Pages;
+using Frontend.Services.Interfaces;
+using Frontend.Services.Responses;
+using Frontend.Tests.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Moq;
+using Xunit;
+
+namespace Frontend.Tests.PagesTests
+{
+    public class KeyStage5PerformanceTests
+    {
+        private readonly Mock<IGetInformationForProject> _getInformationForProject;
+        private Mock<IProjects> _projectRepository;
+        private readonly KeyStage5Performance _subject;
+        private EducationPerformance _foundEducationPerformance;
+        private Project _foundProject;
+        private Academy _foundOutgoingAcademy;
+        private GetInformationForProjectResponse _foundInformationForProject;
+
+        public KeyStage5PerformanceTests()
+        {
+            _projectRepository = new Mock<IProjects>();
+            _getInformationForProject = new Mock<IGetInformationForProject>();
+
+            _foundEducationPerformance = new EducationPerformance
+            {
+                KeyStage5Performance = new List<KeyStage5> {new KeyStage5 {Year = "2019"}}
+            };
+
+            _foundProject = new Project {Urn = "1234"};
+
+            _foundOutgoingAcademy = new Academy
+            {
+                Name = "Academy name", Urn = "Urn", LocalAuthorityName = "LA Name"
+            };
+
+            _foundInformationForProject = new GetInformationForProjectResponse
+            {
+                Project = _foundProject,
+                EducationPerformance = _foundEducationPerformance,
+                OutgoingAcademy = _foundOutgoingAcademy
+            };
+
+            _getInformationForProject
+                .Setup(s => s.Execute(It.IsAny<string>()))
+                .ReturnsAsync(
+                    _foundInformationForProject
+                );
+
+            _projectRepository.Setup(s => s.GetByUrn(It.IsAny<string>())).ReturnsAsync(
+                new RepositoryResult<Project>
+                {
+                    Result = _foundProject
+                });
+
+            _subject = new KeyStage5Performance(_getInformationForProject.Object, _projectRepository.Object);
+        }
+
+        public class OnGetAsyncTests : KeyStage5PerformanceTests
+        {
+            [Theory]
+            [InlineData("1234")]
+            [InlineData("4321")]
+            public async void OnGet_GetInformationForProjectId(string id)
+            {
+                await _subject.OnGetAsync(id);
+
+                _getInformationForProject.Verify(s => s.Execute(id));
+            }
+
+            [Fact]
+            public async void OnGet_AssignsCorrectValuesToViewModel()
+            {
+                var result = await _subject.OnGetAsync("1234");
+
+                Assert.IsType<PageResult>(result);
+                Assert.Equal(_foundProject.Urn, _subject.ProjectUrn);
+                Assert.Equal(_foundEducationPerformance, _subject.EducationPerformance);
+                Assert.Equal(_foundOutgoingAcademy.Urn, _subject.OutgoingAcademyUrn);
+                Assert.Equal(_foundOutgoingAcademy.Name, _subject.OutgoingAcademyName);
+                Assert.Equal(_foundOutgoingAcademy.LocalAuthorityName, _subject.LocalAuthorityName);
+            }
+
+            [Fact]
+            public async void GivenAdditionalInformation_UpdatesTheViewModel()
+            {
+                const string additionalInformation = "some additional info";
+                _foundInformationForProject.Project.KeyStage5PerformanceAdditionalInformation = additionalInformation;
+
+                await _subject.OnGetAsync("1234");
+
+                Assert.Equal(additionalInformation, _subject.AdditionalInformation.AdditionalInformation);
+                Assert.Equal(_foundProject.Urn, _subject.AdditionalInformation.Urn);
+            }
+
+            [Fact]
+            public async void GivenGetByUrnReturnsError_DisplayErrorPage()
+            {
+                var pageModel =
+                    RazorPageTestHelpers.GetPageModelWithViewData<KeyStage5Performance>(
+                        _getInformationForProject.Object, _projectRepository.Object);
+
+                _getInformationForProject.Setup(s => s.Execute(_foundProject.Urn)).ReturnsAsync(
+                    new GetInformationForProjectResponse
+                    {
+                        ResponseError = new ServiceResponseError
+                            {ErrorCode = ErrorCode.NotFound, ErrorMessage = "Error message"}
+                    }
+                );
+
+                var response = await pageModel.OnGetAsync(_foundProject.Urn);
+                var viewResult = Assert.IsType<ViewResult>(response);
+
+                Assert.Equal("ErrorPage", viewResult.ViewName);
+                Assert.Equal("Error message", viewResult.Model);
+            }
+        }
+
+        public class OnPostAsyncTests : KeyStage5PerformanceTests
+        {
+            [Fact]
+            public async void GivenUrn_FetchesProjectFromTheRepository()
+            {
+                await _subject.OnPostAsync("1234", string.Empty);
+
+                _projectRepository.Verify(r => r.GetByUrn("1234"), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenGetByUrnReturnsError_DisplayErrorPage()
+            {
+                var pageModel =
+                    RazorPageTestHelpers.GetPageModelWithViewData<KeyStage5Performance>(
+                        _getInformationForProject.Object, _projectRepository.Object);
+
+                _projectRepository.Setup(s => s.GetByUrn(It.IsAny<string>())).ReturnsAsync(
+                    new RepositoryResult<Project>
+                    {
+                        Error = new RepositoryResultBase.RepositoryError
+                        {
+                            ErrorMessage = "Error"
+                        }
+                    });
+
+
+                var response = await pageModel.OnPostAsync("1234", string.Empty);
+                var viewResult = Assert.IsType<ViewResult>(response);
+
+                Assert.Equal("ErrorPage", viewResult.ViewName);
+                Assert.Equal("Error", viewResult.Model);
+            }
+
+            [Fact]
+            public async void GivenAdditionalInformation_UpdatesTheProjectModel()
+            {
+                const string additionalInformation = "some additional info";
+
+                var response = await _subject.OnPostAsync("1234", additionalInformation);
+
+                var redirectToPageResponse = Assert.IsType<RedirectToPageResult>(response);
+                Assert.Equal("KeyStage5Performance", redirectToPageResponse.PageName);
+                Assert.Equal("OnGetAsync", redirectToPageResponse.PageHandler);
+                Assert.Equal(additionalInformation, _foundProject.KeyStage5PerformanceAdditionalInformation);
+            }
+
+            [Fact]
+            public async void GivenAdditionalInformation_UpdatesTheProjectCorrectly()
+            {
+                const string additionalInfo = "test info";
+
+                await _subject.OnPostAsync("1234", additionalInfo);
+                _projectRepository.Verify(r => r.Update(It.Is<Project>(
+                    project => project.KeyStage5PerformanceAdditionalInformation == additionalInfo
+                )));
+            }
+        }
+    }
+}

--- a/Frontend/Controllers/ProjectController.cs
+++ b/Frontend/Controllers/ProjectController.cs
@@ -30,10 +30,17 @@ namespace Frontend.Controllers
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
+            var viewModel = new ProjectTaskListViewModel
+            {
+                Project = project.Result
+            };
+
             var educationPerformance =
                 await _projectRepositoryEducationPerformance.GetByAcademyUrn(project.Result.OutgoingAcademyUrn);
             if (educationPerformance.IsValid)
             {
+                viewModel.EducationPerformance = educationPerformance.Result;
+
                 ViewData["HasKeyStage2PerformanceData"] =
                     HasKeyStage2PerformanceData(educationPerformance.Result?.KeyStage2Performance);
             }
@@ -42,13 +49,8 @@ namespace Frontend.Controllers
                 ViewData["HasKeyStage2PerformanceData"] = false;
             }
 
-            var viewModel = new ProjectTaskListViewModel
-            {
-                Project = project.Result
-            };
-
             ViewData["ProjectId"] = id;
-            
+
             return View(viewModel);
         }
 

--- a/Frontend/Models/ProjectTaskListViewModel.cs
+++ b/Frontend/Models/ProjectTaskListViewModel.cs
@@ -1,36 +1,45 @@
 ﻿using Data.Models;
 using Data.Models.Projects;
 using System.Linq;
+using Data.Models.KeyStagePerformance;
 
 namespace Frontend.Models
 {
     public class ProjectTaskListViewModel : ProjectViewModel
     {
+        public EducationPerformance EducationPerformance { get; set; }
         public ProjectStatuses FeatureTransferStatus => GetFeatureTransferStatus();
         public ProjectStatuses TransferDatesStatus => GetTransferDatesStatus();
         public ProjectStatuses BenefitsAndOtherFactorsStatus => GetBenefitsAndOtherFactorsStatus();
         public ProjectStatuses RationaleStatus => GetRationaleStatus();
         public ProjectStatuses AcademyAndTrustInformationStatus() => GetAcademyAndTrustInformationStatus();
+
+        public bool HasKeyStage5PerformanceInformation =>
+            EducationPerformance.KeyStage5Performance != null &&
+            EducationPerformance.KeyStage5Performance.Count > 0;
+
         private ProjectStatuses GetAcademyAndTrustInformationStatus()
         {
             var academyAndTrustInformation = Project.AcademyAndTrustInformation;
-            return (string.IsNullOrEmpty(academyAndTrustInformation.Author) && 
-                    (academyAndTrustInformation.Recommendation == TransferAcademyAndTrustInformation.RecommendationResult.Empty)) ? ProjectStatuses.NotStarted
+            return (string.IsNullOrEmpty(academyAndTrustInformation.Author) &&
+                    (academyAndTrustInformation.Recommendation ==
+                     TransferAcademyAndTrustInformation.RecommendationResult.Empty)) ? ProjectStatuses.NotStarted
                 : (!string.IsNullOrEmpty(academyAndTrustInformation.Author) &&
-                   (academyAndTrustInformation.Recommendation != TransferAcademyAndTrustInformation.RecommendationResult.Empty)) ? ProjectStatuses.Completed
+                   (academyAndTrustInformation.Recommendation !=
+                    TransferAcademyAndTrustInformation.RecommendationResult.Empty)) ? ProjectStatuses.Completed
                 : ProjectStatuses.InProgress;
         }
 
         private ProjectStatuses GetFeatureTransferStatus()
         {
             if (Project.Features.WhoInitiatedTheTransfer == TransferFeatures.ProjectInitiators.Empty &&
-                    Project.Features.ReasonForTransfer.IsSubjectToRddOrEsfaIntervention == null &&
-                    Project.Features.TypeOfTransfer == TransferFeatures.TransferTypes.Empty)
+                Project.Features.ReasonForTransfer.IsSubjectToRddOrEsfaIntervention == null &&
+                Project.Features.TypeOfTransfer == TransferFeatures.TransferTypes.Empty)
                 return ProjectStatuses.NotStarted;
 
             if (Project.Features.WhoInitiatedTheTransfer != TransferFeatures.ProjectInitiators.Empty &&
-                    Project.Features.ReasonForTransfer.IsSubjectToRddOrEsfaIntervention != null &&
-                    Project.Features.TypeOfTransfer != TransferFeatures.TransferTypes.Empty)
+                Project.Features.ReasonForTransfer.IsSubjectToRddOrEsfaIntervention != null &&
+                Project.Features.TypeOfTransfer != TransferFeatures.TransferTypes.Empty)
                 return ProjectStatuses.Completed;
 
             return ProjectStatuses.InProgress;

--- a/Frontend/Pages/KeyStage5Performance.cshtml
+++ b/Frontend/Pages/KeyStage5Performance.cshtml
@@ -1,0 +1,87 @@
+@page "/project/{id}/key-stage-5-performance"
+@using Frontend.Helpers
+@model Frontend.Pages.KeyStage5Performance
+
+@{
+    ViewBag.Title = "Key stage 5 performance tables";
+    Layout = "_Layout";
+}
+
+@section BeforeMain
+{
+    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.ProjectUrn">Back to task list</a>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+        <span class="govuk-caption-l">
+            URN @Model.OutgoingAcademyUrn
+        </span>
+        <h1 class="govuk-heading-l">
+            Key stage 5 performance tables
+        </h1>
+        <p class="govuk-body">
+            This information is pre-populated from TRAMS.
+        </p>
+        <p class="govuk-body">
+            <a href="https://www.compare-school-performance.service.gov.uk/school/<URN>" class="govuk-link" rel="noreferrer noopener" target="_blank">Source of data: Find and compare school performance (opens in new tab)</a>
+        </p>
+        <hr class="govuk-section-break govuk-section-break--l">
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
+        @foreach (var ks5Result in Model.EducationPerformance.KeyStage5Performance.OrderByDescending(o => o.Year))
+        {
+            <h2 class="govuk-heading-m">
+                @ks5Result.Year scores for academic and applied general qualifications
+            </h2>
+            <table class="govuk-table govuk-!-margin-bottom-9">
+                <caption class="govuk-table__caption govuk-table__caption--s">Local authority: @Model.LocalAuthorityName</caption>
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header"></th>
+                    <th scope="col" class="govuk-table__header">Academic progress</th>
+                    <th scope="col" class="govuk-table__header">Academic average</th>
+                    <th scope="col" class="govuk-table__header">Applied general progress</th>
+                    <th scope="col" class="govuk-table__header">Applied general average</th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AcademicProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AcademicAverage)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AppliedGeneralProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AppliedGeneralAverage)</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">National average</th>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AcademicProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AcademicAverage)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AppliedGeneralProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AppliedGeneralAverage)</td>
+                </tr>
+                </tbody>
+            </table>
+        }
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <partial name="_AdditionalInformation" model="Model.AdditionalInformation"/>
+</div>
+
+@if (!Model.AdditionalInformation.AddOrEditAdditionalInformation)
+{
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form asp-action="Index" asp-controller="Project" asp-route-id="@Model.ProjectUrn">
+                <button class="govuk-button" data-module="govuk-button">
+                    Confirm and continue
+                </button>
+            </form>
+        </div>
+    </div>
+}

--- a/Frontend/Pages/KeyStage5Performance.cshtml.cs
+++ b/Frontend/Pages/KeyStage5Performance.cshtml.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Data;
+using Data.Models.KeyStagePerformance;
+using Frontend.ExtensionMethods;
+using Frontend.Models.Forms;
+using Frontend.Services.Interfaces;
+using Frontend.Services.Responses;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Frontend.Pages
+{
+    public class KeyStage5Performance : PageModel
+    {
+        private readonly IGetInformationForProject _getInformationForProject;
+        private readonly IProjects _projects;
+        public string ProjectUrn { get; private set; }
+        public EducationPerformance EducationPerformance { get; set; }
+        public string LocalAuthorityName { get; set; }
+        public string OutgoingAcademyName { get; set; }
+        public AdditionalInformationViewModel AdditionalInformation { get; set; }
+        public string OutgoingAcademyUrn { get; set; }
+
+        public KeyStage5Performance(IGetInformationForProject getInformationForProject, IProjects projects)
+        {
+            _getInformationForProject = getInformationForProject;
+            _projects = projects;
+        }
+
+        public async Task<IActionResult> OnGetAsync(string id, bool addOrEditAdditionalInformation = false)
+        {
+            var projectInformation = await _getInformationForProject.Execute(id);
+
+            if (!projectInformation.IsValid)
+            {
+                return this.View("ErrorPage", projectInformation.ResponseError.ErrorMessage);
+            }
+
+            PopulateModel(addOrEditAdditionalInformation, projectInformation);
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(string id, string additionalInformation)
+        {
+            var project = await _projects.GetByUrn(id);
+
+            if (!project.IsValid)
+            {
+                return this.View("ErrorPage", project.Error.ErrorMessage);
+            }
+
+            project.Result.KeyStage5PerformanceAdditionalInformation = additionalInformation;
+            await _projects.Update(project.Result);
+
+            return new RedirectToPageResult(nameof(KeyStage5Performance),
+                "OnGetAsync",
+                new {id},
+                "additional-information-hint");
+        }
+
+        private void PopulateModel(bool addOrEditAdditionalInformation,
+            GetInformationForProjectResponse projectInformation)
+        {
+            ProjectUrn = projectInformation.Project.Urn;
+            OutgoingAcademyUrn = projectInformation.OutgoingAcademy.Urn;
+            LocalAuthorityName = projectInformation.OutgoingAcademy.LocalAuthorityName;
+            OutgoingAcademyName = projectInformation.OutgoingAcademy.Name;
+            EducationPerformance = projectInformation.EducationPerformance;
+            AdditionalInformation = new AdditionalInformationViewModel
+            {
+                AdditionalInformation = projectInformation.Project.KeyStage5PerformanceAdditionalInformation,
+                HintText =
+                    "This information will populate in your HTB template under the key stage performance tables section.",
+                Urn = projectInformation.Project.Urn,
+                AddOrEditAdditionalInformation = addOrEditAdditionalInformation
+            };
+        }
+    }
+}

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -86,6 +86,15 @@
                             </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="key-stage-2-performance-tables">Reference only</strong>
                         </li>
                     }
+                    
+                    @if (Model.HasKeyStage5PerformanceInformation)
+                    {
+                        <li class="moj-task-list__item">
+                            <span class="moj-task-list__task-name">
+                                <a class="govuk-link" asp-page="/KeyStage5Performance" asp-route-id="@Model.Project.Urn" aria-describedby="key-stage-5-performance-tables">Key stage 5 performance tables</a>
+                            </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="key-stage-5-performance-tables">Reference only</strong>
+                        </li>
+                    }
                 </ul>
             </li>
         </ol>


### PR DESCRIPTION
### Context

We want to be able to display the Key stage 5 performance information provided by the TRAMS api

### Changes proposed in this pull request

- Integrate with key stage 5 performance information
- Display key stage 5 performance information

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

