### PR TITLE
HTB Preview - Education performance change links

### DIFF
--- a/Frontend.Tests/HelpersTests/TagHelperTests/BackToPreviewPageTagHelperTests.cs
+++ b/Frontend.Tests/HelpersTests/TagHelperTests/BackToPreviewPageTagHelperTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Frontend.Helpers.TagHelpers;
+using Frontend.Models;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Xunit;
+
+namespace Frontend.Tests.HelpersTests.TagHelperTests
+{
+    public class BackToPreviewPageTagHelperTests
+    {
+        [Fact]
+        public void GivenBackToPreview_RendersPreviewPageLink()
+        {
+            var linkGenerator = new Mock<LinkGenerator>();
+            var projectStatusTagHelper = new BackToPreviewPageTagHelper(linkGenerator.Object)
+            {
+                ReturnToPreview = true,
+                Id = "1000"
+            };
+            
+            var tagHelperContext = new TagHelperContext(
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+            var tagHelperOutput = new TagHelperOutput("backtopreview",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    var helperContent = tagHelperContent.SetHtmlContent("Meow");
+                    return Task.FromResult(helperContent);
+                });
+
+            projectStatusTagHelper.Process(tagHelperContext, tagHelperOutput);
+
+            Assert.Equal("a", tagHelperOutput.TagName);
+            Assert.Equal(Links.HeadteacherBoard.Preview.BackText, tagHelperOutput.Content.GetContent());
+            Assert.True(tagHelperOutput.Attributes.ContainsName("href"));
+        }
+
+        [Fact]
+        public void GivenNotBackToPreview_RendersExistingContent()
+        {
+            var linkGenerator = new Mock<LinkGenerator>();
+            var projectStatusTagHelper = new BackToPreviewPageTagHelper(linkGenerator.Object)
+            {
+                ReturnToPreview = false,
+                Id = "1000"
+            };
+            
+            var tagHelperContext = new TagHelperContext(
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+            var tagHelperOutput = new TagHelperOutput("backtopreview",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    var helperContent = tagHelperContent.SetHtmlContent("<a>Content</a>");
+                    return Task.FromResult(helperContent);
+                });
+
+            projectStatusTagHelper.Process(tagHelperContext, tagHelperOutput);
+            
+            Assert.Null(tagHelperOutput.TagName);
+            Assert.Equal("<a>Content</a>", tagHelperOutput.Content.GetContent());
+        }
+    }
+}

--- a/Frontend/Helpers/TagHelpers/BackToPreviewPageTagHelper.cs
+++ b/Frontend/Helpers/TagHelpers/BackToPreviewPageTagHelper.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text.Encodings.Web;
+using Frontend.Models;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+
+namespace Frontend.Helpers.TagHelpers
+{
+    [HtmlTargetElement("backtopreview")]
+    public class BackToPreviewPageTagHelper : TagHelper
+    {
+        private readonly LinkGenerator _linkGenerator;
+        public bool ReturnToPreview { get; set; }
+        public string Id { get; set; }
+
+        public BackToPreviewPageTagHelper(LinkGenerator linkGenerator)
+        {
+            _linkGenerator = linkGenerator;
+        }
+
+        public override async void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (ReturnToPreview)
+            {
+                output.TagName = "a";
+                output.AddClass("govuk-back-link", HtmlEncoder.Default);
+                output.Attributes.Add("href",
+                    _linkGenerator.GetPathByPage(Links.HeadteacherBoard.Preview.PageName, null, new {id = Id}));
+                output.Content.SetContent(Links.HeadteacherBoard.Preview.BackText);
+            }
+            else
+            {
+                var childContent = await output.GetChildContentAsync();
+                var content = childContent.GetContent();
+                output.TagName = null;
+                output.Content.SetHtmlContent(content);
+            }
+        }
+    }
+}

--- a/Frontend/Models/Forms/AdditionalInformationViewModel.cs
+++ b/Frontend/Models/Forms/AdditionalInformationViewModel.cs
@@ -6,5 +6,6 @@
         public bool AddOrEditAdditionalInformation { get; set; }
         public string AdditionalInformation { get; set; }
         public string HintText { get; set; }
+        public bool ReturnToPreview { get; set; }
     }
 }

--- a/Frontend/Models/Links.cs
+++ b/Frontend/Models/Links.cs
@@ -1,0 +1,17 @@
+namespace Frontend.Models
+{
+    public static class Links
+    {
+        public static class HeadteacherBoard
+        {
+            public static readonly LinkItem Preview = new LinkItem
+                {PageName = "/TaskList/HtbDocument/Preview", BackText = "Back to preview page"};
+        }
+    }
+
+    public class LinkItem
+    {
+        public string PageName { get; set; }
+        public string BackText { get; set; }
+    }
+}

--- a/Frontend/Pages/TaskList/HtbDocument/KeyStage2PerformanceSummary.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/KeyStage2PerformanceSummary.cshtml
@@ -12,7 +12,7 @@
         <dd class="govuk-summary-list__actions">
             <a class="govuk-link"
                asp-page="/TaskList/KeyStage2Performance/KeyStage2Performance" asp-route-id="@Model.Project.Urn"
-               asp-route-add-or-edit-additional-information="true"
+               asp-route-addOrEditAdditionalInformation="@true" asp-route-returnToPreview="@true"
             >
                 Change<span class="govuk-visually-hidden">latest ofsted judgement additional information</span>
             </a>

--- a/Frontend/Pages/TaskList/HtbDocument/KeyStage4PerformanceSummary.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/KeyStage4PerformanceSummary.cshtml
@@ -13,7 +13,7 @@
         <dd class="govuk-summary-list__actions">
             <a class="govuk-link"
                asp-page="/TaskList/KeyStage4Performance/KeyStage4Performance" asp-route-id="@Model.Project.Urn"
-               asp-route-add-or-edit-additional-information="true">
+               asp-route-addOrEditAdditionalInformation="@true" asp-route-returnToPreview="@true">
                 Change<span class="govuk-visually-hidden">latest ofsted judgement additional information</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/HtbDocument/KeyStage5PerformanceSummary.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/KeyStage5PerformanceSummary.cshtml
@@ -1,6 +1,6 @@
 @model ProjectPageModel
 
-<partial name="TaskList/KeyStage5Performance/KeyStage5PerformanceTables" model="@Model" />
+<partial name="TaskList/KeyStage5Performance/KeyStage5PerformanceTables" model="@Model"/>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <div class="govuk-summary-list__row">
@@ -13,7 +13,7 @@
         <dd class="govuk-summary-list__actions">
             <a class="govuk-link"
                asp-page="/TaskList/KeyStage5Performance/KeyStage5Performance" asp-route-id="@Model.Project.Urn"
-               asp-route-add-or-edit-additional-information="true">
+               asp-route-addOrEditAdditionalInformation="@true" asp-route-returnToPreview="@true">
                 Change<span class="govuk-visually-hidden">latest ofsted judgement additional information</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2Performance.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2Performance.cshtml
@@ -1,6 +1,6 @@
 @page "/project/{id}/key-stage-2-performance"
 @using Frontend.Helpers
-@model Frontend.Pages.KeyStage2Performance
+@model Frontend.Pages.TaskList.KeyStage2Performance.KeyStage2Performance
 
 @{
     ViewBag.Title = "Key stage 2 performance tables";
@@ -9,7 +9,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.ProjectUrn">Back to task list</a>
+    <backtopreview id="@Model.ProjectUrn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.ProjectUrn">Back to task list</a>
+    </backtopreview>
 }
 
 <div class="govuk-grid-row">
@@ -83,7 +85,7 @@
 </div>
 
 <div class="govuk-grid-row">
-    <partial name="_AdditionalInformation" model="Model.AdditionalInformation" />
+    <partial name="_AdditionalInformation" model="Model.AdditionalInformation"/>
 </div>
 @if (!Model.AdditionalInformation.AddOrEditAdditionalInformation)
 {

--- a/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2Performance.cshtml.cs
+++ b/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2Performance.cshtml.cs
@@ -2,13 +2,14 @@ using System.Threading.Tasks;
 using Data;
 using Data.Models.KeyStagePerformance;
 using Frontend.ExtensionMethods;
+using Frontend.Models;
 using Frontend.Models.Forms;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Frontend.Pages
+namespace Frontend.Pages.TaskList.KeyStage2Performance
 {
     public class KeyStage2Performance : PageModel
     {
@@ -20,14 +21,16 @@ namespace Frontend.Pages
         public string LocalAuthorityName { get; private set; }
         public AdditionalInformationViewModel AdditionalInformation { get; private set; }
         public EducationPerformance EducationPerformance { get; private set; }
+        public bool ReturnToPreview { get; private set; }
 
         public KeyStage2Performance(IGetInformationForProject getInformationForProject, IProjects projectRepository)
         {
             _getInformationForProject = getInformationForProject;
             _projectRepository = projectRepository;
         }
-        
-        public async Task<IActionResult> OnGetAsync(string id, bool addOrEditAdditionalInformation = false)
+
+        public async Task<IActionResult> OnGetAsync(string id, bool addOrEditAdditionalInformation = false,
+            bool returnToPreview = false)
         {
             var projectInformation = await _getInformationForProject.Execute(id);
 
@@ -36,12 +39,12 @@ namespace Frontend.Pages
                 return this.View("ErrorPage", projectInformation.ResponseError.ErrorMessage);
             }
 
-            BuildPageModel(projectInformation, addOrEditAdditionalInformation);
+            BuildPageModel(projectInformation, addOrEditAdditionalInformation, returnToPreview);
 
             return Page();
         }
 
-        public async Task<IActionResult> OnPostAsync(string id, string additionalInformation)
+        public async Task<IActionResult> OnPostAsync(string id, string additionalInformation, bool returnToPreview)
         {
             var project = await _projectRepository.GetByUrn(id);
 
@@ -49,30 +52,42 @@ namespace Frontend.Pages
             {
                 return this.View("ErrorPage", project.Error.ErrorMessage);
             }
-            
+
             project.Result.KeyStage2PerformanceAdditionalInformation = additionalInformation;
             await _projectRepository.Update(project.Result);
+
+            if (returnToPreview)
+            {
+                return new RedirectToPageResult(
+                    Links.HeadteacherBoard.Preview.PageName,
+                    new {id}
+                );
+            }
             
-            return new RedirectToPageResult(nameof(KeyStage2Performance), 
-                "OnGetAsync", 
-                new { id }, 
+            return new RedirectToPageResult(nameof(KeyStage2Performance),
+                "OnGetAsync",
+                new {id},
                 "additional-information-hint");
         }
 
-        private void BuildPageModel(GetInformationForProjectResponse projectInformation, bool addOrEditAdditionalInformation)
+        private void BuildPageModel(GetInformationForProjectResponse projectInformation,
+            bool addOrEditAdditionalInformation,
+            bool returnToPreview)
         {
             ProjectUrn = projectInformation.Project.Urn;
             OutgoingAcademyUrn = projectInformation.OutgoingAcademy.Urn;
             LocalAuthorityName = projectInformation.OutgoingAcademy.LocalAuthorityName;
             OutgoingAcademyName = projectInformation.OutgoingAcademy.Name;
             EducationPerformance = projectInformation.EducationPerformance;
+            ReturnToPreview = returnToPreview;
             AdditionalInformation = new AdditionalInformationViewModel
             {
                 AdditionalInformation = projectInformation.Project.KeyStage2PerformanceAdditionalInformation,
                 HintText =
                     "This information will populate in your HTB template under the key stage performance tables section.",
                 Urn = projectInformation.Project.Urn,
-                AddOrEditAdditionalInformation = addOrEditAdditionalInformation
+                AddOrEditAdditionalInformation = addOrEditAdditionalInformation,
+                ReturnToPreview = returnToPreview
             };
         }
     }

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml
@@ -1,6 +1,6 @@
 @page "/project/{id}/key-stage-4-performance"
 @using Frontend.Helpers
-@model Frontend.Pages.KeyStage4Performance
+@model Frontend.Pages.TaskList.KeyStage4Performance.KeyStage4Performance
 @{
     ViewBag.Title = "Key stage 4 performance tables";
     Layout = "_Layout";
@@ -8,7 +8,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.ProjectUrn">Back to task list</a>
+    <backtopreview id="@Model.ProjectUrn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.ProjectUrn">Back to task list</a>
+    </backtopreview>
 }
 
 <div class="govuk-grid-row">

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
@@ -5,13 +5,14 @@ using Data;
 using Data.Models.KeyStagePerformance;
 using Frontend.ExtensionMethods;
 using Frontend.Helpers;
+using Frontend.Models;
 using Frontend.Models.Forms;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Frontend.Pages
+namespace Frontend.Pages.TaskList.KeyStage4Performance
 {
     public class KeyStage4Performance : PageModel
     {
@@ -23,14 +24,16 @@ namespace Frontend.Pages
         public string LocalAuthorityName { get; private set; }
         public AdditionalInformationViewModel AdditionalInformation { get; private set; }
         public List<KeyStage4> KeyStage4Results { get; private set; }
-        
+        public bool ReturnToPreview { get; private set; }
+
         public KeyStage4Performance(IGetInformationForProject getInformationForProject, IProjects projectRepository)
         {
             _getInformationForProject = getInformationForProject;
             _projectRepository = projectRepository;
         }
-        
-        public async Task<IActionResult> OnGetAsync(string id, bool addOrEditAdditionalInformation = false)
+
+        public async Task<IActionResult> OnGetAsync(string id, bool addOrEditAdditionalInformation = false,
+            bool returnToPreview = false)
         {
             var projectInformation = await _getInformationForProject.Execute(id);
 
@@ -39,12 +42,12 @@ namespace Frontend.Pages
                 return this.View("ErrorPage", projectInformation.ResponseError.ErrorMessage);
             }
 
-            BuildPageModel(projectInformation, addOrEditAdditionalInformation);
+            BuildPageModel(projectInformation, addOrEditAdditionalInformation, returnToPreview);
 
             return Page();
         }
 
-        public async Task<IActionResult> OnPostAsync(string id, string additionalInformation)
+        public async Task<IActionResult> OnPostAsync(string id, string additionalInformation, bool returnToPreview)
         {
             var project = await _projectRepository.GetByUrn(id);
 
@@ -52,30 +55,41 @@ namespace Frontend.Pages
             {
                 return this.View("ErrorPage", project.Error.ErrorMessage);
             }
-            
+
             project.Result.KeyStage4PerformanceAdditionalInformation = additionalInformation;
             await _projectRepository.Update(project.Result);
             
-            return new RedirectToPageResult(nameof(KeyStage4Performance), 
-                "OnGetAsync", 
-                new { id }, 
+            if (returnToPreview)
+            {
+                return new RedirectToPageResult(
+                    Links.HeadteacherBoard.Preview.PageName,
+                    new {id}
+                );
+            }
+
+            return new RedirectToPageResult(nameof(KeyStage4Performance),
+                "OnGetAsync",
+                new {id},
                 "additional-information-hint");
         }
 
-        private void BuildPageModel(GetInformationForProjectResponse projectInformation, bool addOrEditAdditionalInformation)
+        private void BuildPageModel(GetInformationForProjectResponse projectInformation,
+            bool addOrEditAdditionalInformation, bool returnToPreview)
         {
             ProjectUrn = projectInformation.Project.Urn;
             OutgoingAcademyUrn = projectInformation.OutgoingAcademy.Urn;
             LocalAuthorityName = projectInformation.OutgoingAcademy.LocalAuthorityName;
             OutgoingAcademyName = projectInformation.OutgoingAcademy.Name;
             KeyStage4Results = GetLatestThreeResults(projectInformation.EducationPerformance.KeyStage4Performance);
+            ReturnToPreview = returnToPreview;
             AdditionalInformation = new AdditionalInformationViewModel
             {
                 AdditionalInformation = projectInformation.Project.KeyStage4PerformanceAdditionalInformation,
                 HintText =
                     "This information will populate in your HTB template under the key stage performance tables section.",
                 Urn = projectInformation.Project.Urn,
-                AddOrEditAdditionalInformation = addOrEditAdditionalInformation
+                AddOrEditAdditionalInformation = addOrEditAdditionalInformation,
+                ReturnToPreview = returnToPreview
             };
         }
 
@@ -88,8 +102,9 @@ namespace Frontend.Pages
                     {
                         c.Year = PerformanceDataHelpers.GetFormattedYear(c.Year);
                     }
+
                     return c;
-                }).ToList();        
+                }).ToList();
         }
     }
 }

--- a/Frontend/Pages/TaskList/KeyStage5Performance/KeyStage5Performance.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage5Performance/KeyStage5Performance.cshtml
@@ -1,6 +1,6 @@
 @page "/project/{id}/key-stage-5-performance"
 @using Frontend.Helpers
-@model Frontend.Pages.KeyStage5Performance
+@model Frontend.Pages.TaskList.KeyStage5Performance.KeyStage5Performance
 
 @{
     ViewBag.Title = "Key stage 5 performance tables";
@@ -9,7 +9,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.ProjectUrn">Back to task list</a>
+    <backtopreview return-to-preview="@Model.ReturnToPreview" id="@Model.ProjectUrn">
+        <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.ProjectUrn">Back to task list</a>
+    </backtopreview>
 }
 
 <div class="govuk-grid-row">
@@ -51,17 +53,17 @@
                 <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AcademicProgress)</td>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AcademicAverage)</td>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AppliedGeneralProgress)</td>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.Academy.AppliedGeneralAverage)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.Academy.AcademicProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.Academy.AcademicAverage)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.Academy.AppliedGeneralProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.Academy.AppliedGeneralAverage)</td>
                 </tr>
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">National average</th>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AcademicProgress)</td>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AcademicAverage)</td>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AppliedGeneralProgress)</td>
-                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(@ks5Result.National.AppliedGeneralAverage)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.National.AcademicProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.National.AcademicAverage)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.National.AppliedGeneralProgress)</td>
+                    <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedResult(ks5Result.National.AppliedGeneralAverage)</td>
                 </tr>
                 </tbody>
             </table>

--- a/Frontend/Views/Shared/_AdditionalInformation.cshtml
+++ b/Frontend/Views/Shared/_AdditionalInformation.cshtml
@@ -12,6 +12,7 @@
                 @Model.HintText
             </div>
             <form method="post">
+                <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
                 <textarea class="govuk-textarea" asp-for="@Model.AdditionalInformation" id="additionalInformation" name="additionalInformation" rows="5" aria-describedby="additional-information-hint"></textarea>
                 <button class="govuk-button" data-module="govuk-button">
                     Save and continue


### PR DESCRIPTION
### Context

The HTB preview page has change links for certain fields, as such when the user clicks on them we need to update navigation to correctly point/redirect as appropriate

### Changes proposed in this pull request

- Add a tag helper for going back to the preview page
- Add redirects to the additional information for key stage performance data

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

