### PR TITLE
Show/Hide KS5 data corrextly

### DIFF
--- a/Frontend.Tests/ModelTests/ProjectTaskListViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/ProjectTaskListViewModelTests.cs
@@ -115,12 +115,41 @@ namespace Frontend.Tests.ModelTests
             }
 
             [Fact]
-            public void GivenListWithItem_ReturnTrue()
+            public void GivenListWithItemWithNoAcademy_ReturnFalse()
             {
                 var model = new ProjectTaskListViewModel
                 {
                     EducationPerformance = new EducationPerformance
                         {KeyStage5Performance = new List<KeyStage5> {new KeyStage5()}}
+                };
+                Assert.False(model.HasKeyStage5PerformanceInformation);
+            }
+
+            [Theory]
+            [InlineData("12.12", null)]
+            [InlineData("12.12", "")]
+            [InlineData(null, "12.12")]
+            [InlineData("", "12.12")]
+            [InlineData("12.12", "12.12")]
+            public void GivenListWithItemWithAcademyWithData_ReturnTrue(string academicAverage,
+                string appliedGeneralAverage)
+            {
+                var model = new ProjectTaskListViewModel
+                {
+                    EducationPerformance = new EducationPerformance
+                    {
+                        KeyStage5Performance = new List<KeyStage5>
+                        {
+                            new KeyStage5
+                            {
+                                Academy = new KeyStage5Result
+                                {
+                                    AcademicAverage = academicAverage,
+                                    AppliedGeneralAverage = appliedGeneralAverage
+                                }
+                            }
+                        }
+                    }
                 };
                 Assert.True(model.HasKeyStage5PerformanceInformation);
             }

--- a/Frontend/Models/ProjectTaskListViewModel.cs
+++ b/Frontend/Models/ProjectTaskListViewModel.cs
@@ -14,9 +14,19 @@ namespace Frontend.Models
         public ProjectStatuses RationaleStatus => GetRationaleStatus();
         public ProjectStatuses AcademyAndTrustInformationStatus() => GetAcademyAndTrustInformationStatus();
 
-        public bool HasKeyStage5PerformanceInformation =>
-            EducationPerformance.KeyStage5Performance != null &&
-            EducationPerformance.KeyStage5Performance.Count > 0;
+        public bool HasKeyStage5PerformanceInformation
+        {
+            get
+            {
+                return EducationPerformance.KeyStage5Performance != null &&
+                       EducationPerformance.KeyStage5Performance.Any(ks5 =>
+                           ks5.Academy != null && (
+                               !string.IsNullOrEmpty(ks5.Academy.AcademicAverage) ||
+                               !string.IsNullOrEmpty(ks5.Academy.AppliedGeneralAverage)
+                           )
+                       );
+            }
+        }
 
         private ProjectStatuses GetAcademyAndTrustInformationStatus()
         {

--- a/Frontend/Pages/KeyStage5Performance.cshtml
+++ b/Frontend/Pages/KeyStage5Performance.cshtml
@@ -24,7 +24,7 @@
             This information is pre-populated from TRAMS.
         </p>
         <p class="govuk-body">
-            <a href="https://www.compare-school-performance.service.gov.uk/school/<URN>" class="govuk-link" rel="noreferrer noopener" target="_blank">Source of data: Find and compare school performance (opens in new tab)</a>
+            <a href="https://www.compare-school-performance.service.gov.uk/school/@Model.OutgoingAcademyUrn" class="govuk-link" rel="noreferrer noopener" target="_blank">Source of data: Find and compare school performance (opens in new tab)</a>
         </p>
         <hr class="govuk-section-break govuk-section-break--l">
     </div>


### PR DESCRIPTION
### Context

It turns out KS5 data is similar to other data wherein it appears for schools that aren't appropriate

### Changes proposed in this pull request

- Fix link to compare school service
- show/hide KS5 data correctly

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

