### PR TITLE
Integrate with additional general information data

### DIFF
--- a/Data.TRAMS.Tests/Mappers/Response/TramsEstablishmentMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Response/TramsEstablishmentMapperTests.cs
@@ -11,16 +11,12 @@ namespace Data.TRAMS.Tests.Mappers.Response
     public class TramsEstablishmentMapperTests
     {
         private readonly TramsEstablishmentMapper _subject;
+        private TramsEstablishment _tramsEstablishment;
 
         public TramsEstablishmentMapperTests()
         {
             _subject = new TramsEstablishmentMapper();
-        }
-
-        [Fact]
-        public void GivenTramsAcademy_MapsToInternalAcademySuccessfully()
-        {
-            var academyToMap = new TramsEstablishment
+            _tramsEstablishment = new TramsEstablishment
             {
                 Address = new Address
                 {
@@ -57,8 +53,21 @@ namespace Data.TRAMS.Tests.Mappers.Response
                 OfstedRating = "Good",
                 PhaseOfEducation = new NameAndCode {Name = "Primary"},
                 Ukprn = "Ukprn",
-                Urn = "Urn"
+                Urn = "Urn",
+                ViewAcademyConversion = new ViewAcademyConversion
+                {
+                    Deficit = "Deficit",
+                    Pan = "Pan",
+                    Pfi = "Pfi",
+                    ViabilityIssue = "Viability issue"
+                }
             };
+        }
+
+        [Fact]
+        public void GivenTramsAcademy_MapsToInternalAcademySuccessfully()
+        {
+            var academyToMap = _tramsEstablishment;
 
             var result = _subject.Map(academyToMap);
             var expectedAddress = new List<string> {"Example street", "Town", "Fakeshire", "FA11 1KE"};
@@ -76,6 +85,19 @@ namespace Data.TRAMS.Tests.Mappers.Response
             Assert.Equal(academyToMap.Census.NumberOfGirls, result.PupilNumbers.GirlsOnRoll);
         }
 
+        [Fact]
+        public void GivenViewAcademyConversionNull_DontPopulateInformation()
+        {
+            var academyToMap = _tramsEstablishment;
+            academyToMap.ViewAcademyConversion = null;
+            
+            var result = _subject.Map(academyToMap);
+            Assert.True(string.IsNullOrEmpty(result.GeneralInformation.Deficit));
+            Assert.True(string.IsNullOrEmpty(result.GeneralInformation.Pan));
+            Assert.True(string.IsNullOrEmpty(result.GeneralInformation.Pfi));
+            Assert.True(string.IsNullOrEmpty(result.GeneralInformation.ViabilityIssue));
+        }
+
         private static void AssertLatestOfstedJudgementCorrect(Academy result)
         {
             var latestOfstedJudgement = result.LatestOfstedJudgement;
@@ -90,12 +112,17 @@ namespace Data.TRAMS.Tests.Mappers.Response
             var expectedAgeRange = $"{establishmentToMap.StatutoryLowAge} to {establishmentToMap.StatutoryHighAge}";
             var expectedPercentageFull = ExpectedPercentageFull(establishmentToMap);
             var generalInformation = result.GeneralInformation;
+            var viewAcademyConversion = establishmentToMap.ViewAcademyConversion;
             Assert.Equal(establishmentToMap.PhaseOfEducation.Name, generalInformation.SchoolPhase);
             Assert.Equal(expectedAgeRange, generalInformation.AgeRange);
             Assert.Equal(establishmentToMap.SchoolCapacity, generalInformation.Capacity);
             Assert.Equal(establishmentToMap.Census.NumberOfPupils, generalInformation.NumberOnRoll);
             Assert.Equal(expectedPercentageFull, generalInformation.PercentageFull);
             Assert.Equal(establishmentToMap.EstablishmentType.Name, generalInformation.SchoolType);
+            Assert.Equal(viewAcademyConversion.Deficit, generalInformation.Deficit);
+            Assert.Equal(viewAcademyConversion.Pan, generalInformation.Pan);
+            Assert.Equal(viewAcademyConversion.Pfi, generalInformation.Pfi);
+            Assert.Equal(viewAcademyConversion.ViabilityIssue, generalInformation.ViabilityIssue);
         }
 
         private static string ExpectedPercentageFull(TramsEstablishment establishmentToMap)

--- a/Data.TRAMS/Mappers/Response/TramsEstablishmentMapper.cs
+++ b/Data.TRAMS/Mappers/Response/TramsEstablishmentMapper.cs
@@ -55,15 +55,24 @@ namespace Data.TRAMS.Mappers.Response
 
         private static GeneralInformation GeneralInformation(TramsEstablishment input)
         {
-            return new GeneralInformation
+            var generalInformation = new GeneralInformation
             {
                 AgeRange = $"{input.StatutoryLowAge} to {input.StatutoryHighAge}",
                 Capacity = input.SchoolCapacity,
                 NumberOnRoll = input.Census.NumberOfPupils,
                 PercentageFull = PercentageFull(input),
                 SchoolPhase = input.PhaseOfEducation.Name,
-                SchoolType = input.EstablishmentType.Name
+                SchoolType = input.EstablishmentType.Name,
             };
+
+            if (input.ViewAcademyConversion == null) return generalInformation;
+            
+            generalInformation.Pan = input.ViewAcademyConversion.Pan;
+            generalInformation.Pfi = input.ViewAcademyConversion.Pfi;
+            generalInformation.Deficit = input.ViewAcademyConversion.Deficit;
+            generalInformation.ViabilityIssue = input.ViewAcademyConversion.ViabilityIssue;
+
+            return generalInformation;
         }
 
         private static List<string> Address(TramsEstablishment input)

--- a/Data.TRAMS/Models/TramsEstablishment.cs
+++ b/Data.TRAMS/Models/TramsEstablishment.cs
@@ -105,5 +105,6 @@ namespace Data.TRAMS.Models
         public string Uprn { get; set; }
         public NameAndCode UrbanRural { get; set; }
         public string Urn { get; set; }
+        public ViewAcademyConversion ViewAcademyConversion { get; set; }
     }
 }

--- a/Data.TRAMS/Models/ViewAcademyConversion.cs
+++ b/Data.TRAMS/Models/ViewAcademyConversion.cs
@@ -1,0 +1,10 @@
+namespace Data.TRAMS.Models
+{
+    public class ViewAcademyConversion
+    {
+        public string Deficit { get; set; }
+        public string Pan { get; set; }
+        public string Pfi { get; set; }
+        public string ViabilityIssue { get; set; }
+    }
+}


### PR DESCRIPTION
### Context

The ability to populate new fields from the API has been added, as such we need to map those fields to our internal models

### Changes proposed in this pull request

- Maps data from the `viewAcademyTransfer` field on the API to the general information for the academy

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

