### PR TITLE
Fix to trust search page

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -78,6 +78,20 @@ namespace Frontend.Tests.ControllerTests
         public class TrustSearchTests : TransfersControllerTests
         {
             [Fact]
+            public void GivenErrorMessageExists_SetErrorInViewData()
+            {
+                _trustsRepository.Setup(r => r.SearchTrusts("test"))
+                    .ReturnsAsync(
+                        new RepositoryResult<List<TrustSearchResult>> {Result = new List<TrustSearchResult> { new TrustSearchResult() }});
+                
+                _subject.TempData["ErrorMessage"] = "This is an error message";
+                _subject.TrustSearch("test");
+
+                Assert.Equal(true, _subject.ViewData["Error.Exists"]);
+                Assert.Equal("This is an error message", _subject.ViewData["Error.Message"]);
+            }
+            
+            [Fact]
             public async void GivenSearchingByEmptyString_RedirectToTrustNamePageWithAnError()
             {
                 var response = await _subject.TrustSearch("");

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -69,11 +69,25 @@ namespace Frontend.Controllers
             var model = new TrustSearch {Trusts = result.Result};
             ViewData["Query"] = query;
 
+            ViewData["Error.Exists"] = false;
+            if (TempData.Peek("ErrorMessage") == null) return View(model);
+
+            ViewData["Error.Exists"] = true;
+            ViewData["Error.Message"] = TempData["ErrorMessage"];
+            
             return View(model);
         }
 
         public async Task<IActionResult> OutgoingTrustDetails(string trustId, string query = "", bool change = false)
         {
+            ViewData["ChangeLink"] = change;
+
+            if (string.IsNullOrEmpty(trustId))
+            {
+                TempData["ErrorMessage"] = "Please select a trust";
+                return RedirectToAction("TrustSearch", new { query, change });
+            }
+            
             var result = await _trustsRepository.GetByUkprn(trustId);
 
             if (!result.IsValid)

--- a/Frontend/Views/Transfers/TrustSearch.cshtml
+++ b/Frontend/Views/Transfers/TrustSearch.cshtml
@@ -2,8 +2,11 @@
 @model Frontend.Views.Transfers.TrustSearch
 
 @{
-    ViewBag.Title = "Select an outgoing trust";
     Layout = "_Layout";
+    var errorExists = (bool) ViewData["Error.Exists"];
+    const string pageTitle = "Select an outgoing trust";
+    ViewBag.Title = errorExists ? $"Error: {pageTitle}" : pageTitle;
+    var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
 
 @section BeforeMain
@@ -13,16 +16,41 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        @if (errorExists)
+        {
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+                <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a href="#@Model.Trusts[0]?.Ukprn" data-qa="error__text">
+                                @ViewData["Error.Message"]
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        }
         <form asp-action="OutgoingTrustDetails" method="get" novalidate="">
             <input type="text" name="query" value="@ViewData["Query"]" hidden/>
             <input type="text" name="change" value="@ViewData["ChangeLink"].ToString()" hidden/>
-            <div class="govuk-form-group">
+            <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                         <h1 class="govuk-fieldset__heading">
                             Select the outgoing trust
                         </h1>
                     </legend>
+
+                    @if (errorExists)
+                    {
+                        <span id="academyId-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> @ViewData["Error.Message"]
+                        </span>
+                    }
+
                     <div class="govuk-radios">
                         @foreach (var trust in Model.Trusts)
                         {


### PR DESCRIPTION
### Context

Fix to trust search page - if no trust was selected and user clicked continue an error occurred, now the user is given a suitable error message

### Changes proposed in this pull request

Display error message when user does not select outgoing trust and clicks continue

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

