### PR TITLE
Show error if no incoming trust is selected on search page

### DIFF
--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -200,12 +200,24 @@ namespace Frontend.Controllers
             }
 
             var model = new TrustSearch {Trusts = result.Result};
+            
+            ViewData["Error.Exists"] = false;
+            if (TempData.Peek("ErrorMessage") == null) return View(model);
 
+            ViewData["Error.Exists"] = true;
+            ViewData["Error.Message"] = TempData["ErrorMessage"];
+            
             return View(model);
         }
 
-        public IActionResult ConfirmIncomingTrust(string trustId)
+        public IActionResult ConfirmIncomingTrust(string trustId, string query = "", bool change = false)
         {
+            if (string.IsNullOrEmpty(trustId))
+            {
+                TempData["ErrorMessage"] = "Select a trust";
+                return RedirectToAction("SearchIncomingTrust", new { query, change });
+            }
+            
             HttpContext.Session.SetString(IncomingTrustIdSessionKey, trustId);
 
             return RedirectToAction("CheckYourAnswers");

--- a/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
+++ b/Frontend/Views/Transfers/SearchIncomingTrust.cshtml
@@ -2,30 +2,58 @@
 @model Frontend.Views.Transfers.TrustSearch
 
 @{
-    ViewBag.Title = "Select an incoming trust";
     Layout = "_Layout";
+    var errorExists = (bool) ViewData["Error.Exists"];
+    const string pageTitle = "Select the incoming trust";
+    ViewBag.Title = errorExists ? $"Error: {pageTitle}" : pageTitle;
+    var formClasses = errorExists ? "govuk-form-group--error" : "";
 }
 
 @section BeforeMain
 {
     <a class="govuk-back-link" asp-controller="Transfers" asp-action="IncomingTrust" asp-route-query="@ViewData["Query"]" asp-route-change="@ViewData["ChangeLink"]">Back</a>
 }
-
+    
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        @if (errorExists)
+        {
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+                <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a href="#@Model.Trusts[0]?.Ukprn" data-qa="error__text">
+                                @ViewData["Error.Message"]
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        }
         <form class="govuk-form" asp-action="ConfirmIncomingTrust" method="get">
-            <div class="govuk-form-group">
+            <input type="text" name="query" value="@ViewData["Query"]" hidden/>
+            <input type="text" name="change" value="@ViewData["ChangeLink"].ToString()" hidden/>
+            <div class="govuk-form-group @formClasses">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                         <h1 class="govuk-fieldset__heading">
                             Select an incoming trust
                         </h1>
                     </legend>
+                    @if (errorExists)
+                    {
+                        <span id="academyId-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> @ViewData["Error.Message"]
+                        </span>
+                    }
                     <div class="govuk-radios">
                         @foreach (var trust in Model.Trusts)
                         {
                             <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="@trust.Ukprn" name="trustId" type="radio" value="@trust.Ukprn" aria-describedby="@trust.Ukprn-hint" />
+                                <input class="govuk-radios__input" id="@trust.Ukprn" name="trustId" type="radio" value="@trust.Ukprn" aria-describedby="@trust.Ukprn-hint"/>
                                 <label class="govuk-label govuk-radios__label" for="@trust.Ukprn">
                                     @trust.TrustName.ToTitleCase() (@trust.Ukprn)
                                 </label>


### PR DESCRIPTION
### Context

Show error if no incoming trust is selected on search page

### Changes proposed in this pull request

Show error if no incoming trust is selected on search page

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

