### PR TITLE
Support basic pagination on home screen

### DIFF
--- a/Data.Mock/MockProjectRepository.cs
+++ b/Data.Mock/MockProjectRepository.cs
@@ -24,7 +24,7 @@ namespace Data.Mock
             _projects = new List<Project> {PopulatedProject(), EmptyProject()};
         }
 
-        public Task<RepositoryResult<List<ProjectSearchResult>>> GetProjects()
+        public Task<RepositoryResult<List<ProjectSearchResult>>> GetProjects(int page = 1)
         {
             var result = new RepositoryResult<List<ProjectSearchResult>>
             {

--- a/Data.TRAMS.Tests/TramsProjectsRepositoryTests.cs
+++ b/Data.TRAMS.Tests/TramsProjectsRepositoryTests.cs
@@ -347,7 +347,7 @@ namespace Data.TRAMS.Tests
             [Fact]
             public async void GivenSingleProjectSummaryReturned_MapsCorrectly()
             {
-                _httpClient.Setup(c => c.GetAsync("academyTransferProject")).ReturnsAsync(new HttpResponseMessage
+                _httpClient.Setup(c => c.GetAsync("academyTransferProject?page=1")).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(JsonConvert.SerializeObject(_foundSummaries))
                 });
@@ -376,7 +376,7 @@ namespace Data.TRAMS.Tests
                     }
                 );
 
-                _httpClient.Setup(c => c.GetAsync("academyTransferProject")).ReturnsAsync(new HttpResponseMessage
+                _httpClient.Setup(c => c.GetAsync("academyTransferProject?page=1")).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(JsonConvert.SerializeObject(_foundSummaries))
                 });
@@ -392,7 +392,7 @@ namespace Data.TRAMS.Tests
             [Fact]
             public async void GivenMultipleProjectSummaries_ReturnsMappedSummariesCorrectly()
             {
-                _httpClient.Setup(c => c.GetAsync("academyTransferProject")).ReturnsAsync(new HttpResponseMessage
+                _httpClient.Setup(c => c.GetAsync("academyTransferProject?page=1")).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(JsonConvert.SerializeObject(_foundSummaries))
                 });
@@ -410,7 +410,7 @@ namespace Data.TRAMS.Tests
             [Fact]
             public async void Given404_ReturnsErrorFromRepository()
             {
-                _httpClient.Setup(c => c.GetAsync("academyTransferProject")).ReturnsAsync(new HttpResponseMessage
+                _httpClient.Setup(c => c.GetAsync("academyTransferProject?page=1")).ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.NotFound
                 });
@@ -425,7 +425,7 @@ namespace Data.TRAMS.Tests
             [Fact]
             public async void Given500_ReturnsErrorFromRepository()
             {
-                _httpClient.Setup(c => c.GetAsync("academyTransferProject")).ReturnsAsync(new HttpResponseMessage
+                _httpClient.Setup(c => c.GetAsync("academyTransferProject?page=1")).ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.InternalServerError
                 });
@@ -437,12 +437,28 @@ namespace Data.TRAMS.Tests
                 Assert.Equal("API encountered an error", response.Error.ErrorMessage);
             }
 
+            [Theory]
+            [InlineData(1)]
+            [InlineData(2)]
+            [InlineData(3)]
+            public async void GivenPage_GetsProjectForPage(int page)
+            {
+                _httpClient.Setup(c => c.GetAsync($"academyTransferProject?page={page}")).ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(_foundSummaries))
+                });
+
+                await _subject.GetProjects(page);
+                
+                _httpClient.Verify(c => c.GetAsync($"academyTransferProject?page={page}"), Times.Once());
+            }
+
             #region ApiInterim
 
             [Fact]
             public async void GivenProjectSummary_FillInExtraInformationFromMultipleRequestsAndMap()
             {
-                _httpClient.Setup(c => c.GetAsync("academyTransferProject")).ReturnsAsync(new HttpResponseMessage
+                _httpClient.Setup(c => c.GetAsync("academyTransferProject?page=1")).ReturnsAsync(new HttpResponseMessage
                 {
                     Content = new StringContent(JsonConvert.SerializeObject(_foundSummaries))
                 });

--- a/Data.TRAMS/TramsProjectsRepository.cs
+++ b/Data.TRAMS/TramsProjectsRepository.cs
@@ -33,9 +33,10 @@ namespace Data.TRAMS
             _internalToUpdateMapper = internalToUpdateMapper;
         }
 
-        public async Task<RepositoryResult<List<ProjectSearchResult>>> GetProjects()
+        public async Task<RepositoryResult<List<ProjectSearchResult>>> GetProjects(int page = 1)
         {
-            var response = await _httpClient.GetAsync("academyTransferProject");
+            var response = await _httpClient.GetAsync($"academyTransferProject?page={page}");
+            
             if (response.IsSuccessStatusCode)
             {
                 var apiResponse = await response.Content.ReadAsStringAsync();

--- a/Data/IProjects.cs
+++ b/Data/IProjects.cs
@@ -6,7 +6,7 @@ namespace Data
 {
     public interface IProjects
     {
-        public Task<RepositoryResult<List<ProjectSearchResult>>> GetProjects();
+        public Task<RepositoryResult<List<ProjectSearchResult>>> GetProjects(int page = 1);
         public Task<RepositoryResult<Project>> GetByUrn(string urn);
         public Task<RepositoryResult<Project>> Update(Project project);
         public Task<RepositoryResult<Project>> Create(Project project);

--- a/Frontend/Controllers/HomeController.cs
+++ b/Frontend/Controllers/HomeController.cs
@@ -30,16 +30,16 @@ namespace Frontend.Controllers
         }
 
         [Authorize]
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(int page = 1)
         {
-            var projects = await _projectsRepository.GetProjects();
+            var projects = await _projectsRepository.GetProjects(page);
             if (!projects.IsValid)
             {
                 return View("ErrorPage", projects.Error.ErrorMessage);
             }
 
             _logger.LogInformation("Home page loaded");
-            var model = new Index {Projects = projects.Result};
+            var model = new Index {Projects = projects.Result, Page = page};
             return View(model);
         }
 

--- a/Frontend/Views/Home/Index.cshtml
+++ b/Frontend/Views/Home/Index.cshtml
@@ -2,6 +2,13 @@
 
 @{
     ViewData["Title"] = "Transfer an academy to another trust";
+    var startingPage = 1;
+    if(Model.Page - 5 > 1) startingPage = Model.Page - 5;
+    var hasPreviousPage = Model.Page > 1;
+    var hasNextPage = Model.Projects.Count == 10;
+
+    var previousPage = Model.Page - 1;
+    var nextPage = Model.Page + 1;
 }
 
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
@@ -46,5 +53,33 @@
                 </div>
             </div>
         }
+        <nav class="moj-pagination" id="pagination-label">
+            <p class="govuk-visually-hidden" aria-labelledby="pagination-label">Pagination navigation</p>
+            <ul class="moj-pagination__list">
+                @if (hasPreviousPage)
+                {
+                    <li class="moj-pagination__item  moj-pagination__item--prev">
+                        <a class="moj-pagination__link" asp-action="Index" asp-route-page="@previousPage">Previous<span class="govuk-visually-hidden"> set of pages</span></a>
+                    </li>
+                    @for (var i = startingPage; i < Model.Page; i++)
+                    {
+                        <li class="moj-pagination__item">
+                            <a asp-action="Index" asp-route-page="@i" class="moj-pagination__link">@i</a>
+                        </li>
+                    }
+                }
+                <li class="moj-pagination__item moj-pagination__item--active">@Model.Page</li>
+                @if (hasNextPage)
+                {
+                    <li class="moj-pagination__item">
+                        <a asp-action="Index" asp-route-page="@nextPage" class="moj-pagination__link">@nextPage</a>
+                    </li>
+                    <li class="moj-pagination__item  moj-pagination__item--next">
+                        <a class="moj-pagination__link" asp-action="Index" asp-route-page="@nextPage">Next<span class="govuk-visually-hidden"> set of pages</span></a>
+                    </li>
+                }
+            </ul>
+            <p class="moj-pagination__results"></p>
+        </nav>
     </div>
 </div>

--- a/Frontend/Views/Home/Index.cshtml.cs
+++ b/Frontend/Views/Home/Index.cshtml.cs
@@ -6,5 +6,6 @@ namespace Frontend.Views.Home
     public class Index
     {
         public List<ProjectSearchResult> Projects;
+        public int Page { get; set; }
     }
 }


### PR DESCRIPTION
### Context

For performance, the API only returns the first 10 items from the academy transfer project endpoint, however when there is more there is currently no way to know.

Until there's meta data added to the endpoint, this will check for 10 items, and if there is 10 it will display the "next page" button, otherwise it will not.

### Changes proposed in this pull request

- Add page param to `academytransferproject` endpoint query
- Add MoJ pagination to project list

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

