### PR TITLE
Feature/658 bug validation on dates pages

### DIFF
--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -208,6 +208,16 @@ namespace Frontend.Tests.ControllerTests.Projects
                     Assert.True(responseModel.FormErrors.HasErrors);
                     Assert.Equal("You must enter the date or confirm that you don't know it", responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
+
+                [Fact]
+                public async void GivenValidDateAndUnknownIsTrue_SetsErrorOnViewModel()
+                {
+                    var response = await _subject.FirstDiscussedPost("0001", "25", "10", "2021", dateUnknown: true);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("You must either enter the date or select 'I do not know this'", responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
             }
         }
 
@@ -365,6 +375,16 @@ namespace Frontend.Tests.ControllerTests.Projects
                     Assert.True(responseModel.FormErrors.HasErrors);
                     Assert.Equal("You must enter the date or confirm that you don't know it", responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
+
+                [Fact]
+                public async void GivenValidDateAndUnknownIsTrue_SetsErrorOnViewModel()
+                {
+                    var response = await _subject.TargetDatePost("0001", "25", "10", "2021", dateUnknown: true);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("You must either enter the date or select 'I do not know this'", responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
             }
         }
 
@@ -520,6 +540,16 @@ namespace Frontend.Tests.ControllerTests.Projects
 
                     Assert.True(responseModel.FormErrors.HasErrors);
                     Assert.Equal("You must enter the date or confirm that you don't know it", responseModel.FormErrors.Errors[0].ErrorMessage);
+                }
+
+                [Fact]
+                public async void GivenValidDateAndUnknownIsTrue_SetsErrorOnViewModel()
+                {
+                    var response = await _subject.HtbDatePost("0001", "25", "10", "2021", dateUnknown: true);
+                    var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
+
+                    Assert.True(responseModel.FormErrors.HasErrors);
+                    Assert.Equal("You must either enter the date or select 'I do not know this'", responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
             }
         }

--- a/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/Projects/TransferDatesControllerTests.cs
@@ -27,7 +27,7 @@ namespace Frontend.Tests.ControllerTests.Projects
             _projectsRepository = new Mock<IProjects>();
 
             _projectsRepository.Setup(r => r.GetByUrn(It.IsAny<string>()))
-                .ReturnsAsync(new RepositoryResult<Project> {Result = _foundProject});
+                .ReturnsAsync(new RepositoryResult<Project> { Result = _foundProject });
             _projectsRepository.Setup(s => s.GetByUrn(_errorWithGetByUrn))
                 .ReturnsAsync(
                     new RepositoryResult<Project>
@@ -141,9 +141,10 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [InlineData("1", "0", "2020")]
                 [InlineData("1", "13", "2020")]
                 [InlineData("1", "13", "0")]
-                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year)
+                [InlineData("40", "20", "0", true)]
+                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year, bool dateUnknown = false)
                 {
-                    var response = await _subject.FirstDiscussedPost("0001", day, month, year);
+                    var response = await _subject.FirstDiscussedPost("0001", day, month, year, dateUnknown: dateUnknown);
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
@@ -182,7 +183,7 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [Fact]
                 public async void GivenInvalidInputAndReturnToPreview_AssignItToTheViewModel()
                 {
-                    var response = await _subject.FirstDiscussedPost("0001", "01", null, null, returnToPreview:true);
+                    var response = await _subject.FirstDiscussedPost("0001", "01", null, null, returnToPreview: true);
                     var viewModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(viewModel.ReturnToPreview);
@@ -191,18 +192,18 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [Fact]
                 public async void GivenReturnToPreview_RedirectToPreviewPage()
                 {
-                    var response = await _subject.FirstDiscussedPost("0001", "01", "01", "2020", returnToPreview:true);
+                    var response = await _subject.FirstDiscussedPost("0001", "01", "01", "2020", returnToPreview: true);
                     ControllerTestHelpers.AssertResultRedirectsToPage(
                         response,
                         Links.HeadteacherBoard.Preview.PageName,
-                        new RouteValueDictionary(new {id = "0001"})
+                        new RouteValueDictionary(new { id = "0001" })
                     );
                 }
 
                 [Fact]
                 public async void GivenNoDateAndUnknownIsFalse_SetsErrorOnViewModel()
                 {
-                    var response = await _subject.FirstDiscussedPost("0001", null, null, null, dateUnknown:false);
+                    var response = await _subject.FirstDiscussedPost("0001", null, null, null, dateUnknown: false);
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
@@ -296,20 +297,21 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [InlineData("1", "0", "2020")]
                 [InlineData("1", "13", "2020")]
                 [InlineData("1", "13", "0")]
-                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year)
+                [InlineData("41", "20", "0", true)]
+                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year, bool dateUnknown = false)
                 {
-                    var response = await _subject.TargetDatePost("0001", day, month, year);
+                    var response = await _subject.TargetDatePost("0001", day, month, year, dateUnknown: dateUnknown);
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
                     Assert.Equal("Enter a valid date", responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
-                
+
                 [Fact]
                 public async void GivenTargetTransferDateBeforeHtbDate_SetErrorOnTheModel()
                 {
                     _foundProject.Dates.Htb = "12/10/2020";
-                    
+
                     var response = await _subject.TargetDatePost("0001", "11", "10", "2020");
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
@@ -362,14 +364,14 @@ namespace Frontend.Tests.ControllerTests.Projects
                     ControllerTestHelpers.AssertResultRedirectsToPage(
                         response,
                         Links.HeadteacherBoard.Preview.PageName,
-                        new RouteValueDictionary(new {id = "0001"})
+                        new RouteValueDictionary(new { id = "0001" })
                     );
                 }
-                
+
                 [Fact]
                 public async void GivenNoDateAndUnknownIsFalse_SetsErrorOnViewModel()
                 {
-                    var response = await _subject.TargetDatePost("0001", null, null, null, dateUnknown:false);
+                    var response = await _subject.TargetDatePost("0001", null, null, null, dateUnknown: false);
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
@@ -462,20 +464,21 @@ namespace Frontend.Tests.ControllerTests.Projects
                 [InlineData("1", "0", "2020")]
                 [InlineData("1", "13", "2020")]
                 [InlineData("1", "13", "0")]
-                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year)
+                [InlineData("41", "20", "0", true)]
+                public async void GivenInvalidDate_SetErrorOnTheModel(string day, string month, string year, bool dateUnknown = false)
                 {
-                    var response = await _subject.HtbDatePost("0001", day, month, year);
+                    var response = await _subject.HtbDatePost("0001", day, month, year, dateUnknown: dateUnknown);
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);
                     Assert.Equal("Enter a valid date", responseModel.FormErrors.Errors[0].ErrorMessage);
                 }
-                
+
                 [Fact]
                 public async void GivenABDateBeforeTransferDate_SetErrorOnTheModel()
                 {
                     _foundProject.Dates.Target = "12/10/2020";
-                    
+
                     var response = await _subject.HtbDatePost("0001", "13", "10", "2020");
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
@@ -528,14 +531,14 @@ namespace Frontend.Tests.ControllerTests.Projects
                     ControllerTestHelpers.AssertResultRedirectsToPage(
                         response,
                         Links.HeadteacherBoard.Preview.PageName,
-                        new RouteValueDictionary(new {id = "0001"})
+                        new RouteValueDictionary(new { id = "0001" })
                     );
                 }
-                
+
                 [Fact]
                 public async void GivenNoDateAndUnknownIsFalse_SetsErrorOnViewModel()
                 {
-                    var response = await _subject.HtbDatePost("0001", null, null, null, dateUnknown:false);
+                    var response = await _subject.HtbDatePost("0001", null, null, null, dateUnknown: false);
                     var responseModel = ControllerTestHelpers.GetViewModelFromResult<TransferDatesViewModel>(response);
 
                     Assert.True(responseModel.FormErrors.HasErrors);

--- a/Frontend/Controllers/Projects/TransferDatesController.cs
+++ b/Frontend/Controllers/Projects/TransferDatesController.cs
@@ -61,20 +61,27 @@ namespace Frontend.Controllers.Projects
 
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
 
+            model.Project.Dates.FirstDiscussed = dateString;
+            model.Project.Dates.HasFirstDiscussedDate = !dateUnknown;
+
+            //TODO move validation from controller to attributes
             if (!string.IsNullOrEmpty(dateString) && !DatesHelper.IsValidDate(dateString))
-            {
+            {              
                 model.FormErrors.AddError("day", "day", "Enter a valid date");
                 return View(model);
             }
             
             if (string.IsNullOrEmpty(dateString) && !dateUnknown)
-            {
+            {                
                 model.FormErrors.AddError("day", "day", "You must enter the date or confirm that you don't know it");
                 return View(model);
             }
 
-            model.Project.Dates.FirstDiscussed = dateUnknown ? null : dateString;
-            model.Project.Dates.HasFirstDiscussedDate = !dateUnknown;
+            if (DatesHelper.IsValidDate(dateString) && dateUnknown)
+            {                
+                model.FormErrors.AddError("day", "day", "You must either enter the date or select 'I do not know this'");
+                return View(model);
+            }
             
             var result = await _projectsRepository.Update(model.Project);
             if (!result.IsValid)
@@ -118,15 +125,16 @@ namespace Frontend.Controllers.Projects
             var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
             
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
-            
+
+            model.Project.Dates.Target = dateString;
+            model.Project.Dates.HasTargetDateForTransfer = !dateUnknown;
+
             if (!string.IsNullOrEmpty(dateString) && !DatesHelper.IsValidDate(dateString))
             {
                 model.FormErrors.AddError("day", "day", "Enter a valid date");
                 return View(model);
             }
-            
-            model.Project.Dates.Target = dateUnknown ? null : dateString;
-            
+
             if (!string.IsNullOrEmpty(model.Project.Dates.Target))
             {
                 if (DatesHelper.SourceDateStringIsGreaterThanToTargetDateString(model.Project.Dates.Htb,
@@ -144,8 +152,12 @@ namespace Frontend.Controllers.Projects
                 return View(model);
             }
 
-            model.Project.Dates.HasTargetDateForTransfer = !dateUnknown;
-            
+            if (DatesHelper.IsValidDate(dateString) && dateUnknown)
+            {
+                model.FormErrors.AddError("day", "day", "You must either enter the date or select 'I do not know this'");
+                return View(model);
+            }
+
             var result = await _projectsRepository.Update(model.Project);
             if (!result.IsValid)
             {
@@ -187,14 +199,15 @@ namespace Frontend.Controllers.Projects
             var model = new TransferDatesViewModel {Project = project.Result, ReturnToPreview = returnToPreview};
 
             var dateString = DatesHelper.DayMonthYearToDateString(day, month, year);
+            
+            model.Project.Dates.Htb = dateString;
+            model.Project.Dates.HasHtbDate = !dateUnknown;
 
             if (!string.IsNullOrEmpty(dateString) && !DatesHelper.IsValidDate(dateString))
             {
                 model.FormErrors.AddError("day", "day", "Enter a valid date");
                 return View(model);
             }
-            
-            model.Project.Dates.Htb = dateUnknown ? null : dateString;
             
             if (!string.IsNullOrEmpty(model.Project.Dates.Htb))
             {
@@ -213,7 +226,11 @@ namespace Frontend.Controllers.Projects
                 return View(model);
             }
 
-            model.Project.Dates.HasHtbDate = !dateUnknown;
+            if (DatesHelper.IsValidDate(dateString) && dateUnknown)
+            {
+                model.FormErrors.AddError("day", "day", "You must either enter the date or select 'I do not know this'");
+                return View(model);
+            }
             
             var result = await _projectsRepository.Update(model.Project);
             if (!result.IsValid)


### PR DESCRIPTION
### Context

**Problem** - On the date data input pages if the user selects `I do not know` and also inputs a date, the date will not be saved, instead the `I do not know` value will be saved to the database.

### Changes proposed in this pull request

- Modified to prevent saving a date and selecting date unknown. New error added to end.
- Existing error message order maintained.
- New unit tests added and existing updated to accommodate this change.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

