### PR TITLE
HTB Preview page - change links

### DIFF
--- a/Frontend.Tests/ControllerTests/Projects/AcademyAndTrustInformationControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/AcademyAndTrustInformationControllerTests.cs
@@ -2,10 +2,12 @@ using Data;
 using Data.Models;
 using Data.Models.Projects;
 using Frontend.Controllers.Projects;
+using Frontend.Models;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
 using Frontend.Tests.Helpers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Moq;
 using Xunit;
 
@@ -105,6 +107,16 @@ namespace Frontend.Tests.ControllerTests.Projects
                 }
 
                 [Fact]
+                public async void GivenReturnToPreview_AssignItToTheView()
+                {
+                    var response = await _subject.Recommendation(ProjectUrn, true);
+                    var model =
+                        ControllerTestHelpers.GetViewModelFromResult<AcademyAndTrustInformationViewModel>(response);
+
+                    Assert.True(model.ReturnToPreview);
+                }
+
+                [Fact]
                 public async void GivenGetByUrnReturnsError_DisplayErrorPage()
                 {
                     var response = await _subject.Recommendation(ProjectErrorUrn);
@@ -118,20 +130,20 @@ namespace Frontend.Tests.ControllerTests.Projects
             public class PostTests : RecommendationTests
             {
                 const string Author = "test author";
-                const TransferAcademyAndTrustInformation.RecommendationResult Recommendation = 
+
+                const TransferAcademyAndTrustInformation.RecommendationResult Recommendation =
                     TransferAcademyAndTrustInformation.RecommendationResult.Approve;
+
                 public PostTests()
                 {
                     _projectRepository.Setup(r => r.Update(It.IsAny<Project>()))
                         .ReturnsAsync(
                             new RepositoryResult<Project>());
-
                 }
 
                 [Fact]
                 public async void GivenUrnAndRecommendationAndAuthor_UpdatesTheProject()
                 {
-                    
                     await _subject.Recommendation(ProjectUrn, Recommendation, Author);
 
                     _projectRepository.Verify(r =>
@@ -176,6 +188,14 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Update error", viewResult.Model);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_ReturnToThePreviewPage()
+                {
+                    var response = await _subject.Recommendation(ProjectUrn, Recommendation, Author, true);
+                    ControllerTestHelpers.AssertResultRedirectsToPage(response,
+                        Links.HeadteacherBoard.Preview.PageName, new RouteValueDictionary(new {id = ProjectUrn}));
                 }
             }
         }

--- a/Frontend.Tests/ControllerTests/Projects/BenefitsControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/BenefitsControllerTests.cs
@@ -491,7 +491,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                         {
                             OtherFactor = (TransferBenefits.OtherFactor)Enum.Parse(typeof(TransferBenefits.OtherFactor), "HighProfile"),
                             Checked = true,
-                            Description = ""
+                            Description = "Meow"
                         }
                     };
 

--- a/Frontend.Tests/ControllerTests/Projects/BenefitsControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/BenefitsControllerTests.cs
@@ -8,6 +8,7 @@ using Frontend.Controllers.Projects;
 using Frontend.Models;
 using Frontend.Tests.Helpers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Moq;
 using Xunit;
 
@@ -83,6 +84,15 @@ namespace Frontend.Tests.ControllerTests.Projects
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<BenefitsViewModel>(result);
 
                     Assert.Equal(_foundProject.Urn, viewModel.Project.Urn);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_AssignsToTheModel()
+                {
+                    var result = await _subject.IntendedBenefits("0001", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<BenefitsViewModel>(result);
+
+                    Assert.True(viewModel.ReturnToPreview);
                 }
 
                 [Fact]
@@ -238,7 +248,8 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     var intendedBenefits = new[]
                     {
-                        TransferBenefits.IntendedBenefit.ImprovingSafeguarding, TransferBenefits.IntendedBenefit.CentralFinanceTeamAndSupport
+                        TransferBenefits.IntendedBenefit.ImprovingSafeguarding,
+                        TransferBenefits.IntendedBenefit.CentralFinanceTeamAndSupport
                     };
 
                     var response = await controller.IntendedBenefitsPost("projectUrn", intendedBenefits, "");
@@ -247,6 +258,21 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Project not found", viewModel);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_RedirectToThePreviewPage()
+                {
+                    var intendedBenefits = new List<TransferBenefits.IntendedBenefit>
+                    {
+                        TransferBenefits.IntendedBenefit.ImprovingSafeguarding,
+                        TransferBenefits.IntendedBenefit.StrengtheningGovernance
+                    };
+
+                    var result =
+                        await _subject.IntendedBenefitsPost("projectUrn", intendedBenefits.ToArray(), "", true);
+                    ControllerTestHelpers.AssertResultRedirectsToPage(result, Links.HeadteacherBoard.Preview.PageName,
+                        new RouteValueDictionary(new {id = "projectUrn"}));
                 }
             }
         }
@@ -262,6 +288,15 @@ namespace Frontend.Tests.ControllerTests.Projects
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<BenefitsViewModel>(result);
 
                     Assert.Equal(_foundProject.Urn, viewModel.Project.Urn);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_AssignsToTheModel()
+                {
+                    var result = await _subject.OtherFactors("0001", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<BenefitsViewModel>(result);
+
+                    Assert.True(viewModel.ReturnToPreview);
                 }
 
                 [Fact]
@@ -328,7 +363,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                         },
                     };
 
-                    await _subject.OtherFactorsPost("0001",  otherFactors);
+                    await _subject.OtherFactorsPost("0001",  otherFactors, false);
 
                     _projectsRepository.Verify(r =>
                         r.Update(It.Is<Project>(project => assertOtherFactorsEqual(project)))
@@ -347,7 +382,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                                 OtherFactor = otherFactor, Checked = true, Description = "test description"
                             }).ToList();
                     
-                    var response = await _subject.OtherFactorsPost("0001", otherFactors);
+                    var response = await _subject.OtherFactorsPost("0001", otherFactors, false);
                     ControllerTestHelpers.AssertResultRedirectsToAction(response, "Index");
                 }
 
@@ -367,7 +402,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                         }
                     };
                     
-                    await _subject.OtherFactorsPost("0001", otherFactors);
+                    await _subject.OtherFactorsPost("0001", otherFactors, false);
                     _projectsRepository.Verify(r => r.Update(It.Is<Project>(
                         project => project.Benefits.OtherFactors.Keys.Count == 1 &&
                                    project.Benefits.OtherFactors[otherFactors[0].OtherFactor] ==
@@ -392,7 +427,7 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     var otherFactors = new List<BenefitsViewModel.OtherFactorsViewModel>();
 
-                    var response = await controller.OtherFactorsPost("projectUrn", otherFactors);
+                    var response = await controller.OtherFactorsPost("projectUrn", otherFactors, false);
                     var viewResult = Assert.IsType<ViewResult>(response);
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<string>(response);
 
@@ -417,7 +452,7 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     var otherFactors = new List<BenefitsViewModel.OtherFactorsViewModel>();
 
-                    var response = await controller.OtherFactorsPost("projectUrn", otherFactors);
+                    var response = await controller.OtherFactorsPost("projectUrn", otherFactors, false);
                     var viewResult = Assert.IsType<ViewResult>(response);
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<string>(response);
 
@@ -441,10 +476,28 @@ namespace Frontend.Tests.ControllerTests.Projects
                         }
                     };
 
-                    var response = await _subject.OtherFactorsPost("0001", otherFactors);
+                    var response = await _subject.OtherFactorsPost("0001", otherFactors, false);
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<BenefitsViewModel>(response);
                     Assert.True(viewModel.FormErrors.HasErrors);
                     Assert.True(viewModel.FormErrors.HasErrorForField(otherFactorString));
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_RedirectToThePreviewPage()
+                {
+                    var otherFactors = new List<BenefitsViewModel.OtherFactorsViewModel>
+                    {
+                        new BenefitsViewModel.OtherFactorsViewModel
+                        {
+                            OtherFactor = (TransferBenefits.OtherFactor)Enum.Parse(typeof(TransferBenefits.OtherFactor), "HighProfile"),
+                            Checked = true,
+                            Description = ""
+                        }
+                    };
+
+                    var result = await _subject.OtherFactorsPost("projectUrn", otherFactors, true);
+                    ControllerTestHelpers.AssertResultRedirectsToPage(result, Links.HeadteacherBoard.Preview.PageName,
+                        new RouteValueDictionary(new {id = "projectUrn"}));
                 }
             }
         }

--- a/Frontend.Tests/ControllerTests/Projects/FeaturesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/FeaturesControllerTests.cs
@@ -3,11 +3,11 @@ using System.Threading.Tasks;
 using Data;
 using Data.Models;
 using Data.Models.Projects;
-using DocumentFormat.OpenXml.Presentation;
 using Frontend.Controllers.Projects;
 using Frontend.Models;
 using Frontend.Tests.Helpers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Moq;
 using Xunit;
 
@@ -38,14 +38,14 @@ namespace Frontend.Tests.ControllerTests.Projects
             });
 
             _projectRepository.Setup(r => r.GetByUrn("errorUrn"))
-                        .ReturnsAsync(new RepositoryResult<Project>
-                        {
-                            Error = new RepositoryResultBase.RepositoryError
-                            {
-                                StatusCode = System.Net.HttpStatusCode.NotFound,
-                                ErrorMessage = "Project not found"
-                            }
-                        });
+                .ReturnsAsync(new RepositoryResult<Project>
+                {
+                    Error = new RepositoryResultBase.RepositoryError
+                    {
+                        StatusCode = System.Net.HttpStatusCode.NotFound,
+                        ErrorMessage = "Project not found"
+                    }
+                });
 
             _projectRepository.Setup(r => r.Update(It.IsAny<Project>()))
                 .ReturnsAsync(new RepositoryResult<Project>());
@@ -92,6 +92,15 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Project not found", viewModel);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_AssignsItToTheViewModel()
+                {
+                    var response = await _subject.Initiated("0001", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<FeaturesViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
                 }
             }
 
@@ -170,6 +179,26 @@ namespace Frontend.Tests.ControllerTests.Projects
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Project not found", viewModel);
                 }
+
+                [Fact]
+                public async void GivenReturnToPreviewWithInvalidInput_AssignToTheView()
+                {
+                    var response = await _subject.InitiatedPost("0001", TransferFeatures.ProjectInitiators.Empty, true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<FeaturesViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_RedirectsToPreviewPage()
+                {
+                    var response = await _subject.InitiatedPost("0001", TransferFeatures.ProjectInitiators.Dfe, true);
+
+                    ControllerTestHelpers.AssertResultRedirectsToPage(
+                        response, Links.HeadteacherBoard.Preview.PageName,
+                        new RouteValueDictionary(new {id = "0001"})
+                    );
+                }
             }
         }
 
@@ -193,6 +222,15 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Project not found", viewModel);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_AssignsItToTheViewModel()
+                {
+                    var response = await _subject.Reason("0001", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<FeaturesViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
                 }
             }
 
@@ -277,6 +315,26 @@ namespace Frontend.Tests.ControllerTests.Projects
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Project not found", viewModel);
                 }
+
+                [Fact]
+                public async void GivenReturnToPreviewWithInvalidInput_AssignToTheView()
+                {
+                    var response = await _subject.ReasonPost("0001", null, null, true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<FeaturesViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_RedirectsToPreviewPage()
+                {
+                    var response = await _subject.ReasonPost("0001", true, "Meow", true);
+
+                    ControllerTestHelpers.AssertResultRedirectsToPage(
+                        response, Links.HeadteacherBoard.Preview.PageName,
+                        new RouteValueDictionary(new {id = "0001"})
+                    );
+                }
             }
         }
 
@@ -300,6 +358,15 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Project not found", viewModel);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_AssignsItToTheViewModel()
+                {
+                    var response = await _subject.Type("0001", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<FeaturesViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
                 }
             }
 
@@ -338,7 +405,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                     Assert.Equal("Please select the type of transfer",
                         viewModel.FormErrors.ErrorForField("typeOfTransfer").ErrorMessage);
                 }
-                
+
                 [Fact]
                 public async void GivenOtherTransferTypeButNoText_SetErrorOnTheView()
                 {
@@ -369,6 +436,26 @@ namespace Frontend.Tests.ControllerTests.Projects
                 }
 
                 [Fact]
+                public async void GivenReturnToPreviewWithError_AssignsItToTheViewModel()
+                {
+                    var response = await _subject.TypePost("0001", TransferFeatures.TransferTypes.Empty, "", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<FeaturesViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_RedirectsToPreviewPage()
+                {
+                    var response = await _subject.TypePost("0001", TransferFeatures.TransferTypes.MatClosure, "Meow", true);
+
+                    ControllerTestHelpers.AssertResultRedirectsToPage(
+                        response, Links.HeadteacherBoard.Preview.PageName,
+                        new RouteValueDictionary(new {id = "0001"})
+                    );
+                }
+
+                [Fact]
                 public async void GivenUpdateReturnsError_DisplayErrorPage()
                 {
                     _projectRepository.Setup(r => r.Update(It.IsAny<Project>()))
@@ -390,7 +477,6 @@ namespace Frontend.Tests.ControllerTests.Projects
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Project not found", viewModel);
                 }
-
             }
         }
 

--- a/Frontend.Tests/ControllerTests/Projects/RationaleControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/RationaleControllerTests.cs
@@ -4,6 +4,7 @@ using Frontend.Controllers.Projects;
 using Frontend.Models;
 using Frontend.Tests.Helpers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Moq;
 using Xunit;
 
@@ -19,16 +20,16 @@ namespace Frontend.Tests.ControllerTests.Projects
         {
             _projectRepository = new Mock<IProjects>();
             _projectRepository.Setup(r => r.GetByUrn(It.IsAny<string>()))
-                .ReturnsAsync(new RepositoryResult<Project> { Result = new Project() });
+                .ReturnsAsync(new RepositoryResult<Project> {Result = new Project()});
             _projectRepository.Setup(s => s.GetByUrn(_errorWithGetByUrn))
                 .ReturnsAsync(
-                  new RepositoryResult<Project>
-                  {
-                      Error = new RepositoryResultBase.RepositoryError
-                      {
-                          ErrorMessage = "Error"
-                      }
-                  });
+                    new RepositoryResult<Project>
+                    {
+                        Error = new RepositoryResultBase.RepositoryError
+                        {
+                            ErrorMessage = "Error"
+                        }
+                    });
 
             _projectRepository.Setup(r => r.Update(It.IsAny<Project>()))
                 .ReturnsAsync(new RepositoryResult<Project>());
@@ -78,6 +79,15 @@ namespace Frontend.Tests.ControllerTests.Projects
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Error", viewResult.Model);
                 }
+
+                [Fact]
+                public async void GivenReturnToPreview_AssignToTheViewModel()
+                {
+                    var response = await _subject.Project("0001", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<RationaleViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
+                }
             }
 
             public class PostTests : ProjectTests
@@ -121,22 +131,42 @@ namespace Frontend.Tests.ControllerTests.Projects
                 }
 
                 [Fact]
-                public async void GivenUpdatenReturnsError_DisplayErrorPage()
+                public async void GivenUpdateReturnsError_DisplayErrorPage()
                 {
                     _projectRepository.Setup(s => s.Update(It.IsAny<Project>())).ReturnsAsync(
-                       new RepositoryResult<Project>
-                       {
-                           Error = new RepositoryResultBase.RepositoryError
-                           {
-                               ErrorMessage = "Update error"
-                           }
-                       });
+                        new RepositoryResult<Project>
+                        {
+                            Error = new RepositoryResultBase.RepositoryError
+                            {
+                                ErrorMessage = "Update error"
+                            }
+                        });
 
                     var response = await _subject.ProjectPost("errorWithUpdate", "rationale");
                     var viewResult = Assert.IsType<ViewResult>(response);
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Update error", viewResult.Model);
+                }
+
+                [Fact]
+                public async void GivenInvalidInputAndReturnToPreview_AssignsToTheViewModel()
+                {
+                    var response = await _subject.ProjectPost("0001", null, true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<RationaleViewModel>(response);
+                    
+                    Assert.True(viewModel.ReturnToPreview);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_RedirectsToPreviewPage()
+                {
+                    var response = await _subject.ProjectPost("0001", "meow", true);
+
+                    ControllerTestHelpers.AssertResultRedirectsToPage(
+                        response, Links.HeadteacherBoard.Preview.PageName,
+                        new RouteValueDictionary(new {id = "0001"})
+                    );
                 }
             }
         }
@@ -161,6 +191,15 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Error", viewResult.Model);
+                }
+                
+                [Fact]
+                public async void GivenReturnToPreview_AssignToTheViewModel()
+                {
+                    var response = await _subject.TrustOrSponsor("0001", true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<RationaleViewModel>(response);
+
+                    Assert.True(viewModel.ReturnToPreview);
                 }
             }
 
@@ -205,22 +244,42 @@ namespace Frontend.Tests.ControllerTests.Projects
                 }
 
                 [Fact]
-                public async void GivenUpdatenReturnsError_DisplayErrorPage()
+                public async void GivenUpdateReturnsError_DisplayErrorPage()
                 {
                     _projectRepository.Setup(s => s.Update(It.IsAny<Project>())).ReturnsAsync(
-                       new RepositoryResult<Project>
-                       {
-                           Error = new RepositoryResultBase.RepositoryError
-                           {
-                               ErrorMessage = "Update error"
-                           }
-                       });
+                        new RepositoryResult<Project>
+                        {
+                            Error = new RepositoryResultBase.RepositoryError
+                            {
+                                ErrorMessage = "Update error"
+                            }
+                        });
 
                     var response = await _subject.TrustOrSponsorPost("errorWithUpdate", "rationale");
                     var viewResult = Assert.IsType<ViewResult>(response);
 
                     Assert.Equal("ErrorPage", viewResult.ViewName);
                     Assert.Equal("Update error", viewResult.Model);
+                }
+
+                [Fact]
+                public async void GivenInvalidInputAndReturnToPreview_AssignsToTheViewModel()
+                {
+                    var response = await _subject.TrustOrSponsorPost("0001", null, true);
+                    var viewModel = ControllerTestHelpers.GetViewModelFromResult<RationaleViewModel>(response);
+                    
+                    Assert.True(viewModel.ReturnToPreview);
+                }
+
+                [Fact]
+                public async void GivenReturnToPreview_RedirectsToPreviewPage()
+                {
+                    var response = await _subject.TrustOrSponsorPost("0001", "meow", true);
+
+                    ControllerTestHelpers.AssertResultRedirectsToPage(
+                        response, Links.HeadteacherBoard.Preview.PageName,
+                        new RouteValueDictionary(new {id = "0001"})
+                    );
                 }
             }
         }

--- a/Frontend.Tests/Helpers/ControllerTestHelpers.cs
+++ b/Frontend.Tests/Helpers/ControllerTestHelpers.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Xunit;
 
 namespace Frontend.Tests.Helpers
@@ -18,6 +19,14 @@ namespace Frontend.Tests.Helpers
             Assert.Equal(actionName, redirectResult.ActionName);
 
             return redirectResult;
+        }
+
+        public static void AssertResultRedirectsToPage(IActionResult result, string expectedPageName,
+            RouteValueDictionary expectedRouteValues = null)
+        {
+            var redirectResult = Assert.IsType<RedirectToPageResult>(result);
+            Assert.Equal(expectedPageName, redirectResult.PageName);
+            Assert.Equal(expectedRouteValues, redirectResult.RouteValues);
         }
     }
 }

--- a/Frontend/Controllers/Projects/AcademyAndTrustInformationController.cs
+++ b/Frontend/Controllers/Projects/AcademyAndTrustInformationController.cs
@@ -15,7 +15,8 @@ namespace Frontend.Controllers.Projects
         private readonly IGetInformationForProject _getInformationForProject;
         private readonly IProjects _projectsRepository;
 
-        public AcademyAndTrustInformationController(IProjects projectsRepository, IGetInformationForProject getInformationForProject)
+        public AcademyAndTrustInformationController(IProjects projectsRepository,
+            IGetInformationForProject getInformationForProject)
         {
             _projectsRepository = projectsRepository;
             _getInformationForProject = getInformationForProject;
@@ -41,7 +42,7 @@ namespace Frontend.Controllers.Projects
         }
 
         [HttpGet("recommendation")]
-        public async Task<IActionResult> Recommendation(string urn)
+        public async Task<IActionResult> Recommendation(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -51,14 +52,17 @@ namespace Frontend.Controllers.Projects
 
             var model = new AcademyAndTrustInformationViewModel
             {
-                Project = project.Result
+                Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
 
             return View(model);
         }
 
         [HttpPost("recommendation")]
-        public async Task<IActionResult> Recommendation(string urn, TransferAcademyAndTrustInformation.RecommendationResult recommendation, string author)
+        public async Task<IActionResult> Recommendation(string urn,
+            TransferAcademyAndTrustInformation.RecommendationResult recommendation, string author,
+            bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -76,11 +80,16 @@ namespace Frontend.Controllers.Projects
                 Recommendation = recommendation,
                 Author = author
             };
-            
+
             var result = await _projectsRepository.Update(model.Project);
             if (!result.IsValid)
             {
                 return View("ErrorPage", result.Error.ErrorMessage);
+            }
+
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
             }
 
             return RedirectToAction("Index", new {urn});

--- a/Frontend/Controllers/Projects/BenefitsController.cs
+++ b/Frontend/Controllers/Projects/BenefitsController.cs
@@ -39,7 +39,7 @@ namespace Frontend.Controllers.Projects
         }
 
         [HttpGet("intended-benefits")]
-        public async Task<IActionResult> IntendedBenefits(string urn)
+        public async Task<IActionResult> IntendedBenefits(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -50,6 +50,7 @@ namespace Frontend.Controllers.Projects
             var model = new BenefitsViewModel
             {
                 Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
 
             return View(model);
@@ -58,7 +59,7 @@ namespace Frontend.Controllers.Projects
         [ActionName("IntendedBenefits")]
         [HttpPost("intended-benefits")]
         public async Task<IActionResult> IntendedBenefitsPost(string urn,
-            TransferBenefits.IntendedBenefit[] intendedBenefits, string otherBenefit)
+            TransferBenefits.IntendedBenefit[] intendedBenefits, string otherBenefit, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -98,11 +99,16 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", updateResult.Error.ErrorMessage);
             }
 
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
 
         [HttpGet("other-factors")]
-        public async Task<IActionResult> OtherFactors(string urn)
+        public async Task<IActionResult> OtherFactors(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -113,6 +119,7 @@ namespace Frontend.Controllers.Projects
             var model = new BenefitsViewModel
             {
                 Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
 
             BuildOtherFactorsViewModel(model);
@@ -122,7 +129,7 @@ namespace Frontend.Controllers.Projects
 
         [ActionName("OtherFactors")]
         [HttpPost("other-factors")]
-        public async Task<IActionResult> OtherFactorsPost(string urn, List<BenefitsViewModel.OtherFactorsViewModel> otherFactorsVm)
+        public async Task<IActionResult> OtherFactorsPost(string urn, List<BenefitsViewModel.OtherFactorsViewModel> otherFactorsVm, bool returnToPreview)
         {
             var project = await _projectsRepository.GetByUrn(urn);
 
@@ -161,6 +168,11 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", updateResult.Error.ErrorMessage);
             }
 
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+            
             return RedirectToAction("Index", new {urn});
         }
         

--- a/Frontend/Controllers/Projects/FeaturesController.cs
+++ b/Frontend/Controllers/Projects/FeaturesController.cs
@@ -36,7 +36,7 @@ namespace Frontend.Controllers.Projects
 
         [AcceptVerbs(WebRequestMethods.Http.Get)]
         [Route("initiated")]
-        public async Task<IActionResult> Initiated(string urn)
+        public async Task<IActionResult> Initiated(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -46,15 +46,17 @@ namespace Frontend.Controllers.Projects
 
             var model = new FeaturesViewModel
             {
-                Project = project.Result
+                Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
+            
             return View(model);
         }
 
         [ActionName("Initiated")]
         [Route("initiated")]
         [AcceptVerbs(WebRequestMethods.Http.Post)]
-        public async Task<IActionResult> InitiatedPost(string urn, TransferFeatures.ProjectInitiators whoInitiated)
+        public async Task<IActionResult> InitiatedPost(string urn, TransferFeatures.ProjectInitiators whoInitiated, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -64,7 +66,8 @@ namespace Frontend.Controllers.Projects
 
             var model = new FeaturesViewModel
             {
-                Project = project.Result
+                Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
 
             if (whoInitiated == TransferFeatures.ProjectInitiators.Empty)
@@ -82,12 +85,17 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
 
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
 
         [Route("reason")]
         [AcceptVerbs(WebRequestMethods.Http.Get)]
-        public async Task<IActionResult> Reason(string urn)
+        public async Task<IActionResult> Reason(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -97,7 +105,8 @@ namespace Frontend.Controllers.Projects
 
             var model = new FeaturesViewModel
             {
-                Project = project.Result
+                Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
             return View(model);
         }
@@ -105,7 +114,7 @@ namespace Frontend.Controllers.Projects
         [Route("reason")]
         [ActionName("Reason")]
         [AcceptVerbs(WebRequestMethods.Http.Post)]
-        public async Task<IActionResult> ReasonPost(string urn, bool? isSubjectToIntervention, string moreDetail)
+        public async Task<IActionResult> ReasonPost(string urn, bool? isSubjectToIntervention, string moreDetail, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -115,7 +124,8 @@ namespace Frontend.Controllers.Projects
 
             var model = new FeaturesViewModel
             {
-                Project = project.Result
+                Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
 
             if (!isSubjectToIntervention.HasValue)
@@ -134,12 +144,17 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
 
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
 
         [Route("type")]
         [AcceptVerbs(WebRequestMethods.Http.Get)]
-        public async Task<IActionResult> Type(string urn)
+        public async Task<IActionResult> Type(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -149,7 +164,8 @@ namespace Frontend.Controllers.Projects
 
             var model = new FeaturesViewModel
             {
-                Project = project.Result
+                Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
             return View(model);
         }
@@ -158,7 +174,7 @@ namespace Frontend.Controllers.Projects
         [ActionName("Type")]
         [AcceptVerbs(WebRequestMethods.Http.Post)]
         public async Task<IActionResult> TypePost(string urn, TransferFeatures.TransferTypes typeOfTransfer,
-            string otherType)
+            string otherType, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -168,7 +184,8 @@ namespace Frontend.Controllers.Projects
 
             var model = new FeaturesViewModel
             {
-                Project = project.Result
+                Project = project.Result,
+                ReturnToPreview = returnToPreview
             };
 
             model.Project.Features.TypeOfTransfer = typeOfTransfer;
@@ -191,6 +208,11 @@ namespace Frontend.Controllers.Projects
             if (!result.IsValid)
             {
                 return View("ErrorPage", result.Error.ErrorMessage);
+            }
+
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
             }
 
             return RedirectToAction("Index", new { urn });

--- a/Frontend/Controllers/Projects/LatestOfstedJudgementController.cs
+++ b/Frontend/Controllers/Projects/LatestOfstedJudgementController.cs
@@ -15,14 +15,16 @@ namespace Frontend.Controllers.Projects
         private readonly IGetInformationForProject _getInformationForProject;
         private readonly IProjects _projectsRepository;
 
-        public LatestOfstedJudgementController(IGetInformationForProject getInformationForProject, IProjects projectsRepository)
+        public LatestOfstedJudgementController(IGetInformationForProject getInformationForProject,
+            IProjects projectsRepository)
         {
             _getInformationForProject = getInformationForProject;
             _projectsRepository = projectsRepository;
         }
 
         [HttpGet]
-        public async Task<IActionResult> Index(string id, bool addOrEditAdditionalInformation = false)
+        public async Task<IActionResult> Index(string id, bool addOrEditAdditionalInformation = false,
+            bool returnToPreview = false)
         {
             var projectInformation = await _getInformationForProject.Execute(id);
             if (!projectInformation.IsValid)
@@ -34,12 +36,15 @@ namespace Frontend.Controllers.Projects
             {
                 Project = projectInformation.Project,
                 Academy = projectInformation.OutgoingAcademy,
+                ReturnToPreview = returnToPreview,
                 AdditionalInformationModel = new AdditionalInformationViewModel
                 {
                     AdditionalInformation = projectInformation.Project.LatestOfstedJudgementAdditionalInformation,
-                    HintText = "This information will populate into your HTB template under the school performance (Ofsted information) section.",
+                    HintText =
+                        "This information will populate into your HTB template under the school performance (Ofsted information) section.",
                     Urn = projectInformation.Project.Urn,
-                    AddOrEditAdditionalInformation = addOrEditAdditionalInformation
+                    AddOrEditAdditionalInformation = addOrEditAdditionalInformation,
+                    ReturnToPreview = returnToPreview
                 }
             };
 
@@ -47,7 +52,7 @@ namespace Frontend.Controllers.Projects
         }
 
         [HttpPost]
-        public async Task<IActionResult> Index(string id, string additionalInformation)
+        public async Task<IActionResult> Index(string id, string additionalInformation, bool returnToPreview = false)
         {
             var model = await _projectsRepository.GetByUrn(id);
             if (!model.IsValid)
@@ -62,9 +67,14 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
 
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id});
+            }
+
             return RedirectToAction(nameof(this.Index),
                 "LatestOfstedJudgement",
-                new { id },
+                new {id},
                 "additional-information-hint");
         }
     }

--- a/Frontend/Controllers/Projects/PupilNumbersController.cs
+++ b/Frontend/Controllers/Projects/PupilNumbersController.cs
@@ -22,7 +22,8 @@ namespace Frontend.Controllers.Projects
         }
 
         [HttpGet]
-        public async Task<IActionResult> Index(string id, bool addOrEditAdditionalInformation = false)
+        public async Task<IActionResult> Index(string id, bool addOrEditAdditionalInformation = false,
+            bool returnToPreview = false)
         {
             var projectInformation = await _getInformationForProject.Execute(id);
             if (!projectInformation.IsValid)
@@ -34,12 +35,15 @@ namespace Frontend.Controllers.Projects
             {
                 Project = projectInformation.Project,
                 OutgoingAcademy = projectInformation.OutgoingAcademy,
+                ReturnToPreview = returnToPreview,
                 AdditionalInformationModel = new AdditionalInformationViewModel
                 {
                     AdditionalInformation = projectInformation.Project.PupilNumbersAdditionalInformation,
-                    HintText = "This information will populate into your HTB template under the school pupil forecasts section.",
+                    HintText =
+                        "This information will populate into your HTB template under the school pupil forecasts section.",
                     Urn = projectInformation.Project.Urn,
-                    AddOrEditAdditionalInformation = addOrEditAdditionalInformation
+                    AddOrEditAdditionalInformation = addOrEditAdditionalInformation,
+                    ReturnToPreview = returnToPreview
                 }
             };
 
@@ -47,7 +51,7 @@ namespace Frontend.Controllers.Projects
         }
 
         [HttpPost]
-        public async Task<IActionResult> Index(string id, string additionalInformation)
+        public async Task<IActionResult> Index(string id, string additionalInformation, bool returnToPreview = false)
         {
             var model = await _projectsRepository.GetByUrn(id);
             if (!model.IsValid)
@@ -62,9 +66,14 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", model.Error.ErrorMessage);
             }
 
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id});
+            }
+
             return RedirectToAction(nameof(this.Index),
                 "PupilNumbers",
-                new { id },
+                new {id},
                 "additional-information-hint");
         }
     }

--- a/Frontend/Controllers/Projects/RationaleController.cs
+++ b/Frontend/Controllers/Projects/RationaleController.cs
@@ -22,7 +22,7 @@ namespace Frontend.Controllers.Projects
         public async Task<IActionResult> Index(string urn)
         {
             var project = await _projectsRepository.GetByUrn(urn);
-            if(!project.IsValid)
+            if (!project.IsValid)
             {
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
@@ -36,7 +36,7 @@ namespace Frontend.Controllers.Projects
         }
 
         [HttpGet("rationale")]
-        public async Task<IActionResult> Project(string urn)
+        public async Task<IActionResult> Project(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -44,17 +44,14 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new RationaleViewModel
-            {
-                Project = project.Result
-            };
+            var model = new RationaleViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
 
             return View(model);
         }
 
         [ActionName("Project")]
         [HttpPost("rationale")]
-        public async Task<IActionResult> ProjectPost(string urn, string rationale)
+        public async Task<IActionResult> ProjectPost(string urn, string rationale, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -62,13 +59,10 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new RationaleViewModel
-            {
-                Project = project.Result
-            };
+            var model = new RationaleViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
 
             model.Project.Rationale.Project = rationale;
-            
+
             if (string.IsNullOrEmpty(rationale))
             {
                 model.FormErrors.AddError("rationale", "rationale", "Please enter a rationale");
@@ -80,11 +74,17 @@ namespace Frontend.Controllers.Projects
             {
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
+
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
 
         [HttpGet("trust-or-sponsor")]
-        public async Task<IActionResult> TrustOrSponsor(string urn)
+        public async Task<IActionResult> TrustOrSponsor(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -92,17 +92,14 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new RationaleViewModel
-            {
-                Project = project.Result
-            };
+            var model = new RationaleViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
 
             return View(model);
         }
 
         [ActionName("TrustOrSponsor")]
         [HttpPost("trust-or-sponsor")]
-        public async Task<IActionResult> TrustOrSponsorPost(string urn, string rationale)
+        public async Task<IActionResult> TrustOrSponsorPost(string urn, string rationale, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -110,13 +107,10 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new RationaleViewModel
-            {
-                Project = project.Result
-            };
+            var model = new RationaleViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
 
             model.Project.Rationale.Trust = rationale;
-            
+
             if (string.IsNullOrEmpty(rationale))
             {
                 model.FormErrors.AddError("rationale", "rationale", "Please enter a rationale");
@@ -128,6 +122,12 @@ namespace Frontend.Controllers.Projects
             {
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
+
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
     }

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using Data;
-using Frontend.Helpers;
 using Frontend.Models;
 using Helpers;
 using Microsoft.AspNetCore.Authorization;
@@ -13,12 +12,10 @@ namespace Frontend.Controllers.Projects
     public class TransferDatesController : Controller
     {
         private readonly IProjects _projectsRepository;
-        private readonly IDateTimeProvider _dateTimeProvider;
 
-        public TransferDatesController(IProjects projectsRepository, IDateTimeProvider dateTimeProvider)
+        public TransferDatesController(IProjects projectsRepository)
         {
             _projectsRepository = projectsRepository;
-            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task<IActionResult> Index(string urn)
@@ -37,7 +34,7 @@ namespace Frontend.Controllers.Projects
         }
 
         [HttpGet("first-discussed")]
-        public async Task<IActionResult> FirstDiscussed(string urn)
+        public async Task<IActionResult> FirstDiscussed(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -45,16 +42,14 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new TransferDatesViewModel
-            {
-                Project = project.Result
-            };
+            var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
             return View(model);
         }
 
         [HttpPost("first-discussed")]
         [ActionName("FirstDiscussed")]
-        public async Task<IActionResult> FirstDiscussedPost(string urn, string day, string month, string year)
+        public async Task<IActionResult> FirstDiscussedPost(string urn, string day, string month, string year,
+            bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -62,10 +57,8 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new TransferDatesViewModel
-            {
-                Project = project.Result
-            };
+            var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
+
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
             model.Project.Dates.FirstDiscussed = dateString;
 
@@ -86,11 +79,17 @@ namespace Frontend.Controllers.Projects
             {
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
+
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
 
         [HttpGet("target-date")]
-        public async Task<IActionResult> TargetDate(string urn)
+        public async Task<IActionResult> TargetDate(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -98,16 +97,15 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new TransferDatesViewModel
-            {
-                Project = project.Result
-            };
+            var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
+
             return View(model);
         }
 
         [HttpPost("target-date")]
         [ActionName("TargetDate")]
-        public async Task<IActionResult> TargetDatePost(string urn, string day, string month, string year)
+        public async Task<IActionResult> TargetDatePost(string urn, string day, string month, string year,
+            bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -115,10 +113,8 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new TransferDatesViewModel
-            {
-                Project = project.Result
-            };
+            var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
+
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
             model.Project.Dates.Target = dateString;
 
@@ -139,11 +135,17 @@ namespace Frontend.Controllers.Projects
             {
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
+
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
 
         [HttpGet("htb-date")]
-        public async Task<IActionResult> HtbDate(string urn)
+        public async Task<IActionResult> HtbDate(string urn, bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -151,16 +153,14 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new TransferDatesViewModel
-            {
-                Project = project.Result
-            };
+            var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
             return View(model);
         }
 
         [HttpPost("htb-date")]
         [ActionName("HtbDate")]
-        public async Task<IActionResult> HtbDatePost(string urn, string day, string month, string year)
+        public async Task<IActionResult> HtbDatePost(string urn, string day, string month, string year,
+            bool returnToPreview = false)
         {
             var project = await _projectsRepository.GetByUrn(urn);
             if (!project.IsValid)
@@ -168,10 +168,8 @@ namespace Frontend.Controllers.Projects
                 return View("ErrorPage", project.Error.ErrorMessage);
             }
 
-            var model = new TransferDatesViewModel
-            {
-                Project = project.Result
-            };
+            var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
+
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
             model.Project.Dates.Htb = dateString;
 
@@ -192,6 +190,12 @@ namespace Frontend.Controllers.Projects
             {
                 return View("ErrorPage", result.Error.ErrorMessage);
             }
+
+            if (returnToPreview)
+            {
+                return RedirectToPage(Links.HeadteacherBoard.Preview.PageName, new {id = urn});
+            }
+
             return RedirectToAction("Index", new {urn});
         }
     }

--- a/Frontend/Models/AcademyAndTrustInformationViewModel.cs
+++ b/Frontend/Models/AcademyAndTrustInformationViewModel.cs
@@ -8,6 +8,7 @@ namespace Frontend.Models
 {
     public class AcademyAndTrustInformationViewModel : ProjectViewModel
     {
+        public bool ReturnToPreview { get; set; }
         public static List<RadioButtonViewModel> RecommendedRadioButtons(TransferAcademyAndTrustInformation.RecommendationResult selected)
         {
             var values =

--- a/Frontend/Models/BenefitsViewModel.cs
+++ b/Frontend/Models/BenefitsViewModel.cs
@@ -15,6 +15,8 @@ namespace Frontend.Models
             FormErrors = new FormErrorsViewModel();
         }
 
+        public bool ReturnToPreview { get; set; }
+
         public List<string> IntendedBenefitsSummary()
         {
             var summary = Project.Benefits.IntendedBenefits

--- a/Frontend/Models/FeaturesViewModel.cs
+++ b/Frontend/Models/FeaturesViewModel.cs
@@ -22,6 +22,8 @@ namespace Frontend.Models
         public bool IsTransferSubjectToIntervention =>
             Project.Features.ReasonForTransfer.IsSubjectToRddOrEsfaIntervention == true;
 
+        public bool ReturnToPreview { get; set; }
+
         public static List<RadioButtonViewModel> InitiatedRadioButtons(TransferFeatures.ProjectInitiators selected)
         {
             var values =

--- a/Frontend/Models/LatestOfstedJudgementViewModel.cs
+++ b/Frontend/Models/LatestOfstedJudgementViewModel.cs
@@ -8,5 +8,6 @@ namespace Frontend.Models
         public Project Project { get; set; }
         public Academy Academy { get; set; }
         public AdditionalInformationViewModel AdditionalInformationModel { get; set; }
+        public bool ReturnToPreview { get; set; }
     }
 }

--- a/Frontend/Models/PupilNumbersViewModel.cs
+++ b/Frontend/Models/PupilNumbersViewModel.cs
@@ -8,6 +8,6 @@ namespace Frontend.Models
         public Project Project { get; set; }
         public Academy OutgoingAcademy { get; set; }
         public AdditionalInformationViewModel AdditionalInformationModel { get; set; }
-
+        public bool ReturnToPreview { get; set; }
     }
 }

--- a/Frontend/Models/RationaleViewModel.cs
+++ b/Frontend/Models/RationaleViewModel.cs
@@ -10,5 +10,7 @@ namespace Frontend.Models
         {
             FormErrors = new FormErrorsViewModel();
         }
+
+        public bool ReturnToPreview { get; set; }
     }
 }

--- a/Frontend/Models/TransferDatesViewModel.cs
+++ b/Frontend/Models/TransferDatesViewModel.cs
@@ -20,6 +20,7 @@ namespace Frontend.Models
         public DateInputViewModel TransferFirstDiscussed => DateInputForField(Project.Dates.FirstDiscussed);
         public DateInputViewModel TargetDate => DateInputForField(Project.Dates.Target);
         public DateInputViewModel HtbDate => DateInputForField(Project.Dates.Htb);
+        public bool ReturnToPreview { get; set; }
 
         private static DateInputViewModel DateInputForField(string transferDatesFirstDiscussed)
         {

--- a/Frontend/Pages/TaskList/AcademyAndTrustInformation/AcademyAndTrustInformation.cshtml
+++ b/Frontend/Pages/TaskList/AcademyAndTrustInformation/AcademyAndTrustInformation.cshtml
@@ -19,7 +19,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-action="Recommendation" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="AcademyAndTrustInformation" asp-action="Recommendation" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="@true">
                 Change<span class="govuk-visually-hidden">recommendation</span>
             </a>
         </dd>
@@ -39,7 +40,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-action="Recommendation" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="AcademyAndTrustInformation" asp-action="Recommendation" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="@true">
                 Change<span class="govuk-visually-hidden">author</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/Benefits/Benefits.cshtml
+++ b/Frontend/Pages/TaskList/Benefits/Benefits.cshtml
@@ -44,7 +44,8 @@
             </dd>
         }
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="Benefits" asp-action="IntendedBenefits" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="Benefits" asp-action="IntendedBenefits" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="@true">
                 Change<span class="govuk-visually-hidden">intended benefits</span>
             </a>
         </dd>
@@ -73,7 +74,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="Benefits" asp-action="OtherFactors" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="Benefits" asp-action="OtherFactors" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">other factors to consider</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/Features/Features.cshtml
+++ b/Frontend/Pages/TaskList/Features/Features.cshtml
@@ -19,7 +19,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="Features" asp-action="Initiated" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="Features" asp-action="Initiated" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">who initiated the transfer</span>
             </a>
         </dd>
@@ -47,7 +48,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="Features" asp-action="Reason" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="Features" asp-action="Reason" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">reason for transfer</span>
             </a>
         </dd>
@@ -72,7 +74,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="Features" asp-action="Type" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="Features" asp-action="Type" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">type of transfer</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/HtbDocument/LatestOfstedJudgement.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/LatestOfstedJudgement.cshtml
@@ -55,7 +55,8 @@
         <dd class="govuk-summary-list__actions">
             <a class="govuk-link"
                asp-controller="LatestOfstedJudgement" asp-action="Index"
-               asp-route-urn="@Model.Project.Urn" asp-route-addOrEditAdditionalInformation="true">
+               asp-route-id="@Model.Project.Urn" asp-route-addOrEditAdditionalInformation="true"
+               asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">latest ofsted judgement additional information</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/HtbDocument/Preview.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/Preview.cshtml
@@ -121,18 +121,6 @@
             </div>
         </section>
         
-        <h2 class="govuk-heading-s">Latest Ofsted judgement</h2>
-        <section class="app-summary-card govuk-!-margin-bottom-7">
-            <header class="app-summary-card__header">
-                <h2 class="app-summary-card__title">
-                    Latest Ofsted judgement details
-                </h2>
-            </header>
-            <div class="app-summary-card__body">
-                <partial name="LatestOfstedJudgement" model="Model"></partial>
-            </div>
-        </section>
-        
         <h2 class="govuk-heading-s">Key stage 2 performance tables</h2>
         <section class="app-summary-card govuk-!-margin-bottom-7">
             <header class="app-summary-card__header">

--- a/Frontend/Pages/TaskList/HtbDocument/PupilNumbers.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/PupilNumbers.cshtml
@@ -23,7 +23,8 @@
         <dd class="govuk-summary-list__actions">
             <a class="govuk-link"
                asp-controller="PupilNumbers" asp-action="Index"
-               asp-route-urn="@Model.Project.Urn" asp-route-addOrEditAdditionalInformation="true">
+               asp-route-id="@Model.Project.Urn" asp-route-addOrEditAdditionalInformation="true"
+               asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">pupil numbers additional information</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/Rationale/Rationale.cshtml
+++ b/Frontend/Pages/TaskList/Rationale/Rationale.cshtml
@@ -16,7 +16,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-action="Project" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="Rationale" asp-action="Project" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">rationale for project</span>
             </a>
         </dd>
@@ -36,7 +37,8 @@
             }
         </dd>
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-action="TrustOrSponsor" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="Rationale" asp-action="TrustOrSponsor" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">rationale for the trust or sponsor</span>
             </a>
         </dd>

--- a/Frontend/Pages/TaskList/TransferDates/TransferDates.cshtml
+++ b/Frontend/Pages/TaskList/TransferDates/TransferDates.cshtml
@@ -25,7 +25,8 @@
             </dd>
         }
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="TransferDates" asp-action="FirstDiscussed" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="TransferDates" asp-action="FirstDiscussed" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">date first discussed</span>
             </a>
         </dd>
@@ -50,7 +51,8 @@
             </dd>
         }
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="TransferDates" asp-action="TargetDate" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="TransferDates" asp-action="TargetDate" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">target date for transfer</span>
             </a>
         </dd>
@@ -75,7 +77,8 @@
             </dd>
         }
         <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" asp-controller="TransferDates" asp-action="HtbDate" asp-route-urn="@Model.Project.Urn">
+            <a class="govuk-link" asp-controller="TransferDates" asp-action="HtbDate" 
+               asp-route-urn="@Model.Project.Urn" asp-route-returnToPreview="true">
                 Change<span class="govuk-visually-hidden">HTB date</span>
             </a>
         </dd>

--- a/Frontend/Views/AcademyAndTrustInformation/Recommendation.cshtml
+++ b/Frontend/Views/AcademyAndTrustInformation/Recommendation.cshtml
@@ -20,6 +20,7 @@
             Recommendation
         </h1>
         <form asp-action="Recommendation" method="post" novalidate="">
+            <input name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/Frontend/Views/Benefits/IntendedBenefits.cshtml
+++ b/Frontend/Views/Benefits/IntendedBenefits.cshtml
@@ -12,7 +12,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -20,6 +22,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="IntendedBenefits" method="post" novalidate="">
+            <input name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @formClasses @otherBenefitFormClasses">
                 <fieldset class="govuk-fieldset" aria-describedby="intended-benefits-hint">
                     <legend class="govuk-fieldset__legend">

--- a/Frontend/Views/Benefits/OtherFactors.cshtml
+++ b/Frontend/Views/Benefits/OtherFactors.cshtml
@@ -10,7 +10,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -18,6 +20,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="OtherFactors" method="post" novalidate="">
+            <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
                     <legend class="govuk-fieldset__legend">

--- a/Frontend/Views/Benefits/OtherFactors.cshtml
+++ b/Frontend/Views/Benefits/OtherFactors.cshtml
@@ -42,7 +42,7 @@
                         {
                             <div class="govuk-checkboxes__item">
                                 <input asp-for="@Model.OtherFactorsVm[i].Checked" class="govuk-checkboxes__input" aria-controls="conditional-@Model.OtherFactorsVm[i].OtherFactor" aria-expanded="false">
-                                <label id="@Model.OtherFactorsVm[i].OtherFactor" class="govuk-label govuk-checkboxes__label" for="@Model.OtherFactorsVm[i].OtherFactor">
+                                <label id="@Model.OtherFactorsVm[i].OtherFactor" class="govuk-label govuk-checkboxes__label" asp-for="@Model.OtherFactorsVm[i].Checked">
                                     @{
                                         var displayName = EnumHelpers<TransferBenefits.OtherFactor>.GetDisplayValue(@Model.OtherFactorsVm[i].OtherFactor);
                                         @displayName

--- a/Frontend/Views/Features/Initiated.cshtml
+++ b/Frontend/Views/Features/Initiated.cshtml
@@ -9,7 +9,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -17,6 +19,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="Initiated" method="post" novalidate="">
+            <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend">

--- a/Frontend/Views/Features/Reason.cshtml
+++ b/Frontend/Views/Features/Reason.cshtml
@@ -7,7 +7,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -21,6 +23,7 @@
             Reason for transfer
         </h1>
         <form asp-action="Reason" method="post" novalidate="">
+            <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @Model.FormErrors.FormClassesForField("isSubjectToIntervention")">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/Frontend/Views/Features/Type.cshtml
+++ b/Frontend/Views/Features/Type.cshtml
@@ -11,7 +11,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -19,6 +21,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="Type" method="post" novalidate="">
+            <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @typeOfTransferFormClasses @otherTypeFormClasses">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend">

--- a/Frontend/Views/LatestOfstedJudgement/Index.cshtml
+++ b/Frontend/Views/LatestOfstedJudgement/Index.cshtml
@@ -7,7 +7,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Back to task list</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Back to task list</a>
+    </backtopreview>
 }
 
 <div class="govuk-grid-row">

--- a/Frontend/Views/PupilNumbers/Index.cshtml
+++ b/Frontend/Views/PupilNumbers/Index.cshtml
@@ -7,7 +7,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Back to task list</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-controller="Project" asp-action="Index" asp-route-id="@Model.Project.Urn">Back to task list</a>
+    </backtopreview>
 }
 
 <div class="govuk-grid-row">

--- a/Frontend/Views/Rationale/Project.cshtml
+++ b/Frontend/Views/Rationale/Project.cshtml
@@ -8,7 +8,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -16,6 +18,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="Project" method="post" novalidate="">
+            <input type="text" value="@Model.ReturnToPreview.ToString()" name="returnToPreview" hidden />
             <div class="govuk-form-group @formClasses">
                 <label class="govuk-label govuk-!-font-weight-bold" for="rationale">
                     <span class="govuk-caption-l">

--- a/Frontend/Views/Rationale/TrustOrSponsor.cshtml
+++ b/Frontend/Views/Rationale/TrustOrSponsor.cshtml
@@ -8,7 +8,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -16,6 +18,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="TrustOrSponsor" method="post" novalidate="">
+            <input type="text" value="@Model.ReturnToPreview.ToString()" name="returnToPreview" hidden />
             <div class="govuk-form-group @formClasses">
                 <label class="govuk-label govuk-!-font-weight-bold" for="rationale">
                     <span class="govuk-caption-l">

--- a/Frontend/Views/TransferDates/FirstDiscussed.cshtml
+++ b/Frontend/Views/TransferDates/FirstDiscussed.cshtml
@@ -8,7 +8,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -16,6 +18,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="FirstDiscussed" asp-route-urn="@Model.Project.Urn" method="post" novalidate="">
+            <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" role="group" aria-describedby="transfer-first-discussed-date-hint">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/Frontend/Views/TransferDates/HtbDate.cshtml
+++ b/Frontend/Views/TransferDates/HtbDate.cshtml
@@ -1,4 +1,3 @@
-@using Frontend.Helpers
 @using Helpers
 @model TransferDatesViewModel
 
@@ -12,7 +11,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -20,6 +21,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="HtbDate" method="post" novalidate="">
+            <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l" aria-describedby="set-htb-date-hint">

--- a/Frontend/Views/TransferDates/TargetDate.cshtml
+++ b/Frontend/Views/TransferDates/TargetDate.cshtml
@@ -8,7 +8,9 @@
 
 @section BeforeMain
 {
-    <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    <backtopreview id="@Model.Project.Urn" return-to-preview="@Model.ReturnToPreview">
+        <a class="govuk-back-link" asp-action="Index" asp-route-urn="@Model.Project.Urn">Back</a>
+    </backtopreview>
 }
 
 @await Html.PartialAsync("_FormErrorSummary", Model.FormErrors)
@@ -16,6 +18,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form asp-action="TargetDate" asp-route-urn="@Model.Project.Urn" method="post" novalidate="">
+            <input type="text" name="returnToPreview" value="@Model.ReturnToPreview.ToString()" hidden />
             <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset" role="group" aria-describedby="target-date-for-transfer-hint">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">


### PR DESCRIPTION
### Context

The HTB Preview page has change links on it - this adds support for all of those links to allow users to navigate as expected

### Changes proposed in this pull request

- Support returning to the preview page on every change link

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

