### PR TITLE
Hide additional information on general info page

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
+
       - name: build frontend
         run: make build-frontend
 

--- a/Frontend/Views/GeneralInformation/Index.cshtml
+++ b/Frontend/Views/GeneralInformation/Index.cshtml
@@ -21,17 +21,13 @@
     <div class="govuk-grid-column-full">
         <partial name="_FormFieldSummaryList" model="Model.OutgoingAcademy.GeneralInformation.FieldsToDisplay()"/>
     </div>
-    <partial name="_AdditionalInformation" model="Model.AdditionalInformationModel"/>
 </div>
-@if (!Model.AdditionalInformationModel.AddOrEditAdditionalInformation)
-{
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <form asp-controller="Project" asp-route-id="@Model.Project.Urn">
-                <button class="govuk-button" data-module="govuk-button">
-                    Confirm and continue
-                </button>
-            </form>
-        </div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <form asp-controller="Project" asp-route-id="@Model.Project.Urn">
+            <button class="govuk-button" data-module="govuk-button">
+                Confirm and continue
+            </button>
+        </form>
     </div>
-}
+</div>


### PR DESCRIPTION
### Context

This text is no longer necessary

### Changes proposed in this pull request

- Hides the general information additional information field

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

