### PR TITLE
Performance table fixes

### DIFF
--- a/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
+++ b/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
@@ -60,5 +60,21 @@ namespace Frontend.Tests.HelpersTests
                 Assert.Equal("no data", result);
             }
         }
+        
+        public class GetFormattedYearTests
+        {
+            [Theory]
+            [InlineData(null, null)]
+            [InlineData("", "")]
+            [InlineData("2018-2019", "2018 - 2019")]
+            [InlineData("2018 - 2019", "2018 - 2019")]
+            [InlineData("randomness", "randomness")]
+            public void GivenYear_ShouldFormatCorrectly(string unformattedYear, string expectedFormattedYear)
+            {
+                var result = PerformanceDataHelpers.GetFormattedYear(unformattedYear);
+                
+                Assert.Equal(expectedFormattedYear, result);
+            }
+        }
     }
 }

--- a/Frontend.Tests/PagesTests/KeyStage4PerformanceTests.cs
+++ b/Frontend.Tests/PagesTests/KeyStage4PerformanceTests.cs
@@ -116,7 +116,7 @@ namespace Frontend.Tests.PagesTests
             public async void GivenAdditionalInformation_UpdatesTheViewModel()
             {
                 const string additionalInformation = "some additional info";
-                _foundInformationForProject.Project.KeyStage2PerformanceAdditionalInformation = additionalInformation;
+                _foundInformationForProject.Project.KeyStage4PerformanceAdditionalInformation = additionalInformation;
                 _getInformationForProject.Setup(s => s.Execute(ProjectUrn))
                     .ReturnsAsync(_foundInformationForProject);
 
@@ -180,7 +180,7 @@ namespace Frontend.Tests.PagesTests
             public async void GivenGetByUrnReturnsError_DisplayErrorPage()
             {
                 var pageModel =
-                    RazorPageTestHelpers.GetPageModelWithViewData<KeyStage2Performance>(
+                    RazorPageTestHelpers.GetPageModelWithViewData<KeyStage4Performance>(
                         _getInformationForProject.Object, _projectRepository.Object);
 
                 var response = await pageModel.OnPostAsync(ProjectErrorUrn, string.Empty);
@@ -200,7 +200,7 @@ namespace Frontend.Tests.PagesTests
                 var redirectToPageResponse = Assert.IsType<RedirectToPageResult>(response);
                 Assert.Equal("KeyStage4Performance", redirectToPageResponse.PageName);
                 Assert.Equal("OnGetAsync", redirectToPageResponse.PageHandler);
-                Assert.Equal(additionalInformation, _foundProject.KeyStage2PerformanceAdditionalInformation);
+                Assert.Equal(additionalInformation, _foundProject.KeyStage4PerformanceAdditionalInformation);
             }
             
             [Fact]
@@ -210,7 +210,7 @@ namespace Frontend.Tests.PagesTests
 
                 await _subject.OnPostAsync(ProjectUrn, additionalInfo);
                 _projectRepository.Verify(r => r.Update(It.Is<Project>(
-                    project => project.KeyStage2PerformanceAdditionalInformation == additionalInfo
+                    project => project.KeyStage4PerformanceAdditionalInformation == additionalInfo
                 )));
             }
         }

--- a/Frontend.Tests/PagesTests/KeyStage4PerformanceTests.cs
+++ b/Frontend.Tests/PagesTests/KeyStage4PerformanceTests.cs
@@ -46,7 +46,7 @@ namespace Frontend.Tests.PagesTests
                     {
                         new KeyStage4
                         {
-                            Year = "2020",
+                            Year = "2019-2020",
                             SipNumberofpupilsprogress8 = new DisadvantagedPupilsResult
                             {
                                 NotDisadvantaged = "20.5",
@@ -55,7 +55,7 @@ namespace Frontend.Tests.PagesTests
                         },
                         new KeyStage4
                         {
-                            Year = "2019",
+                            Year = "2018-2019",
                             SipNumberofpupilsprogress8 = new DisadvantagedPupilsResult
                             {
                                 NotDisadvantaged = "40.8",
@@ -107,8 +107,8 @@ namespace Frontend.Tests.PagesTests
                 Assert.Equal(AcademyName, _subject.OutgoingAcademyName);
                 Assert.Equal(LAName, _subject.LocalAuthorityName);
                 Assert.Equal(3, _subject.KeyStage4Results.Count);
-                Assert.Equal("2020", _subject.KeyStage4Results[0].Year);
-                Assert.Equal("2019", _subject.KeyStage4Results[1].Year);
+                Assert.Equal("2019 - 2020", _subject.KeyStage4Results[0].Year);
+                Assert.Equal("2018 - 2019", _subject.KeyStage4Results[1].Year);
                 Assert.Null(_subject.KeyStage4Results[2].Year);
             }
             

--- a/Frontend/Helpers/PerformanceDataHelpers.cs
+++ b/Frontend/Helpers/PerformanceDataHelpers.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
+using System.Linq;
 using Data.Models.KeyStagePerformance;
+using DocumentFormat.OpenXml.Office2010.PowerPoint;
 using Microsoft.AspNetCore.Html;
 
 namespace Frontend.Helpers
@@ -10,8 +12,8 @@ namespace Frontend.Helpers
 
         public static HtmlString GetFormattedResult(DisadvantagedPupilsResult disadvantagedPupilResult)
         {
-            if (string.IsNullOrEmpty(disadvantagedPupilResult.NotDisadvantaged) &&
-                string.IsNullOrEmpty(disadvantagedPupilResult.Disadvantaged))
+            if (string.IsNullOrEmpty(disadvantagedPupilResult?.NotDisadvantaged) &&
+                string.IsNullOrEmpty(disadvantagedPupilResult?.Disadvantaged))
                 return new HtmlString(NoDataText);
 
             return new HtmlString(
@@ -33,7 +35,14 @@ namespace Frontend.Helpers
 
             return $"{lowerConfidenceInterval.ToString()} to {upperConfidenceInterval.ToString()}";
         }
-        
+
+        public static string GetFormattedYear(string year)
+        {
+            if (string.IsNullOrEmpty(year)) return year;
+            var trimmedYear = string.Concat(year.Where(c => !char.IsWhiteSpace(c)));
+            return trimmedYear.Contains("-") ? trimmedYear.Replace("-", " - ") : year;
+        }
+
         private static string FormatStringAsDouble(string result)
         {
             var resultIsDouble = double.TryParse(result, NumberStyles.Number, CultureInfo.InvariantCulture, out var resultAsDouble);

--- a/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2Performance.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2Performance.cshtml
@@ -34,7 +34,7 @@
         @foreach (var ks2Result in Model.EducationPerformance.KeyStage2Performance.OrderByDescending(o => o.Year))
         {
             <table class="govuk-table govuk-!-margin-bottom-9">
-                <caption class="govuk-table__caption govuk-table__caption--m">@ks2Result.Year key stage 2</caption>
+                <caption class="govuk-table__caption govuk-table__caption--m">@PerformanceDataHelpers.GetFormattedYear(ks2Result.Year) key stage 2</caption>
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     <th scope="col" class="govuk-table__header"></th>

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml
@@ -219,9 +219,9 @@
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">School confidence interval</th>
-                <td class="govuk-table__cell">@Model.KeyStage4Results[2].SipProgress8lowerconfidence to @Model.KeyStage4Results[2].SipProgress8upperconfidence</td>
-                <td class="govuk-table__cell">@Model.KeyStage4Results[1].SipProgress8lowerconfidence to @Model.KeyStage4Results[1].SipProgress8upperconfidence</td>
-                <td class="govuk-table__cell">@Model.KeyStage4Results[0].SipProgress8lowerconfidence to @Model.KeyStage4Results[0].SipProgress8upperconfidence</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[2].SipProgress8lowerconfidence,Model.KeyStage4Results[2].SipProgress8upperconfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[1].SipProgress8lowerconfidence,Model.KeyStage4Results[1].SipProgress8upperconfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[0].SipProgress8lowerconfidence,Model.KeyStage4Results[0].SipProgress8upperconfidence)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
@@ -53,7 +53,7 @@ namespace Frontend.Pages
                 return this.View("ErrorPage", project.Error.ErrorMessage);
             }
             
-            project.Result.KeyStage2PerformanceAdditionalInformation = additionalInformation;
+            project.Result.KeyStage4PerformanceAdditionalInformation = additionalInformation;
             await _projectRepository.Update(project.Result);
             
             return new RedirectToPageResult(nameof(KeyStage4Performance), 
@@ -71,7 +71,7 @@ namespace Frontend.Pages
             KeyStage4Results = GetLatestThreeResults(projectInformation.EducationPerformance.KeyStage4Performance);
             AdditionalInformation = new AdditionalInformationViewModel
             {
-                AdditionalInformation = projectInformation.Project.KeyStage2PerformanceAdditionalInformation,
+                AdditionalInformation = projectInformation.Project.KeyStage4PerformanceAdditionalInformation,
                 HintText =
                     "This information will populate in your HTB template under the key stage performance tables section.",
                 Urn = projectInformation.Project.Urn,

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Data;
 using Data.Models.KeyStagePerformance;
 using Frontend.ExtensionMethods;
+using Frontend.Helpers;
 using Frontend.Models.Forms;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
@@ -81,7 +82,14 @@ namespace Frontend.Pages
         private static List<KeyStage4> GetLatestThreeResults(List<KeyStage4> keyStage4Performance)
         {
             return keyStage4Performance.Take(3).OrderByDescending(a => a.Year)
-                .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).ToList();
+                .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).Select(c =>
+                {
+                    if (c.Year != null)
+                    {
+                        c.Year = PerformanceDataHelpers.GetFormattedYear(c.Year);
+                    }
+                    return c;
+                }).ToList();        
         }
     }
 }

--- a/Frontend/Pages/TaskList/KeyStage5Performance/KeyStage5Performance.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage5Performance/KeyStage5Performance.cshtml
@@ -35,7 +35,7 @@
         @foreach (var ks5Result in Model.EducationPerformance.KeyStage5Performance.OrderByDescending(o => o.Year))
         {
             <h2 class="govuk-heading-m">
-                @ks5Result.Year scores for academic and applied general qualifications
+                @PerformanceDataHelpers.GetFormattedYear(ks5Result.Year) scores for academic and applied general qualifications
             </h2>
             <table class="govuk-table govuk-!-margin-bottom-9">
                 <caption class="govuk-table__caption govuk-table__caption--s">Local authority: @Model.LocalAuthorityName</caption>

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -82,7 +82,7 @@
                     {
                         <li class="moj-task-list__item">
                             <span class="moj-task-list__task-name">
-                                <a class="govuk-link" asp-page="/KeyStage2Performance" asp-route-id="@Model.Project.Urn" aria-describedby="key-stage-2-performance-tables">Key stage 2 performance tables</a>
+                                <a class="govuk-link" asp-page="/TaskList/KeyStage2Performance/KeyStage2Performance" asp-route-id="@Model.Project.Urn" aria-describedby="key-stage-2-performance-tables">Key stage 2 performance tables</a>
                             </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="key-stage-2-performance-tables">Reference only</strong>
                         </li>
                     }
@@ -90,7 +90,7 @@
                     {
                         <li class="moj-task-list__item">
                             <span class="moj-task-list__task-name">
-                                <a class="govuk-link" asp-page="/KeyStage4Performance" asp-route-id="@Model.Project.Urn" aria-describedby="key-stage-4-performance-tables">Key stage 4 performance tables</a>
+                                <a class="govuk-link" asp-page="/TaskList/KeyStage4Performance/KeyStage4Performance" asp-route-id="@Model.Project.Urn" aria-describedby="key-stage-4-performance-tables">Key stage 4 performance tables</a>
                             </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="key-stage-4-performance-tables">Reference only</strong>
                         </li>
                     }
@@ -99,7 +99,7 @@
                     {
                         <li class="moj-task-list__item">
                             <span class="moj-task-list__task-name">
-                                <a class="govuk-link" asp-page="/KeyStage5Performance" asp-route-id="@Model.Project.Urn" aria-describedby="key-stage-5-performance-tables">Key stage 5 performance tables</a>
+                                <a class="govuk-link" asp-page="/TaskList/KeyStage5Performance/KeyStage5Performance" asp-route-id="@Model.Project.Urn" aria-describedby="key-stage-5-performance-tables">Key stage 5 performance tables</a>
                             </span><strong class="govuk-tag govuk-tag--grey moj-task-list__tag" id="key-stage-5-performance-tables">Reference only</strong>
                         </li>
                     }


### PR DESCRIPTION
### Context

Fixes to the performance table pages

### Changes proposed in this pull request

Format the year to include a space in between years (e.g. 2018 - 2019)
Fix bug with KS4 page where it was using KS2 additional information field
Fix KS4 page formatting of confidence interval level

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

