### PR TITLE
Allow empty date fields

### DIFF
--- a/Data.TRAMS.Tests/Mappers/Request/InternalProjectToUpdateMapperTests.cs
+++ b/Data.TRAMS.Tests/Mappers/Request/InternalProjectToUpdateMapperTests.cs
@@ -96,6 +96,26 @@ namespace Data.TRAMS.Tests.Mappers.Request
             AssertGeneralInformationIsCorrect(toMap, result);
         }
 
+        [Fact]
+        public void GivenNullDate_ShouldSetHasDateToFalse()
+        {
+            var subject = new InternalProjectToUpdateMapper();
+            var toMap = new Project
+            {
+                Dates = new TransferDates
+                {
+                    Htb = null,
+                    Target = null,
+                    FirstDiscussed = null
+                },
+            };
+
+            var result = subject.Map(toMap);
+            Assert.False(result.Dates.HasHtbDate);
+            Assert.False(result.Dates.HasTargetDateForTransfer);
+            Assert.False(result.Dates.HasTransferFirstDiscussedDate);
+        }
+
         private static void AssertGeneralInformationIsCorrect(Project toMap, TramsProjectUpdate result)
         {
             Assert.Equal(toMap.AcademyAndTrustInformation.Author, result.GeneralInformation.Author);
@@ -124,6 +144,9 @@ namespace Data.TRAMS.Tests.Mappers.Request
             Assert.Equal(toMap.Dates.FirstDiscussed, result.Dates.TransferFirstDiscussed);
             Assert.Equal(toMap.Dates.Htb, result.Dates.HtbDate);
             Assert.Equal(toMap.Dates.Target, result.Dates.TargetDateForTransfer);
+            Assert.True(result.Dates.HasHtbDate);
+            Assert.True(result.Dates.HasTargetDateForTransfer);
+            Assert.True(result.Dates.HasTransferFirstDiscussedDate);
         }
 
         private static void AssertBenefitsAreCorrect(Project toMap, TramsProjectUpdate result)

--- a/Data.TRAMS/Mappers/Request/InternalProjectToUpdateMapper.cs
+++ b/Data.TRAMS/Mappers/Request/InternalProjectToUpdateMapper.cs
@@ -69,8 +69,11 @@ namespace Data.TRAMS.Mappers.Request
             return new AcademyTransferProjectDates
             {
                 HtbDate = input.Dates.Htb,
+                HasHtbDate = !string.IsNullOrEmpty(input.Dates.Htb),
                 TransferFirstDiscussed = input.Dates.FirstDiscussed,
-                TargetDateForTransfer = input.Dates.Target
+                HasTransferFirstDiscussedDate = !string.IsNullOrEmpty(input.Dates.FirstDiscussed),
+                TargetDateForTransfer = input.Dates.Target,
+                HasTargetDateForTransfer = !string.IsNullOrEmpty(input.Dates.Target)
             };
         }
 

--- a/Data.TRAMS/Models/AcademyTransferProject/AcademyTransferProjectDates.cs
+++ b/Data.TRAMS/Models/AcademyTransferProject/AcademyTransferProjectDates.cs
@@ -3,7 +3,10 @@ namespace Data.TRAMS.Models.AcademyTransferProject
     public class AcademyTransferProjectDates
     {
         public string HtbDate { get; set; }
+        public bool HasHtbDate { get; set; } = true;
         public string TargetDateForTransfer { get; set; }
+        public bool HasTargetDateForTransfer { get; set; } = true;
         public string TransferFirstDiscussed { get; set; }
+        public bool HasTransferFirstDiscussedDate { get; set; } = true;
     }
 }

--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -131,7 +131,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
-                    Assert.Equal("Enter the date the transfer was first discussed",
+                    Assert.Equal("Enter a valid date",
                         responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
 
@@ -182,7 +182,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [Fact]
                 public async void GivenInvalidInputAndReturnToPreview_AssignItToTheViewModel()
                 {
-                    var response = await _subject.FirstDiscussedPost("0001", null, null, null, true);
+                    var response = await _subject.FirstDiscussedPost("0001", "01", null, null, true);
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(viewModel.ReturnToPreview);
@@ -266,7 +266,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
-                    Assert.Equal("Enter the target date for the transfer",
+                    Assert.Equal("Enter a valid date",
                         responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
 
@@ -329,7 +329,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [Fact]
                 public async void GivenInvalidInputAndReturnToPreview_AssignItToTheViewModel()
                 {
-                    var response = await _subject.TargetDatePost("0001", null, null, null, true);
+                    var response = await _subject.TargetDatePost("0001", "45", null, "2020", true);
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(viewModel.ReturnToPreview);
@@ -413,7 +413,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
-                    Assert.Equal("Enter the Advisory Board date", responseModel.FormErrors.Errors[0].ErrorMessage);
+                    Assert.Equal("Enter a valid date", responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
 
                 [Theory]
@@ -475,7 +475,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [Fact]
                 public async void GivenInvalidInputAndReturnToPreview_AssignItToTheViewModel()
                 {
-                    var response = await _subject.HtbDatePost("0001", null, null, null, true);
+                    var response = await _subject.HtbDatePost("0001", null, "01", null, true);
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(viewModel.ReturnToPreview);

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -62,13 +62,7 @@ namespace Frontend.Controllers.Projects
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
             model.Project.Dates.FirstDiscussed = dateString;
 
-            if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
-            {
-                model.FormErrors.AddError("day", "day", "Enter the date the transfer was first discussed");
-                return View(model);
-            }
-
-            if (!DatesHelper.IsValidDate(dateString))
+            if (!string.IsNullOrEmpty(dateString) && !DatesHelper.IsValidDate(dateString))
             {
                 model.FormErrors.AddError("day", "day", "Enter a valid date");
                 return View(model);
@@ -118,13 +112,7 @@ namespace Frontend.Controllers.Projects
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
             model.Project.Dates.Target = dateString;
 
-            if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
-            {
-                model.FormErrors.AddError("day", "day", "Enter the target date for the transfer");
-                return View(model);
-            }
-
-            if (!DatesHelper.IsValidDate(dateString))
+            if (!string.IsNullOrEmpty(dateString) && !DatesHelper.IsValidDate(dateString))
             {
                 model.FormErrors.AddError("day", "day", "Enter a valid date");
                 return View(model);
@@ -184,13 +172,7 @@ namespace Frontend.Controllers.Projects
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
             model.Project.Dates.Htb = dateString;
 
-            if (string.IsNullOrEmpty(day) || string.IsNullOrEmpty(month) || string.IsNullOrEmpty(year))
-            {
-                model.FormErrors.AddError("day", "day", "Enter the Advisory Board date");
-                return View(model);
-            }
-
-            if (!DatesHelper.IsValidDate(dateString))
+            if (!string.IsNullOrEmpty(dateString) && !DatesHelper.IsValidDate(dateString))
             {
                 model.FormErrors.AddError("day", "day", "Enter a valid date");
                 return View(model);

--- a/Helpers.Tests/DatesHelperTests.cs
+++ b/Helpers.Tests/DatesHelperTests.cs
@@ -20,5 +20,19 @@ namespace Helpers.Tests
                 Assert.Equal(expectedResult, result);
             }
         }
+
+        public class DayMonthYearToDateStringTests
+        {
+            [Theory]
+            [InlineData(null, null, null, null)]
+            [InlineData("", "", "", null)]
+            [InlineData("1", "1", "2020", "01/01/2020")]
+            public void GivenDayMonthYear_ShouldReturnCorrectDateString(string day, string month, string year,
+                string expectedResult)
+            {
+                var result = DatesHelper.DayMonthYearToDateString(day, month, year);
+                Assert.Equal(expectedResult, result);
+            }
+        }
     }
 }

--- a/Helpers/DatesHelper.cs
+++ b/Helpers/DatesHelper.cs
@@ -14,6 +14,9 @@ namespace Helpers
 
         public static string DayMonthYearToDateString(string day, string month, string year)
         {
+            if (string.IsNullOrEmpty(day) && string.IsNullOrEmpty(month) && string.IsNullOrEmpty(year))
+                return null;
+            
             day = string.IsNullOrEmpty(day) ? "" : day.PadLeft(2, '0');
             month = string.IsNullOrEmpty(month) ? "" : month.PadLeft(2, '0');
             year = string.IsNullOrEmpty(year) ? "" : year;


### PR DESCRIPTION
### Context

Allow users to set the Htb, transfer and discussed date back to null after they have been set

### Changes proposed in this pull request

Update Trams API to allow the Htb, transfer and discussed date to be set back to null
Update AT service to remove required validation and set and send extra fields to trams api

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

