### PR TITLE
Accessibility: Add Error to page title on error

### DIFF
--- a/Frontend.Tests/ModelTests/FormsTests/FormErrorsViewModelTests.cs
+++ b/Frontend.Tests/ModelTests/FormsTests/FormErrorsViewModelTests.cs
@@ -1,0 +1,25 @@
+using Frontend.Models.Forms;
+using Xunit;
+
+namespace Frontend.Tests.ModelTests.FormsTests
+{
+    public class FormErrorsViewModelTests
+    {
+        private const string PageTitle = "pageTitle";
+        private FormErrorsViewModel Sut { get; } = new FormErrorsViewModel();
+
+        [Fact]
+        public void WhenThereAreNoErrors_ShouldProcessPageTitleCorrectly() =>
+            Assert.Equal(PageTitle, Sut.ProcessPageTitleIfThereIsAnError(PageTitle));
+
+        [Fact]
+        public void WhenThereAreErrors_ShouldProcessPageTitleCorrectly()
+        {
+            Sut.AddError("id", "field", "errorMessage");
+
+            var result = Sut.ProcessPageTitleIfThereIsAnError(PageTitle);
+            
+            Assert.Equal("Error: pageTitle", result);
+        }
+    }
+}

--- a/Frontend/Models/Forms/FormErrorsViewModel.cs
+++ b/Frontend/Models/Forms/FormErrorsViewModel.cs
@@ -8,6 +8,8 @@ namespace Frontend.Models.Forms
         public List<FormError> Errors { get; }
         public bool HasErrors => Errors.Count > 0;
 
+        public string ProcessPageTitleIfThereIsAnError(string pageTitle) => this.HasErrors ? $"Error: {pageTitle}" : pageTitle;
+
         public FormErrorsViewModel()
         {
             Errors = new List<FormError>();

--- a/Frontend/Views/Benefits/IntendedBenefits.cshtml
+++ b/Frontend/Views/Benefits/IntendedBenefits.cshtml
@@ -4,7 +4,8 @@
 @model BenefitsViewModel
 
 @{
-    ViewBag.Title = "Intended benefits";
+
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Intended benefits");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.FormClassesForField("intendedBenefits");
     var otherBenefitFormClasses = Model.FormErrors.FormClassesForField("otherBenefit");

--- a/Frontend/Views/Benefits/OtherFactors.cshtml
+++ b/Frontend/Views/Benefits/OtherFactors.cshtml
@@ -3,7 +3,7 @@
 @model BenefitsViewModel
 
 @{
-    ViewBag.Title = "Other factors";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Other factors");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.FormClassesForField("otherFactors");
 }

--- a/Frontend/Views/Features/Initiated.cshtml
+++ b/Frontend/Views/Features/Initiated.cshtml
@@ -1,7 +1,7 @@
 @model FeaturesViewModel    
 
 @{
-    ViewBag.Title = "Who initiated the academy transfer?";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Who initiated the academy transfer?");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.HasErrors ? "govuk-form-group--error" : "";
     var radioButtons = FeaturesViewModel.InitiatedRadioButtons(Model.Project.Features.WhoInitiatedTheTransfer);

--- a/Frontend/Views/Features/Reason.cshtml
+++ b/Frontend/Views/Features/Reason.cshtml
@@ -1,7 +1,7 @@
 @model Frontend.Models.FeaturesViewModel
 
 @{
-    ViewBag.Title = "Reason for transfer";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Reason for transfer");
     Layout = "_Layout";
 }
 

--- a/Frontend/Views/Features/Type.cshtml
+++ b/Frontend/Views/Features/Type.cshtml
@@ -2,7 +2,7 @@
 @model FeaturesViewModel
 
 @{
-    ViewBag.Title = "Type of transfer";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Type of transfer");
     Layout = "_Layout";
     var typeOfTransferFormClasses = Model.FormErrors.FormClassesForField("typeOfTransfer");
     var otherTypeFormClasses = Model.FormErrors.FormClassesForField("otherType");

--- a/Frontend/Views/Rationale/Project.cshtml
+++ b/Frontend/Views/Rationale/Project.cshtml
@@ -1,7 +1,7 @@
 @model RationaleViewModel
 
 @{
-    ViewBag.Title = "Write the rationale for the project";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Write the rationale for the project");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.FormClassesForField("rationale");
 }

--- a/Frontend/Views/Rationale/TrustOrSponsor.cshtml
+++ b/Frontend/Views/Rationale/TrustOrSponsor.cshtml
@@ -1,7 +1,7 @@
 @model RationaleViewModel
 
 @{
-    ViewBag.Title = "Write the rationale for the trust or sponsor";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Write the rationale for the trust or sponsor");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.FormClassesForField("rationale");
 }

--- a/Frontend/Views/TransferDates/FirstDiscussed.cshtml
+++ b/Frontend/Views/TransferDates/FirstDiscussed.cshtml
@@ -1,7 +1,7 @@
 @model TransferDatesViewModel
 
 @{
-    ViewBag.Title = "Add the date the transfer was first discussed with the outgoing trust";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Add the date the transfer was first discussed with the outgoing trust");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.HasErrors ? "govuk-form-group--error" : "";
 }

--- a/Frontend/Views/TransferDates/HtbDate.cshtml
+++ b/Frontend/Views/TransferDates/HtbDate.cshtml
@@ -2,7 +2,7 @@
 @model TransferDatesViewModel
 
 @{
-    ViewBag.Title = "Set AB date";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Set AB date");
     Layout = "_Layout";
     var htbDate = Model.Project.Dates.Htb;
     var htbStartDate = string.IsNullOrEmpty(htbDate) ? DatesHelper.DateTimeToDateString(DateTime.Today) : htbDate;

--- a/Frontend/Views/TransferDates/TargetDate.cshtml
+++ b/Frontend/Views/TransferDates/TargetDate.cshtml
@@ -1,7 +1,7 @@
 @model TransferDatesViewModel
 
 @{
-    ViewBag.Title = "Add the target date for the transfer";
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Add the target date for the transfer");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.HasErrors ? "govuk-form-group--error" : "";
 }

--- a/Frontend/Views/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/IncomingTrust.cshtml
@@ -1,10 +1,8 @@
 @{
-    ViewBag.Title = $"Add the incoming trust name for {ViewData["OutgoingAcademyName"]}";
     Layout = "_Layout";
-}
-
-@{
     var errorExists = (bool) ViewData["Error.Exists"];
+    var pageTitle = $"Add the incoming trust name for {ViewData["OutgoingAcademyName"]}";
+    ViewBag.Title = errorExists ? $"Error: {pageTitle}" : pageTitle;
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
 

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -1,9 +1,10 @@
 @model Frontend.Views.Transfers.OutgoingTrustAcademies
 
 @{
-    ViewBag.Title = "Add the transferring academies";
     Layout = "_Layout";
     var errorExists = (bool) ViewData["Error.Exists"];
+    const string pageTitle = "Add the transferring academies";
+    ViewBag.Title = errorExists ? $"Error: {pageTitle}" : pageTitle;
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
 

--- a/Frontend/Views/Transfers/TrustName.cshtml
+++ b/Frontend/Views/Transfers/TrustName.cshtml
@@ -1,7 +1,8 @@
 @{
-    ViewBag.Title = "Add the outgoing trust name";
     Layout = "_Layout";
     var errorExists = (bool) ViewData["Error.Exists"];
+    const string pageTitle = "Add the outgoing trust name";
+    ViewBag.Title = errorExists ? $"Error: {pageTitle}" : pageTitle;
     var formClasses = errorExists ? "govuk-form-group--error" : "";
     var changeLinkClicked = (bool) ViewData["ChangeLink"];
 }


### PR DESCRIPTION
### Context

Add Error to page title when there is an error (this was flagged as an issue in Accessibility report

### Changes proposed in this pull request

Add error to relevant pages where an error can occur

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

