### PR TITLE
Ensure only send GA data in production environment

### DIFF
--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -1,6 +1,9 @@
 ﻿@using Microsoft.Extensions.Configuration
 @using NetEscapades.AspNetCore.SecurityHeaders
+@using Microsoft.AspNetCore.Hosting
+@using Microsoft.Extensions.Hosting
 @inject IConfiguration _configuration
+@inject IWebHostEnvironment _environment
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 @{ var nonce = Context.GetNonce(); }
@@ -12,7 +15,7 @@
     @{
         var pageTitle = (ViewData["Title"] == null ? "" : $"{ViewData["Title"]} - ") + "Manage an academy transfer";
     }
-    
+
     <title>@pageTitle</title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -28,20 +31,30 @@
     <link rel="stylesheet" href="~/dist/site.css"/>
 
     <meta property="og:image" content="~/assets/images/govuk-opengraph-image.png">
-    <!-- Google Tag Manager -->
-    <script nonce="@nonce">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+
+    @if (_environment.IsProduction())
+    {
+        <!-- Google Tag Manager -->
+        <script nonce="@nonce">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-T43KJ2P');</script>
-    <!-- End Google Tag Manager -->
+        <!-- End Google Tag Manager -->
+    }
 </head>
 
 <body class="govuk-template__body ">
-<!-- Google Tag Manager (noscript) -->
-<noscript nonce="@nonce"><iframe src=https://www.googletagmanager.com/ns.html?id=GTM-T43KJ2P
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
+@if (_environment.IsProduction())
+{
+    <!-- Google Tag Manager (noscript) -->
+    <noscript nonce="@nonce">
+        <iframe src=https://www.googletagmanager.com/ns.html?id=GTM-T43KJ2P
+                height="0" width="0" style="display:none;visibility:hidden">
+        </iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+}
 <script nonce="@nonce">
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>


### PR DESCRIPTION
### Context

Ensure only send GA data in production environment

### Changes proposed in this pull request

Tested GA data is sent in dev with updated security headers, so now restricted to just send in production

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

