### PR TITLE
Update page titles

### DIFF
--- a/Frontend/Views/Benefits/IntendedBenefits.cshtml
+++ b/Frontend/Views/Benefits/IntendedBenefits.cshtml
@@ -5,7 +5,7 @@
 
 @{
 
-    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Intended benefits");
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("What are the benefits the transfer intended to bring?");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.FormClassesForField("intendedBenefits");
     var otherBenefitFormClasses = Model.FormErrors.FormClassesForField("otherBenefit");

--- a/Frontend/Views/Benefits/OtherFactors.cshtml
+++ b/Frontend/Views/Benefits/OtherFactors.cshtml
@@ -3,7 +3,7 @@
 @model BenefitsViewModel
 
 @{
-    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Other factors");
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Are there any other factors to consider during this transfer?");
     Layout = "_Layout";
     var formClasses = Model.FormErrors.FormClassesForField("otherFactors");
 }

--- a/Frontend/Views/Features/Type.cshtml
+++ b/Frontend/Views/Features/Type.cshtml
@@ -2,7 +2,7 @@
 @model FeaturesViewModel
 
 @{
-    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Type of transfer");
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("What type of transfer is it?");
     Layout = "_Layout";
     var typeOfTransferFormClasses = Model.FormErrors.FormClassesForField("typeOfTransfer");
     var otherTypeFormClasses = Model.FormErrors.FormClassesForField("otherType");

--- a/Frontend/Views/HeadteacherBoard/Download.cshtml
+++ b/Frontend/Views/HeadteacherBoard/Download.cshtml
@@ -1,7 +1,7 @@
 @model ProjectViewModel
 
 @{
-    ViewBag.Title = "Generate HTB documents";
+    ViewBag.Title = "Download headteacher board (HTB) documents";
     Layout = "_Layout";
 }
 

--- a/Frontend/Views/Project/Index.cshtml
+++ b/Frontend/Views/Project/Index.cshtml
@@ -1,7 +1,7 @@
 @model ProjectTaskListViewModel
 
 @{
-    ViewBag.Title = $"Project {Model.Project.Urn}";
+    ViewBag.Title = Model.Project.OutgoingAcademyName;
     Layout = "_Layout";
 }
 

--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 
-    <title>@ViewData["Title"] - Transfer an academy - GOV.UK</title>
+    <title>@ViewData["Title"] - Manage an academy</title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="robots" content="noindex">

--- a/Frontend/Views/TransferDates/HtbDate.cshtml
+++ b/Frontend/Views/TransferDates/HtbDate.cshtml
@@ -2,7 +2,7 @@
 @model TransferDatesViewModel
 
 @{
-    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Set AB date");
+    ViewBag.Title = Model.FormErrors.ProcessPageTitleIfThereIsAnError("Set Advisory Board date");
     Layout = "_Layout";
     var htbDate = Model.Project.Dates.Htb;
     var htbStartDate = string.IsNullOrEmpty(htbDate) ? DatesHelper.DateTimeToDateString(DateTime.Today) : htbDate;

--- a/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Views/Transfers/OutgoingTrustAcademies.cshtml
@@ -3,7 +3,7 @@
 @{
     Layout = "_Layout";
     var errorExists = (bool) ViewData["Error.Exists"];
-    const string pageTitle = "Add the transferring academies";
+    const string pageTitle = "Select the transferring academies";
     ViewBag.Title = errorExists ? $"Error: {pageTitle}" : pageTitle;
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }

--- a/Frontend/Views/Transfers/TrustSearch.cshtml
+++ b/Frontend/Views/Transfers/TrustSearch.cshtml
@@ -4,7 +4,7 @@
 @{
     Layout = "_Layout";
     var errorExists = (bool) ViewData["Error.Exists"];
-    const string pageTitle = "Select an outgoing trust";
+    const string pageTitle = "Select the outgoing trust";
     ViewBag.Title = errorExists ? $"Error: {pageTitle}" : pageTitle;
     var formClasses = errorExists ? "govuk-form-group--error" : "";
 }


### PR DESCRIPTION
### Context

Some page titles have become out of sync of the heading, ensure the page title matches the h1 heading

### Changes proposed in this pull request

Update all page titles to match heading
Remove Gov.Uk from page title
Amend `transfer and academy` to `manage an academy` in the page title

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

