### PR TITLE
Update years in performance pages

### DIFF
--- a/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
+++ b/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
@@ -86,8 +86,8 @@ namespace Frontend.Tests.HelpersTests
             [Theory]
             [InlineData(null, null)]
             [InlineData("", "")]
-            [InlineData("2018-2019", "2018 - 2019")]
-            [InlineData("2018 - 2019", "2018 - 2019")]
+            [InlineData("2018-2019", "2018 to 2019")]
+            [InlineData("2018 - 2019", "2018 to 2019")]
             [InlineData("randomness", "randomness")]
             public void GivenYear_ShouldFormatCorrectly(string unformattedYear, string expectedFormattedYear)
             {

--- a/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
+++ b/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
@@ -284,7 +284,7 @@ namespace Frontend.Tests.HelpersTests
                 if (year3 != null)
                     ks4Results.Add(new KeyStage4 { Year = year3 });
 
-                var result = PerformanceDataHelpers.GetKeyStage4Results(ks4Results);
+                var result = PerformanceDataHelpers.GetFormattedKeyStage4Results(ks4Results);
                 
                 Assert.Equal(3,result.Count);
                 Assert.Equal("2018-2019", result[0].Year);
@@ -295,7 +295,7 @@ namespace Frontend.Tests.HelpersTests
             [Fact]
             public void GivenNoYearData_ShouldNotErrorAndReturnEmptyData()
             {
-                var result = PerformanceDataHelpers.GetKeyStage4Results(new List<KeyStage4>());
+                var result = PerformanceDataHelpers.GetFormattedKeyStage4Results(new List<KeyStage4>());
                 
                 Assert.Equal(3,result.Count);
                 Assert.All(result, ks4Result => Assert.Null(ks4Result.Year));

--- a/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
+++ b/Frontend.Tests/HelpersTests/PerformanceDataHelpersTests.cs
@@ -261,5 +261,45 @@ namespace Frontend.Tests.HelpersTests
                 Assert.True(PerformanceDataHelpers.HasKeyStage5PerformanceInformation(model));
             }
         }
+
+        public class GetKeyStage4ResultsTests
+        {
+            [Theory]
+            [InlineData("2018-2019", "2017-2018", "2016-2017")]
+            [InlineData("2017-2018", "2016-2017", "2018-2019")]
+            [InlineData("2016-2017", "2017-2018", "2018-2019")]
+            [InlineData("2018-2019", "2017-2018", null)]
+            [InlineData(null, "2018-2019", "2017-2018")]
+            [InlineData("2018-2019", null, "2017-2018")]
+            [InlineData("2018-2019", null, null)]
+            [InlineData(null, "2018-2019", null)]
+            [InlineData(null, null, "2018-2019")]
+            public void GiveDataWithMissingYears_ShouldReturnCorrectMissingYearDataSet(string year1, string year2, string year3)
+            {
+                var ks4Results = new List<KeyStage4>();
+                if (year1 != null)
+                    ks4Results.Add(new KeyStage4 { Year = year1 });
+                if (year2 != null)
+                    ks4Results.Add(new KeyStage4 { Year = year2 });
+                if (year3 != null)
+                    ks4Results.Add(new KeyStage4 { Year = year3 });
+
+                var result = PerformanceDataHelpers.GetKeyStage4Results(ks4Results);
+                
+                Assert.Equal(3,result.Count);
+                Assert.Equal("2018-2019", result[0].Year);
+                Assert.Equal("2017-2018", result[1].Year);
+                Assert.Equal("2016-2017", result[2].Year);
+            }
+
+            [Fact]
+            public void GivenNoYearData_ShouldNotErrorAndReturnEmptyData()
+            {
+                var result = PerformanceDataHelpers.GetKeyStage4Results(new List<KeyStage4>());
+                
+                Assert.Equal(3,result.Count);
+                Assert.All(result, ks4Result => Assert.Null(ks4Result.Year));
+            }
+        }
     }
 }

--- a/Frontend.Tests/PagesTests/TaskList/KeyStage4PerformanceTests.cs
+++ b/Frontend.Tests/PagesTests/TaskList/KeyStage4PerformanceTests.cs
@@ -108,8 +108,8 @@ namespace Frontend.Tests.PagesTests.TaskList
                 Assert.Equal(AcademyName, _subject.OutgoingAcademyName);
                 Assert.Equal(LaName, _subject.LocalAuthorityName);
                 Assert.Equal(3, _subject.KeyStage4Results.Count);
-                Assert.Equal("2019 - 2020", _subject.KeyStage4Results[0].Year);
-                Assert.Equal("2018 - 2019", _subject.KeyStage4Results[1].Year);
+                Assert.Equal("2019 to 2020", _subject.KeyStage4Results[0].Year);
+                Assert.Equal("2018 to 2019", _subject.KeyStage4Results[1].Year);
                 Assert.Null(_subject.KeyStage4Results[2].Year);
             }
             

--- a/Frontend.Tests/PagesTests/TaskList/KeyStage4PerformanceTests.cs
+++ b/Frontend.Tests/PagesTests/TaskList/KeyStage4PerformanceTests.cs
@@ -108,9 +108,9 @@ namespace Frontend.Tests.PagesTests.TaskList
                 Assert.Equal(AcademyName, _subject.OutgoingAcademyName);
                 Assert.Equal(LaName, _subject.LocalAuthorityName);
                 Assert.Equal(3, _subject.KeyStage4Results.Count);
-                Assert.Equal("2019 to 2020", _subject.KeyStage4Results[0].Year);
-                Assert.Equal("2018 to 2019", _subject.KeyStage4Results[1].Year);
-                Assert.Null(_subject.KeyStage4Results[2].Year);
+                Assert.Equal("2019-2020", _subject.KeyStage4Results[0].Year);
+                Assert.Equal("2018-2019", _subject.KeyStage4Results[1].Year);
+                Assert.Equal("2017-2018", _subject.KeyStage4Results[2].Year);
             }
             
             [Fact]

--- a/Frontend/Helpers/PerformanceDataHelpers.cs
+++ b/Frontend/Helpers/PerformanceDataHelpers.cs
@@ -48,7 +48,7 @@ namespace Frontend.Helpers
         {
             if (string.IsNullOrEmpty(year)) return year;
             var trimmedYear = string.Concat(year.Where(c => !char.IsWhiteSpace(c)));
-            return trimmedYear.Contains("-") ? trimmedYear.Replace("-", " - ") : year;
+            return trimmedYear.Contains("-") ? trimmedYear.Replace("-", " to ") : year;
         }
 
         public static bool HasKeyStage2PerformanceInformation(IList<KeyStage2> keyStage2Results)

--- a/Frontend/Helpers/PerformanceDataHelpers.cs
+++ b/Frontend/Helpers/PerformanceDataHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -55,12 +56,12 @@ namespace Frontend.Helpers
         {
             return keyStage2Results != null &&
                    keyStage2Results.Any(result => HasValue(result.MathsProgressScore)
-                                                                           || HasValue(result.ReadingProgressScore)
-                                                                           || HasValue(result.WritingProgressScore)
-                                                                           || HasValue(result
-                                                                               .PercentageAchievingHigherStdInRWM)
-                                                                           || HasValue(result
-                                                                               .PercentageMeetingExpectedStdInRWM));
+                                                  || HasValue(result.ReadingProgressScore)
+                                                  || HasValue(result.WritingProgressScore)
+                                                  || HasValue(result
+                                                      .PercentageAchievingHigherStdInRWM)
+                                                  || HasValue(result
+                                                      .PercentageMeetingExpectedStdInRWM));
         }
 
         public static bool HasKeyStage4PerformanceInformation(IList<KeyStage4> keyStage4Results)
@@ -101,6 +102,39 @@ namespace Frontend.Helpers
             var resultIsDouble = double.TryParse(result, NumberStyles.Number, CultureInfo.InvariantCulture,
                 out var resultAsDouble);
             return resultIsDouble ? $"{resultAsDouble}" : result;
+        }
+
+        public static List<KeyStage4> GetKeyStage4Results(IEnumerable<KeyStage4> keyStage4Results)
+        {
+            var formattedKeyStage4Results = keyStage4Results.Take(3).OrderByDescending(a => a.Year)
+                .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).ToList();
+            
+            return GetResultsWithNextLatestYearPopulatedForMissingYearData(formattedKeyStage4Results).ToList();
+        }
+
+        private static IEnumerable<KeyStage4> GetResultsWithNextLatestYearPopulatedForMissingYearData(IList<KeyStage4> keyStage4Results)
+        {
+            if (!keyStage4Results.Any(k => string.IsNullOrEmpty(k.Year)))
+                return keyStage4Results;
+            
+            if (keyStage4Results.All(k => string.IsNullOrEmpty(k.Year)))
+                return keyStage4Results;
+            
+            for (var i = 0; i < keyStage4Results.Count; i++)
+            {
+                if (string.IsNullOrEmpty(keyStage4Results[i].Year))
+                {
+                    keyStage4Results[i].Year = GetPreviousYearFromYearString(keyStage4Results[i - 1].Year);
+                }
+            }
+
+            static string GetPreviousYearFromYearString(string year)
+            {
+                var yearAsNumber = Convert.ToInt16(year.Split('-')[0]);
+                return $"{yearAsNumber - 1}-{yearAsNumber}";
+            }
+
+            return keyStage4Results;
         }
     }
 }

--- a/Frontend/Helpers/PerformanceDataHelpers.cs
+++ b/Frontend/Helpers/PerformanceDataHelpers.cs
@@ -104,7 +104,7 @@ namespace Frontend.Helpers
             return resultIsDouble ? $"{resultAsDouble}" : result;
         }
 
-        public static List<KeyStage4> GetKeyStage4Results(IEnumerable<KeyStage4> keyStage4Results)
+        public static List<KeyStage4> GetFormattedKeyStage4Results(IEnumerable<KeyStage4> keyStage4Results)
         {
             var formattedKeyStage4Results = keyStage4Results.Take(3).OrderByDescending(a => a.Year)
                 .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).ToList();

--- a/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2PerformanceTables.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage2Performance/KeyStage2PerformanceTables.cshtml
@@ -4,7 +4,7 @@
 @foreach (var ks2Result in Model.EducationPerformance.KeyStage2Performance.OrderByDescending(o => o.Year))
 {
     <table class="govuk-table govuk-!-margin-bottom-9">
-        <caption class="govuk-table__caption govuk-table__caption--m">@ks2Result.Year key stage 2</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">@PerformanceDataHelpers.GetFormattedYear(ks2Result.Year) key stage 2</caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header"></th>

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml
@@ -43,29 +43,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8score)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8score)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipAttainment8score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8score)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8Score)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8Score)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageA8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8Score)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8Score)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8Score)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageA8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8Score)</td>
             </tr>
             </tbody>
         </table>
@@ -74,29 +74,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8scoreenglish)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8scoreenglish)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipAttainment8scoreenglish)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8scoreenglish)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8scoreenglish)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8English)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8English)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageA8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8English)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8English)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8English)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageA8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8English)</td>
             </tr>
             </tbody>
         </table>
@@ -106,29 +106,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8scoremaths)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8scoremaths)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipAttainment8scoremaths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8scoremaths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8scoremaths)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8Maths)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8Maths)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageA8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8Maths)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8Maths)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8Maths)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageA8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8Maths)</td>
             </tr>
             </tbody>
         </table>
@@ -138,29 +138,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8scoreebacc)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8scoreebacc)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipAttainment8scoreebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipAttainment8scoreebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipAttainment8scoreebacc)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8EBacc)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8EBacc)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageA8EBacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageA8EBacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageA8EBacc)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8EBacc)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8EBacc)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageA8EBacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageA8EBacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageA8EBacc)</td>
             </tr>
             </tbody>
         </table>
@@ -176,29 +176,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipNumberofpupilsprogress8)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipNumberofpupilsprogress8)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipNumberofpupilsprogress8)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipNumberofpupilsprogress8)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipNumberofpupilsprogress8)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8PupilsIncluded)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8PupilsIncluded)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageP8PupilsIncluded)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8PupilsIncluded)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8PupilsIncluded)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8PupilsIncluded)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8PupilsIncluded)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageP8PupilsIncluded)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8PupilsIncluded)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8PupilsIncluded)</td>
             </tr>
             </tbody>
         </table>
@@ -207,47 +207,47 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipProgress8Score)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipProgress8Score)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipProgress8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipProgress8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipProgress8Score)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">School confidence interval</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[2].SipProgress8lowerconfidence,Model.KeyStage4Results[2].SipProgress8upperconfidence)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[1].SipProgress8lowerconfidence,Model.KeyStage4Results[1].SipProgress8upperconfidence)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[0].SipProgress8lowerconfidence,Model.KeyStage4Results[0].SipProgress8upperconfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[1].SipProgress8lowerconfidence,Model.KeyStage4Results[1].SipProgress8upperconfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(Model.KeyStage4Results[2].SipProgress8lowerconfidence,Model.KeyStage4Results[2].SipProgress8upperconfidence)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8Score)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8Score)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageP8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8Score)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA confidence interval</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[2].LAAverageP8LowerConfidence, @Model.KeyStage4Results[2].LAAverageP8UpperConfidence)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[1].LAAverageP8LowerConfidence, @Model.KeyStage4Results[1].LAAverageP8UpperConfidence)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[0].LAAverageP8LowerConfidence, @Model.KeyStage4Results[0].LAAverageP8UpperConfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[1].LAAverageP8LowerConfidence, @Model.KeyStage4Results[1].LAAverageP8UpperConfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[2].LAAverageP8LowerConfidence, @Model.KeyStage4Results[2].LAAverageP8UpperConfidence)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8Score)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8Score)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageP8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8Score)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8Score)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National LA confidence interval</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[2].NationalAverageP8LowerConfidence, @Model.KeyStage4Results[2].NationalAverageP8UpperConfidence)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[1].NationalAverageP8LowerConfidence, @Model.KeyStage4Results[1].NationalAverageP8UpperConfidence)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[0].NationalAverageP8LowerConfidence, @Model.KeyStage4Results[0].NationalAverageP8UpperConfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[1].NationalAverageP8LowerConfidence, @Model.KeyStage4Results[1].NationalAverageP8UpperConfidence)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(@Model.KeyStage4Results[2].NationalAverageP8LowerConfidence, @Model.KeyStage4Results[2].NationalAverageP8UpperConfidence)</td>
             </tr>
             </tbody>
         </table>
@@ -257,29 +257,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipProgress8english)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipProgress8english)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipProgress8english)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipProgress8english)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipProgress8english)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8English)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8English)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageP8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8English)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8English)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8English)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageP8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8English)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8English)</td>
             </tr>
             </tbody>
         </table>
@@ -289,29 +289,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(Model.KeyStage4Results[2].SipProgress8maths)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(Model.KeyStage4Results[1].SipProgress8maths)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(Model.KeyStage4Results[0].SipProgress8maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(Model.KeyStage4Results[1].SipProgress8maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(Model.KeyStage4Results[2].SipProgress8maths)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8Maths)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8Maths)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageP8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8Maths)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8Maths)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8Maths)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageP8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8Maths)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8Maths)</td>
             </tr>
             </tbody>
         </table>
@@ -321,29 +321,29 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.OutgoingAcademyName</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipProgress8ebacc)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipProgress8ebacc)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].SipProgress8ebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].SipProgress8ebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].SipProgress8ebacc)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">@Model.LocalAuthorityName LA average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8Ebacc)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8Ebacc)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].LAAverageP8Ebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].LAAverageP8Ebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].LAAverageP8Ebacc)</td>
             </tr>
             <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">National average</th>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8Ebacc)</td>
-                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8Ebacc)</td>
                 <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[0].NationalAverageP8Ebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[1].NationalAverageP8Ebacc)</td>
+                <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(@Model.KeyStage4Results[2].NationalAverageP8Ebacc)</td>
             </tr>
             </tbody>
         </table>
@@ -357,9 +357,9 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[2]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[1]?.Year</th>
-                <th scope="col" class="govuk-table__header">@Model.KeyStage4Results[0]?.Year</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[0]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[1]?.Year)</th>
+                <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(Model.KeyStage4Results[2]?.Year)</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Data;
 using Data.Models.KeyStagePerformance;
@@ -80,7 +79,7 @@ namespace Frontend.Pages.TaskList.KeyStage4Performance
             OutgoingAcademyUrn = projectInformation.OutgoingAcademy.Urn;
             LocalAuthorityName = projectInformation.OutgoingAcademy.LocalAuthorityName;
             OutgoingAcademyName = projectInformation.OutgoingAcademy.Name;
-            KeyStage4Results = GetLatestThreeResults(projectInformation.EducationPerformance.KeyStage4Performance);
+            KeyStage4Results = PerformanceDataHelpers.GetKeyStage4Results(projectInformation.EducationPerformance.KeyStage4Performance);
             ReturnToPreview = returnToPreview;
             AdditionalInformation = new AdditionalInformationViewModel
             {
@@ -91,20 +90,6 @@ namespace Frontend.Pages.TaskList.KeyStage4Performance
                 AddOrEditAdditionalInformation = addOrEditAdditionalInformation,
                 ReturnToPreview = returnToPreview
             };
-        }
-
-        private static List<KeyStage4> GetLatestThreeResults(List<KeyStage4> keyStage4Performance)
-        {
-            return keyStage4Performance.Take(3).OrderByDescending(a => a.Year)
-                .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).Select(c =>
-                {
-                    if (c.Year != null)
-                    {
-                        c.Year = PerformanceDataHelpers.GetFormattedYear(c.Year);
-                    }
-
-                    return c;
-                }).ToList();
         }
     }
 }

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4Performance.cshtml.cs
@@ -79,7 +79,7 @@ namespace Frontend.Pages.TaskList.KeyStage4Performance
             OutgoingAcademyUrn = projectInformation.OutgoingAcademy.Urn;
             LocalAuthorityName = projectInformation.OutgoingAcademy.LocalAuthorityName;
             OutgoingAcademyName = projectInformation.OutgoingAcademy.Name;
-            KeyStage4Results = PerformanceDataHelpers.GetKeyStage4Results(projectInformation.EducationPerformance.KeyStage4Performance);
+            KeyStage4Results = PerformanceDataHelpers.GetFormattedKeyStage4Results(projectInformation.EducationPerformance.KeyStage4Performance);
             ReturnToPreview = returnToPreview;
             AdditionalInformation = new AdditionalInformationViewModel
             {

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4PerformanceTables.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4PerformanceTables.cshtml
@@ -2,7 +2,7 @@
 @model ProjectPageModel
 
 @{
-    var keyStage4Results = PerformanceDataHelpers.GetKeyStage4Results(Model.EducationPerformance.KeyStage4Performance);
+    var keyStage4Results = PerformanceDataHelpers.GetFormattedKeyStage4Results(Model.EducationPerformance.KeyStage4Performance);
 }
 
 <h2 class="govuk-heading-l">

--- a/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4PerformanceTables.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage4Performance/KeyStage4PerformanceTables.cshtml
@@ -1,10 +1,8 @@
-@using Data.Models.KeyStagePerformance
 @using Frontend.Helpers
 @model ProjectPageModel
 
 @{
-    var keyStage4Results = Model.EducationPerformance.KeyStage4Performance.Take(3).OrderByDescending(a => a.Year)
-        .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).ToList();
+    var keyStage4Results = PerformanceDataHelpers.GetKeyStage4Results(Model.EducationPerformance.KeyStage4Performance);
 }
 
 <h2 class="govuk-heading-l">
@@ -16,29 +14,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8score)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8score)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipAttainment8score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8score)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8Score)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8Score)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageA8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8Score)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8Score)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8Score)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageA8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8Score)</td>
     </tr>
     </tbody>
 </table>
@@ -47,29 +45,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8scoreenglish)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8scoreenglish)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipAttainment8scoreenglish)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8scoreenglish)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8scoreenglish)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8English)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8English)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageA8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8English)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8English)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8English)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageA8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8English)</td>
     </tr>
     </tbody>
 </table>
@@ -79,29 +77,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8scoremaths)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8scoremaths)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipAttainment8scoremaths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8scoremaths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8scoremaths)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8Maths)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8Maths)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageA8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8Maths)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8Maths)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8Maths)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageA8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8Maths)</td>
     </tr>
     </tbody>
 </table>
@@ -111,29 +109,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8scoreebacc)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8scoreebacc)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipAttainment8scoreebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipAttainment8scoreebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipAttainment8scoreebacc)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8EBacc)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8EBacc)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageA8EBacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageA8EBacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageA8EBacc)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8EBacc)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8EBacc)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageA8EBacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageA8EBacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageA8EBacc)</td>
     </tr>
     </tbody>
 </table>
@@ -147,29 +145,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipNumberofpupilsprogress8)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipNumberofpupilsprogress8)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipNumberofpupilsprogress8)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipNumberofpupilsprogress8)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipNumberofpupilsprogress8)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8PupilsIncluded)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8PupilsIncluded)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageP8PupilsIncluded)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8PupilsIncluded)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8PupilsIncluded)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8PupilsIncluded)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8PupilsIncluded)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageP8PupilsIncluded)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8PupilsIncluded)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8PupilsIncluded)</td>
     </tr>
     </tbody>
 </table>
@@ -178,47 +176,47 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8Score)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8Score)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipProgress8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8Score)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">School confidence interval</th>
-        <td class="govuk-table__cell">@keyStage4Results[2].SipProgress8lowerconfidence to @keyStage4Results[2].SipProgress8upperconfidence</td>
-        <td class="govuk-table__cell">@keyStage4Results[1].SipProgress8lowerconfidence to @keyStage4Results[1].SipProgress8upperconfidence</td>
-        <td class="govuk-table__cell">@keyStage4Results[0].SipProgress8lowerconfidence to @keyStage4Results[0].SipProgress8upperconfidence</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[0].SipProgress8lowerconfidence, keyStage4Results[0].SipProgress8upperconfidence)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[1].SipProgress8lowerconfidence, keyStage4Results[1].SipProgress8upperconfidence)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[2].SipProgress8lowerconfidence, keyStage4Results[2].SipProgress8upperconfidence)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8Score)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8Score)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageP8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8Score)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA confidence interval</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[2].LAAverageP8LowerConfidence, keyStage4Results[2].LAAverageP8UpperConfidence)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[1].LAAverageP8LowerConfidence, keyStage4Results[1].LAAverageP8UpperConfidence)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[0].LAAverageP8LowerConfidence, keyStage4Results[0].LAAverageP8UpperConfidence)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[1].LAAverageP8LowerConfidence, keyStage4Results[1].LAAverageP8UpperConfidence)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[2].LAAverageP8LowerConfidence, keyStage4Results[2].LAAverageP8UpperConfidence)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8Score)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8Score)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageP8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8Score)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8Score)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National LA confidence interval</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[2].NationalAverageP8LowerConfidence, keyStage4Results[2].NationalAverageP8UpperConfidence)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[1].NationalAverageP8LowerConfidence, keyStage4Results[1].NationalAverageP8UpperConfidence)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[0].NationalAverageP8LowerConfidence, keyStage4Results[0].NationalAverageP8UpperConfidence)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[1].NationalAverageP8LowerConfidence, keyStage4Results[1].NationalAverageP8UpperConfidence)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedConfidenceInterval(keyStage4Results[2].NationalAverageP8LowerConfidence, keyStage4Results[2].NationalAverageP8UpperConfidence)</td>
     </tr>
     </tbody>
 </table>
@@ -228,29 +226,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8english)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8english)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipProgress8english)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8english)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8english)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8English)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8English)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageP8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8English)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8English)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8English)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageP8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8English)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8English)</td>
     </tr>
     </tbody>
 </table>
@@ -260,29 +258,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8maths)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8maths)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipProgress8maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8maths)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8Maths)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8Maths)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageP8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8Maths)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8Maths)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8Maths)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageP8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8Maths)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8Maths)</td>
     </tr>
     </tbody>
 </table>
@@ -292,29 +290,29 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.Name</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8ebacc)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8ebacc)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].SipProgress8ebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].SipProgress8ebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].SipProgress8ebacc)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">@Model.TransferringAcademy.LocalAuthorityName LA average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8Ebacc)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8Ebacc)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].LAAverageP8Ebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].LAAverageP8Ebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].LAAverageP8Ebacc)</td>
     </tr>
     <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">National average</th>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8Ebacc)</td>
-        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8Ebacc)</td>
         <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[0].NationalAverageP8Ebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[1].NationalAverageP8Ebacc)</td>
+        <td class="govuk-table__cell">@PerformanceDataHelpers.GetFormattedHtmlResult(keyStage4Results[2].NationalAverageP8Ebacc)</td>
     </tr>
     </tbody>
 </table>
@@ -326,9 +324,9 @@
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[2]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[1]?.Year</th>
-        <th scope="col" class="govuk-table__header">@keyStage4Results[0]?.Year</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[0]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[1]?.Year)</th>
+        <th scope="col" class="govuk-table__header">@PerformanceDataHelpers.GetFormattedYear(keyStage4Results[2]?.Year)</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">

--- a/Frontend/Pages/TaskList/KeyStage5Performance/KeyStage5PerformanceTables.cshtml
+++ b/Frontend/Pages/TaskList/KeyStage5Performance/KeyStage5PerformanceTables.cshtml
@@ -4,7 +4,7 @@
 @foreach (var ks5Result in Model.EducationPerformance.KeyStage5Performance.OrderByDescending(o => o.Year))
 {
     <h2 class="govuk-heading-m">
-        @ks5Result.Year scores for academic and applied general qualifications
+        @PerformanceDataHelpers.GetFormattedYear(ks5Result.Year) scores for academic and applied general qualifications
     </h2>
     <table class="govuk-table govuk-!-margin-bottom-9">
         <caption class="govuk-table__caption govuk-table__caption--s">Local authority: @Model.TransferringAcademy.LocalAuthorityName</caption>

--- a/Frontend/Services/CreateHtbDocument.cs
+++ b/Frontend/Services/CreateHtbDocument.cs
@@ -237,17 +237,15 @@ namespace Frontend.Services
             }
             else
             {
-                var ks4Results = htbDocument.KeyStage4Performance.Take(3)
-                    .OrderByDescending(a => a.Year)
-                    .Concat(Enumerable.Range(0, 3).Select(_ => new KeyStage4())).Take(3).Select(c =>
+                var ks4Results = htbDocument.KeyStage4Performance.Select(c =>
+                {
+                    if (c.Year != null)
                     {
-                        if (c.Year != null)
-                        {
-                            c.Year = PerformanceDataHelpers.GetFormattedYear(c.Year);
-                        }
+                        c.Year = PerformanceDataHelpers.GetFormattedYear(c.Year);
+                    }
 
-                        return c;
-                    }).ToList();
+                    return c;
+                }).ToList();
 
                 documentBuilder.ReplacePlaceholderWithContent("KeyStage4PerformanceSection", builder =>
                 {
@@ -274,16 +272,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .SipAttainment8score)
                             },
                             new TextElement
@@ -293,7 +291,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .SipAttainment8score)
                             }
                         },
@@ -302,7 +300,7 @@ namespace Frontend.Services
                             new TextElement {Value = $"{htbDocument.LocalAuthorityName} LA Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageA8Score)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageA8Score)
                             },
                             new TextElement
                             {
@@ -310,7 +308,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageA8Score)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageA8Score)
                             }
                         },
                         new[]
@@ -319,7 +317,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].NationalAverageA8Score)
+                                    ks4Results[0].NationalAverageA8Score)
                             },
                             new TextElement
                             {
@@ -329,7 +327,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].NationalAverageA8Score)
+                                    ks4Results[2].NationalAverageA8Score)
                             }
                         }
                     });
@@ -345,16 +343,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .SipAttainment8scoreenglish)
                             },
                             new TextElement
@@ -364,7 +362,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .SipAttainment8scoreenglish)
                             }
                         },
@@ -374,7 +372,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].LAAverageA8English)
+                                    ks4Results[0].LAAverageA8English)
                             },
                             new TextElement
                             {
@@ -384,7 +382,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].LAAverageA8English)
+                                    ks4Results[2].LAAverageA8English)
                             }
                         },
                         new[]
@@ -392,7 +390,7 @@ namespace Frontend.Services
                             new TextElement {Value = "National Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .NationalAverageA8English)
                             },
                             new TextElement
@@ -402,7 +400,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .NationalAverageA8English)
                             }
                         }
@@ -419,16 +417,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .SipAttainment8scoremaths)
                             },
                             new TextElement
@@ -438,7 +436,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .SipAttainment8scoremaths)
                             }
                         },
@@ -447,7 +445,7 @@ namespace Frontend.Services
                             new TextElement {Value = $"{htbDocument.LocalAuthorityName} LA Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageA8Maths)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageA8Maths)
                             },
                             new TextElement
                             {
@@ -455,7 +453,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageA8Maths)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageA8Maths)
                             }
                         },
                         new[]
@@ -464,7 +462,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].NationalAverageA8Maths)
+                                    ks4Results[0].NationalAverageA8Maths)
                             },
                             new TextElement
                             {
@@ -474,7 +472,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].NationalAverageA8Maths)
+                                    ks4Results[2].NationalAverageA8Maths)
                             }
                         }
                     });
@@ -490,16 +488,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .SipAttainment8scoreebacc)
                             },
                             new TextElement
@@ -509,7 +507,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .SipAttainment8scoreebacc)
                             }
                         },
@@ -518,7 +516,7 @@ namespace Frontend.Services
                             new TextElement {Value = $"{htbDocument.LocalAuthorityName} LA Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageA8EBacc)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageA8EBacc)
                             },
                             new TextElement
                             {
@@ -526,7 +524,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageA8EBacc)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageA8EBacc)
                             }
                         },
                         new[]
@@ -535,7 +533,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].NationalAverageA8EBacc)
+                                    ks4Results[0].NationalAverageA8EBacc)
                             },
                             new TextElement
                             {
@@ -545,7 +543,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].NationalAverageA8EBacc)
+                                    ks4Results[2].NationalAverageA8EBacc)
                             }
                         }
                     });
@@ -567,16 +565,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .SipNumberofpupilsprogress8)
                             },
                             new TextElement
@@ -586,7 +584,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .SipNumberofpupilsprogress8)
                             }
                         },
@@ -595,7 +593,7 @@ namespace Frontend.Services
                             new TextElement {Value = $"{htbDocument.LocalAuthorityName} LA Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .LAAverageP8PupilsIncluded)
                             },
                             new TextElement
@@ -605,7 +603,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .LAAverageP8PupilsIncluded)
                             }
                         },
@@ -614,7 +612,7 @@ namespace Frontend.Services
                             new TextElement {Value = "National Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .NationalAverageP8PupilsIncluded)
                             },
                             new TextElement
@@ -624,7 +622,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .NationalAverageP8PupilsIncluded)
                             }
                         }
@@ -641,16 +639,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].SipProgress8Score)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].SipProgress8Score)
                             },
                             new TextElement
                             {
@@ -658,7 +656,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].SipProgress8Score)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].SipProgress8Score)
                             }
                         },
                         new[]
@@ -667,8 +665,8 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedConfidenceInterval(
-                                    ks4Results[2].SipProgress8lowerconfidence,
-                                    ks4Results[2].SipProgress8upperconfidence)
+                                    ks4Results[0].SipProgress8lowerconfidence,
+                                    ks4Results[0].SipProgress8upperconfidence)
                             },
                             new TextElement
                             {
@@ -679,8 +677,8 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedConfidenceInterval(
-                                    ks4Results[0].SipProgress8lowerconfidence,
-                                    ks4Results[0].SipProgress8upperconfidence)
+                                    ks4Results[2].SipProgress8lowerconfidence,
+                                    ks4Results[2].SipProgress8upperconfidence)
                             }
                         },
                         new[]
@@ -688,7 +686,7 @@ namespace Frontend.Services
                             new TextElement {Value = $"{htbDocument.LocalAuthorityName} LA Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageP8Score)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageP8Score)
                             },
                             new TextElement
                             {
@@ -696,7 +694,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageP8Score)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageP8Score)
                             }
                         },
                         new[]
@@ -706,7 +704,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedConfidenceInterval(
-                                    ks4Results[2].LAAverageP8LowerConfidence, ks4Results[2].LAAverageP8UpperConfidence)
+                                    ks4Results[0].LAAverageP8LowerConfidence, ks4Results[0].LAAverageP8UpperConfidence)
                             },
                             new TextElement
                             {
@@ -716,7 +714,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedConfidenceInterval(
-                                    ks4Results[0].LAAverageP8LowerConfidence, ks4Results[0].LAAverageP8UpperConfidence)
+                                    ks4Results[2].LAAverageP8LowerConfidence, ks4Results[2].LAAverageP8UpperConfidence)
                             }
                         },
                         new[]
@@ -725,7 +723,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].NationalAverageP8Score)
+                                    ks4Results[0].NationalAverageP8Score)
                             },
                             new TextElement
                             {
@@ -735,7 +733,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].NationalAverageP8Score)
+                                    ks4Results[2].NationalAverageP8Score)
                             }
                         },
                         new[]
@@ -744,8 +742,8 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedConfidenceInterval(
-                                    ks4Results[2].NationalAverageP8LowerConfidence,
-                                    ks4Results[2].NationalAverageP8UpperConfidence)
+                                    ks4Results[0].NationalAverageP8LowerConfidence,
+                                    ks4Results[0].NationalAverageP8UpperConfidence)
                             },
                             new TextElement
                             {
@@ -756,8 +754,8 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedConfidenceInterval(
-                                    ks4Results[0].NationalAverageP8LowerConfidence,
-                                    ks4Results[0].NationalAverageP8UpperConfidence)
+                                    ks4Results[2].NationalAverageP8LowerConfidence,
+                                    ks4Results[2].NationalAverageP8UpperConfidence)
                             }
                         }
                     });
@@ -773,16 +771,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .SipProgress8english)
                             },
                             new TextElement
@@ -792,7 +790,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .SipProgress8english)
                             }
                         },
@@ -802,7 +800,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].LAAverageP8English)
+                                    ks4Results[0].LAAverageP8English)
                             },
                             new TextElement
                             {
@@ -812,7 +810,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].LAAverageP8English)
+                                    ks4Results[2].LAAverageP8English)
                             }
                         },
                         new[]
@@ -820,7 +818,7 @@ namespace Frontend.Services
                             new TextElement {Value = "National Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
                                     .NationalAverageP8English)
                             },
                             new TextElement
@@ -830,7 +828,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0]
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2]
                                     .NationalAverageP8English)
                             }
                         }
@@ -847,16 +845,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].SipProgress8maths)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].SipProgress8maths)
                             },
                             new TextElement
                             {
@@ -864,7 +862,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].SipProgress8maths)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].SipProgress8maths)
                             }
                         },
                         new[]
@@ -872,7 +870,7 @@ namespace Frontend.Services
                             new TextElement {Value = $"{htbDocument.LocalAuthorityName} LA Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageP8Maths)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageP8Maths)
                             },
                             new TextElement
                             {
@@ -880,7 +878,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageP8Maths)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageP8Maths)
                             }
                         },
                         new[]
@@ -889,7 +887,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].NationalAverageP8Maths)
+                                    ks4Results[0].NationalAverageP8Maths)
                             },
                             new TextElement
                             {
@@ -899,7 +897,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].NationalAverageP8Maths)
+                                    ks4Results[2].NationalAverageP8Maths)
                             }
                         }
                     });
@@ -915,16 +913,16 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {
                             new TextElement {Value = htbDocument.SchoolName, Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].SipProgress8ebacc)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].SipProgress8ebacc)
                             },
                             new TextElement
                             {
@@ -932,7 +930,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].SipProgress8ebacc)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].SipProgress8ebacc)
                             }
                         },
                         new[]
@@ -940,7 +938,7 @@ namespace Frontend.Services
                             new TextElement {Value = $"{htbDocument.LocalAuthorityName} LA Average", Bold = true},
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageP8Ebacc)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageP8Ebacc)
                             },
                             new TextElement
                             {
@@ -948,7 +946,7 @@ namespace Frontend.Services
                             },
                             new TextElement
                             {
-                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[0].LAAverageP8Ebacc)
+                                Value = PerformanceDataHelpers.GetFormattedStringResult(ks4Results[2].LAAverageP8Ebacc)
                             }
                         },
                         new[]
@@ -957,7 +955,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[2].NationalAverageP8Ebacc)
+                                    ks4Results[0].NationalAverageP8Ebacc)
                             },
                             new TextElement
                             {
@@ -967,7 +965,7 @@ namespace Frontend.Services
                             new TextElement
                             {
                                 Value = PerformanceDataHelpers.GetFormattedStringResult(
-                                    ks4Results[0].NationalAverageP8Ebacc)
+                                    ks4Results[2].NationalAverageP8Ebacc)
                             }
                         }
                     });
@@ -983,9 +981,9 @@ namespace Frontend.Services
                         new[]
                         {
                             new TextElement {Value = "", Bold = true},
-                            new TextElement {Value = ks4Results[2].Year, Bold = true},
+                            new TextElement {Value = ks4Results[0].Year, Bold = true},
                             new TextElement {Value = ks4Results[1].Year, Bold = true},
-                            new TextElement {Value = ks4Results[0].Year, Bold = true}
+                            new TextElement {Value = ks4Results[2].Year, Bold = true}
                         },
                         new[]
                         {

--- a/Frontend/Services/GetHtbDocumentForProject.cs
+++ b/Frontend/Services/GetHtbDocumentForProject.cs
@@ -82,7 +82,7 @@ namespace Frontend.Services
                 OfstedReport = academy.LatestOfstedJudgement.OfstedReport,
                 OfstedAdditionalInformation = project.LatestOfstedJudgementAdditionalInformation,
                 KeyStage2Performance = educationPerformance.KeyStage2Performance,
-                KeyStage4Performance = PerformanceDataHelpers.GetKeyStage4Results(educationPerformance.KeyStage4Performance),
+                KeyStage4Performance = PerformanceDataHelpers.GetFormattedKeyStage4Results(educationPerformance.KeyStage4Performance),
                 KeyStage5Performance = educationPerformance.KeyStage5Performance,
                 KeyStage2AdditionalInformation = project.KeyStage2PerformanceAdditionalInformation,
                 KeyStage4AdditionalInformation = project.KeyStage4PerformanceAdditionalInformation,

--- a/Frontend/Services/GetHtbDocumentForProject.cs
+++ b/Frontend/Services/GetHtbDocumentForProject.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Data.Models.Projects;
 using Frontend.ExtensionMethods;
+using Frontend.Helpers;
 using Frontend.Models;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
@@ -81,7 +82,7 @@ namespace Frontend.Services
                 OfstedReport = academy.LatestOfstedJudgement.OfstedReport,
                 OfstedAdditionalInformation = project.LatestOfstedJudgementAdditionalInformation,
                 KeyStage2Performance = educationPerformance.KeyStage2Performance,
-                KeyStage4Performance = educationPerformance.KeyStage4Performance,
+                KeyStage4Performance = PerformanceDataHelpers.GetKeyStage4Results(educationPerformance.KeyStage4Performance),
                 KeyStage5Performance = educationPerformance.KeyStage5Performance,
                 KeyStage2AdditionalInformation = project.KeyStage2PerformanceAdditionalInformation,
                 KeyStage4AdditionalInformation = project.KeyStage4PerformanceAdditionalInformation,


### PR DESCRIPTION
### Context

Update year data in performance sections

### Changes proposed in this pull request

Update year to read for example 2018 to 2019 instead of 2018-2019
Change order of KS4 years to show most recent first
Insert calculated year for those schools with no data for that year in ks4 data

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

