### PR TITLE
Add space to years in KS4 data

### DIFF
--- a/Frontend.Tests/PagesTests/KeyStage4PerformanceTests.cs
+++ b/Frontend.Tests/PagesTests/KeyStage4PerformanceTests.cs
@@ -46,7 +46,7 @@ namespace Frontend.Tests.PagesTests
                     {
                         new KeyStage4
                         {
-                            Year = "2020",
+                            Year = "2019-2020",
                             SipNumberofpupilsprogress8 = new DisadvantagedPupilsResult
                             {
                                 NotDisadvantaged = "20.5",
@@ -55,7 +55,7 @@ namespace Frontend.Tests.PagesTests
                         },
                         new KeyStage4
                         {
-                            Year = "2019",
+                            Year = "2018-2019",
                             SipNumberofpupilsprogress8 = new DisadvantagedPupilsResult
                             {
                                 NotDisadvantaged = "40.8",
@@ -107,8 +107,8 @@ namespace Frontend.Tests.PagesTests
                 Assert.Equal(AcademyName, _subject.OutgoingAcademyName);
                 Assert.Equal(LAName, _subject.LocalAuthorityName);
                 Assert.Equal(3, _subject.KeyStage4Results.Count);
-                Assert.Equal("2020", _subject.KeyStage4Results[0].Year);
-                Assert.Equal("2019", _subject.KeyStage4Results[1].Year);
+                Assert.Equal("2018 - 2019", _subject.KeyStage4Results[1].Year);
+                Assert.Equal("2019 - 2020", _subject.KeyStage4Results[0].Year);
                 Assert.Null(_subject.KeyStage4Results[2].Year);
             }
             

--- a/Frontend/Helpers/PerformanceDataHelpers.cs
+++ b/Frontend/Helpers/PerformanceDataHelpers.cs
@@ -10,8 +10,8 @@ namespace Frontend.Helpers
 
         public static HtmlString GetFormattedResult(DisadvantagedPupilsResult disadvantagedPupilResult)
         {
-            if (string.IsNullOrEmpty(disadvantagedPupilResult.NotDisadvantaged) &&
-                string.IsNullOrEmpty(disadvantagedPupilResult.Disadvantaged))
+            if (string.IsNullOrEmpty(disadvantagedPupilResult?.NotDisadvantaged) &&
+                string.IsNullOrEmpty(disadvantagedPupilResult?.Disadvantaged))
                 return new HtmlString(NoDataText);
 
             return new HtmlString(

--- a/Frontend/Pages/KeyStage4Performance.cshtml
+++ b/Frontend/Pages/KeyStage4Performance.cshtml
@@ -219,9 +219,9 @@
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">School confidence interval</th>
-                <td class="govuk-table__cell">@Model.KeyStage4Results[2].SipProgress8lowerconfidence to @Model.KeyStage4Results[2].SipProgress8upperconfidence</td>
-                <td class="govuk-table__cell">@Model.KeyStage4Results[1].SipProgress8lowerconfidence to @Model.KeyStage4Results[1].SipProgress8upperconfidence</td>
-                <td class="govuk-table__cell">@Model.KeyStage4Results[0].SipProgress8lowerconfidence to @Model.KeyStage4Results[0].SipProgress8upperconfidence</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[2].SipProgress8lowerconfidence, @Model.KeyStage4Results[2].SipProgress8upperconfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[1].SipProgress8lowerconfidence, @Model.KeyStage4Results[1].SipProgress8upperconfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[0].SipProgress8lowerconfidence, @Model.KeyStage4Results[0].SipProgress8upperconfidence)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>

--- a/Frontend/Pages/KeyStage4Performance.cshtml.cs
+++ b/Frontend/Pages/KeyStage4Performance.cshtml.cs
@@ -81,7 +81,14 @@ namespace Frontend.Pages
         private static List<KeyStage4> GetLatestThreeResults(List<KeyStage4> keyStage4Performance)
         {
             return keyStage4Performance.Take(3).OrderByDescending(a => a.Year)
-                .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).ToList();
+                .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).Select(c => 
+                {
+                    if (c.Year != null)
+                    {
+                        c.Year = c.Year.Replace("-", " - ");
+                    }
+                    return c;
+                }).ToList();        
         }
     }
 }


### PR DESCRIPTION
### Context

Add space to years in KS4 data

### Changes proposed in this pull request

Add space to years in KS4 data
Fix bug where schools with less than 3 years data would not display correctly

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

