### PR TITLE
Add css class to resolve csp error on ga noscript iframe

### DIFF
--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -47,10 +47,10 @@
 <body class="govuk-template__body ">
 @if (_environment.IsProduction())
 {
-    <!-- Google Tag Manager (noscript) -->
-    <noscript nonce="@nonce">
+     <!-- Google Tag Manager (noscript) -->
+     <noscript nonce="@nonce">
         <iframe src=https://www.googletagmanager.com/ns.html?id=GTM-T43KJ2P
-                height="0" width="0" style="display:none;visibility:hidden">
+                class="not-visible" height="0" width="0">
         </iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->

--- a/Frontend/wwwroot/src/css/site.scss
+++ b/Frontend/wwwroot/src/css/site.scss
@@ -69,3 +69,8 @@ aside.app-related-items {
 .dfe-sign-out {
   float: right;
 }
+
+.not-visible {
+  display:none;
+  visibility:hidden
+}


### PR DESCRIPTION
### Context

Add css class to resolve csp error on ga noscript iframe

### Changes proposed in this pull request

Add css class to resolve csp error on ga noscript iframe if javascript is disabled

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

