### PR TITLE
Remove application form content from help text

### DIFF
--- a/Frontend/Views/GeneralInformation/Index.cshtml
+++ b/Frontend/Views/GeneralInformation/Index.cshtml
@@ -16,7 +16,7 @@
             URN @Model.Project.OutgoingAcademyUrn
         </span>
         <h1 class="govuk-heading-l">General information</h1>
-        <p class="govuk-body">This information is pre-populated from TRAMS and the school's application form</p>
+        <p class="govuk-body">This information is pre-populated from TRAMS</p>
     </div>
     <div class="govuk-grid-column-full">
         <partial name="_FormFieldSummaryList" model="Model.OutgoingAcademy.GeneralInformation.FieldsToDisplay()"/>

--- a/Frontend/Views/PupilNumbers/Index.cshtml
+++ b/Frontend/Views/PupilNumbers/Index.cshtml
@@ -18,7 +18,7 @@
             URN @Model.Project.OutgoingAcademyUrn
         </span>
         <h1 class="govuk-heading-l">Pupil numbers</h1>
-        <p class="govuk-body">This information is pre-populated from TRAMS and the school's application form</p>
+        <p class="govuk-body">This information is pre-populated from TRAMS</p>
     </div>
     <div class="govuk-grid-column-full">
         <partial name="_FormFieldSummaryList" model="Model.OutgoingAcademy.PupilNumbers.FieldsToDisplay()" />


### PR DESCRIPTION
### Context

AT does not have an application form, so this is irrelevant

### Changes proposed in this pull request

- Remove content that's no longer relevant referencing the application form

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

