### PR TITLE
Improve performance of  "getInformation" pages

### DIFF
--- a/Frontend.Tests/ServicesTests/GetInformationForProjectTests.cs
+++ b/Frontend.Tests/ServicesTests/GetInformationForProjectTests.cs
@@ -4,6 +4,9 @@ using Data.Models;
 using Data.Models.KeyStagePerformance;
 using Data.Models.Projects;
 using Frontend.Services;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -21,6 +24,7 @@ namespace Frontend.Tests.ServicesTests
         private Project _foundProject;
         private Academy _foundAcademy;
         private EducationPerformance _foundEducationPerformance;
+        private Mock<IDistributedCache> _distributedCache;
 
         public GetInformationForProjectTests()
         {
@@ -30,11 +34,13 @@ namespace Frontend.Tests.ServicesTests
             _projectsRepository = new Mock<IProjects>();
             _academiesRepository = new Mock<IAcademies>();
             _educationPerformanceRepository = new Mock<IEducationPerformance>();
+            _distributedCache = new Mock<IDistributedCache>();
 
             _subject = new GetInformationForProject(
                 _academiesRepository.Object, 
                 _projectsRepository.Object, 
-                _educationPerformanceRepository.Object);
+                _educationPerformanceRepository.Object,
+                _distributedCache.Object);
 
             SetupRepositories();
         }
@@ -49,7 +55,8 @@ namespace Frontend.Tests.ServicesTests
                     new TransferringAcademies
                     {
                         OutgoingAcademyUkprn = _academyUkprn, 
-                        OutgoingAcademyUrn = _academyUrn
+                        OutgoingAcademyUrn = _academyUrn,
+                        IncomingTrustName = "incoming trust name"
                     }
                 }
             };
@@ -120,6 +127,7 @@ namespace Frontend.Tests.ServicesTests
         public async void GivenProjectWithMultipleAcademies_LooksUpAcademies()
         {
             const string projectUrn = "TestProject";
+            const string incomingTrustName = "Incoming Trust Name";
             var outgoingAcademy1 = new { ukprn = "A1Ukprn", urn = "A1Urn" };
             var outgoingAcademy2 = new { ukprn = "A2Ukprn", urn = "A2Urn" };
             var outgoingAcademy3 = new { ukprn = "A3Ukprn", urn = "A3Urn" };
@@ -131,17 +139,20 @@ namespace Frontend.Tests.ServicesTests
                     new TransferringAcademies
                     {
                         OutgoingAcademyUkprn = outgoingAcademy1.ukprn,
-                        OutgoingAcademyUrn = outgoingAcademy1.urn
+                        OutgoingAcademyUrn = outgoingAcademy1.urn,
+                        IncomingTrustName = incomingTrustName
                     },
                     new TransferringAcademies
                     {
                         OutgoingAcademyUkprn = outgoingAcademy2.ukprn,
-                        OutgoingAcademyUrn = outgoingAcademy2.urn
+                        OutgoingAcademyUrn = outgoingAcademy2.urn,
+                        IncomingTrustName = incomingTrustName
                     },
                     new TransferringAcademies
                     {
                         OutgoingAcademyUkprn = outgoingAcademy3.ukprn,
-                        OutgoingAcademyUrn = outgoingAcademy3.urn
+                        OutgoingAcademyUrn = outgoingAcademy3.urn,
+                        IncomingTrustName = incomingTrustName
                     }
                 }
             };

--- a/Frontend.Tests/ServicesTests/TaskListServiceTests.cs
+++ b/Frontend.Tests/ServicesTests/TaskListServiceTests.cs
@@ -5,7 +5,9 @@ using Data.Models;
 using Data.Models.KeyStagePerformance;
 using Data.Models.Projects;
 using Data.TRAMS;
+using Frontend.BackgroundServices;
 using Frontend.Services;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using Index = Frontend.Pages.Projects.Index;
@@ -30,7 +32,7 @@ namespace Frontend.Tests.ServicesTests
                 });
 
             _subject = new TaskListService(ProjectRepository.Object);
-            _index = new Index(_subject)
+            _index = new Index(_subject, new PerformanceDataChannel(new Mock<ILogger<PerformanceDataChannel>>().Object))
             {
                 Urn = ProjectUrn0001
             };

--- a/Frontend/BackgroundServices/PerformanceDataChannel.cs
+++ b/Frontend/BackgroundServices/PerformanceDataChannel.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Frontend.BackgroundServices
+{
+    public class PerformanceDataChannel
+    {
+        private const int MaxMessagesInChannel = 100;
+
+        private readonly Channel<string> _channel;
+        private readonly ILogger<PerformanceDataChannel> _logger;
+
+        public PerformanceDataChannel(ILogger<PerformanceDataChannel> logger)
+        {
+            var options = new BoundedChannelOptions(MaxMessagesInChannel)
+            {
+                SingleWriter = false,
+                SingleReader = true                
+            };
+
+            _channel = Channel.CreateBounded<string>(options);
+
+            _logger = logger;
+        }
+        
+        public async Task<bool> AddProjectUrnAsync(string projectUrn, CancellationToken ct = default)
+        {
+            while (await _channel.Writer.WaitToWriteAsync(ct) && !ct.IsCancellationRequested)
+            {
+                if (_channel.Writer.TryWrite(projectUrn))
+                {
+                    Log.ChannelMessageWritten(_logger, projectUrn);
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        
+        public IAsyncEnumerable<string> ReadAllAsync(CancellationToken ct = default) =>
+            _channel.Reader.ReadAllAsync(ct);
+
+        public bool TryCompleteWriter(Exception ex = null) => _channel.Writer.TryComplete(ex);
+        internal static class EventIds
+        {
+            public static readonly EventId ChannelMessageWritten = new EventId(100, "ChannelMessageWritten");
+        }
+        private static class Log
+        {
+            private static readonly Action<ILogger, string, Exception> _channelMessageWritten = LoggerMessage.Define<string>(
+                LogLevel.Information,
+                EventIds.ChannelMessageWritten,
+                "Project Urn {ProjectUrn} was written to the channel.");
+
+            public static void ChannelMessageWritten(ILogger logger, string fileName)
+            {
+                _channelMessageWritten(logger, fileName, null);
+            }
+        }
+    }
+}

--- a/Frontend/BackgroundServices/PerformanceDataProcessingService.cs
+++ b/Frontend/BackgroundServices/PerformanceDataProcessingService.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Frontend.Services.Interfaces;
+using Frontend.Services.Responses;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Frontend.BackgroundServices
+{
+    public class PerformanceDataProcessingService : BackgroundService
+    {
+        private readonly ILogger<PerformanceDataProcessingService> _logger;
+        private readonly PerformanceDataChannel _performanceDataChannel;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IDistributedCache _distributedCache;
+
+        public PerformanceDataProcessingService(ILogger<PerformanceDataProcessingService> logger,
+            PerformanceDataChannel performanceDataChannel, IServiceProvider serviceProvider, IDistributedCache distributedCache)
+        {
+            _logger = logger;
+            _performanceDataChannel = performanceDataChannel;
+            _serviceProvider = serviceProvider;
+            _distributedCache = distributedCache;
+        }
+        
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            await foreach (var projectUrn in _performanceDataChannel.ReadAllAsync())
+            {
+                using var scope = _serviceProvider.CreateScope();
+                var processor = scope.ServiceProvider.GetRequiredService<IGetInformationForProject>();
+                await processor.Execute(projectUrn);
+            }
+        }
+        
+        internal static class EventIds
+        {
+            public static readonly EventId StartedProcessing = new EventId(100, "StartedProcessing");
+            public static readonly EventId ProcessorStopping = new EventId(101, "ProcessorStopping");
+            public static readonly EventId StoppedProcessing = new EventId(102, "StoppedProcessing");
+            public static readonly EventId ProcessedMessage = new EventId(110, "ProcessedMessage");
+        }
+
+        private static class Log
+        {
+            private static readonly Action<ILogger, string, Exception> _processedMessage = LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                EventIds.ProcessedMessage,
+                "Read and processed message with ID '{MessageId}' from the channel.");
+
+            public static void StartedProcessing(ILogger logger) => logger.Log(LogLevel.Trace, EventIds.StartedProcessing, "Started message processing service.");
+
+            public static void ProcessorStopping(ILogger logger) => logger.Log(LogLevel.Information, EventIds.ProcessorStopping, "Message processing stopping due to app termination!");
+
+            public static void StoppedProcessing(ILogger logger) => logger.Log(LogLevel.Trace, EventIds.StoppedProcessing, "Stopped message processing service.");
+
+            public static void ProcessedMessage(ILogger logger, string messageId) => _processedMessage(logger, messageId, null);
+        }
+    }
+}

--- a/Frontend/Pages/Projects/Index.cshtml.cs
+++ b/Frontend/Pages/Projects/Index.cshtml.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Data;
 using Data.Models;
+using Frontend.BackgroundServices;
 using Frontend.Models;
 using Frontend.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +14,7 @@ namespace Frontend.Pages.Projects
     public class Index : CommonPageModel
     {
         private readonly ITaskListService _taskListService;
+        private readonly PerformanceDataChannel _performanceDataChannel;
         public ProjectStatuses FeatureTransferStatus { get; set; }
         public ProjectStatuses TransferDatesStatus { get; set; }
         public ProjectStatuses BenefitsAndOtherFactorsStatus { get; set; }
@@ -21,17 +24,27 @@ namespace Frontend.Pages.Projects
         /// <summary>
         /// Item1 Academy Ukprn, Item2 Academy Name
         /// </summary>
-        public List<Tuple<string,string>> Academies { get; set; }
-        
-        public Index(ITaskListService taskListService)
+        public List<Tuple<string, string>> Academies { get; set; }
+
+        public Index(ITaskListService taskListService, PerformanceDataChannel performanceDataChannel)
         {
             _taskListService = taskListService;
+            _performanceDataChannel = performanceDataChannel;
         }
 
-        public IActionResult OnGet()
+        public async Task<IActionResult> OnGet(CancellationToken cancellationToken)
         {
+            await RetrievePerformanceData(cancellationToken);
+
             _taskListService.BuildTaskListStatuses(this);
             return Page();
+        }
+
+        private async Task RetrievePerformanceData(CancellationToken cancellationToken)
+        {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(30)); // wait max 30 seconds
+            await _performanceDataChannel.AddProjectUrnAsync(Urn, cts.Token);
         }
     }
 }

--- a/Frontend/Services/GetInformationForProject.cs
+++ b/Frontend/Services/GetInformationForProject.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Data;
 using Data.Models;
@@ -7,6 +9,8 @@ using Data.Models.KeyStagePerformance;
 using Data.Models.Projects;
 using Frontend.Services.Interfaces;
 using Frontend.Services.Responses;
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
 
 namespace Frontend.Services
 {
@@ -15,40 +19,62 @@ namespace Frontend.Services
         private readonly IProjects _projectsRepository;
         private readonly IAcademies _academiesRepository;
         private readonly IEducationPerformance _educationPerformanceRepository;
+        private readonly IDistributedCache _distributedCache;
 
         public GetInformationForProject(IAcademies academiesRepository,
-            IProjects projectsRepository, IEducationPerformance educationPerformanceRepository)
+            IProjects projectsRepository, IEducationPerformance educationPerformanceRepository,
+            IDistributedCache distributedCache)
         {
             _academiesRepository = academiesRepository;
             _projectsRepository = projectsRepository;
             _educationPerformanceRepository = educationPerformanceRepository;
+            _distributedCache = distributedCache;
         }
 
         public async Task<GetInformationForProjectResponse> Execute(string projectUrn)
         {
+            var cacheKey = $"GetInformation_{projectUrn}";
+            var cachedString = await _distributedCache.GetStringAsync(cacheKey);
+            //Check for information in cache
+            if (!string.IsNullOrWhiteSpace(cachedString))
+            {
+                return JsonConvert.DeserializeObject<GetInformationForProjectResponse>(cachedString);
+            }
+
             var projectResult = await _projectsRepository.GetByUrn(projectUrn);
-            
+
             var outgoingAcademies = new List<Academy>();
-            
+
             foreach (var transferringAcademy in projectResult.Result.TransferringAcademies)
             {
-                var academyResult = await _academiesRepository.GetAcademyByUkprn(transferringAcademy.OutgoingAcademyUkprn);
+                var academyResult =
+                    await _academiesRepository.GetAcademyByUkprn(transferringAcademy.OutgoingAcademyUkprn);
                 var academy = academyResult.Result;
                 SetAdditionalInformation(academy, transferringAcademy);
-                academy.EducationPerformance = await SetPerformanceData(transferringAcademy, academy.LocalAuthorityName, projectResult.Result.Urn);
+                academy.EducationPerformance = await SetPerformanceData(transferringAcademy, academy.LocalAuthorityName,
+                    projectResult.Result.Urn);
                 outgoingAcademies.Add(academy);
             }
 
-            return new GetInformationForProjectResponse
+            var response = new GetInformationForProjectResponse
             {
                 Project = projectResult.Result,
                 OutgoingAcademies = outgoingAcademies
             };
+            var cacheOptions = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpiration = DateTimeOffset.Now.AddDays(1)
+            };
+            await _distributedCache.SetStringAsync(cacheKey, JsonConvert.SerializeObject(response), cacheOptions);
+
+            return response;
         }
 
-        private async Task<EducationPerformance> SetPerformanceData(TransferringAcademies transferringAcademy, string localAuthorityName, string projectUrn)
+        private async Task<EducationPerformance> SetPerformanceData(TransferringAcademies transferringAcademy,
+            string localAuthorityName, string projectUrn)
         {
-            var educationPerformanceResult = await _educationPerformanceRepository.GetByAcademyUrn(transferringAcademy.OutgoingAcademyUrn);
+            var educationPerformanceResult =
+                await _educationPerformanceRepository.GetByAcademyUrn(transferringAcademy.OutgoingAcademyUrn);
             var performance = educationPerformanceResult.Result;
             performance.KeyStage2AdditionalInformation = transferringAcademy.KeyStage2PerformanceAdditionalInformation;
             performance.KeyStage4AdditionalInformation = transferringAcademy.KeyStage4PerformanceAdditionalInformation;

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Linq;
 using StackExchange.Redis;
 using System;
+using Frontend.BackgroundServices;
 
 
 namespace Frontend
@@ -74,7 +75,7 @@ namespace Frontend
             services.Configure<RouteOptions>(options => { options.LowercaseUrls = true; });
             services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
 
-            ConfigureTramsRepositories(services, Configuration);
+            AddServices(services, Configuration);
 
             ConfigureServiceClasses(services);
 
@@ -189,7 +190,7 @@ namespace Frontend
             });
         }
 
-        private static void ConfigureTramsRepositories(IServiceCollection services, IConfiguration configuration)
+        private static void AddServices(IServiceCollection services, IConfiguration configuration)
         {
             var tramsApiBase = configuration["TRAMS_API_BASE"];
             var tramsApiKey = configuration["TRAMS_API_KEY"];
@@ -208,6 +209,8 @@ namespace Frontend
             
             services.AddSingleton(new TramsHttpClient(tramsApiBase, tramsApiKey));
             services.AddSingleton<ITramsHttpClient>(r => new TramsHttpClient(tramsApiBase, tramsApiKey));
+            services.AddSingleton<PerformanceDataChannel>();
+            services.AddHostedService<PerformanceDataProcessingService>();
         }
 
         private static void ConfigureServiceClasses(IServiceCollection serviceCollection)


### PR DESCRIPTION
### Context
Improve performance of  "getInformation" pages

### Changes proposed in this pull request
Send Project urn to channel on tasklist load
Retrieve the performance data for each project in the background
Store for one day in cache

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally

