### PR TITLE
Feature 85762 - Check session is still valid before creating project

### DIFF
--- a/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
+++ b/Frontend.Tests/ControllerTests/TransfersControllerTests.cs
@@ -42,7 +42,7 @@ namespace Frontend.Tests.ControllerTests
                 new TempDataDictionaryFactory(tempDataProvider.Object);
             var tempData = tempDataDictionaryFactory.GetTempData(httpContext);
 
-            _subject = new TransfersController(_academiesRepository.Object, _projectsRepository.Object,
+            _subject = new TransfersController(_projectsRepository.Object,
                 _trustsRepository.Object, referenceNumberService.Object) {TempData = tempData, ControllerContext = {HttpContext = httpContext}};
         }
 

--- a/Frontend/Controllers/TransfersController.cs
+++ b/Frontend/Controllers/TransfersController.cs
@@ -10,7 +10,6 @@ using Frontend.Views.Transfers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Sentry;
 using Session = Frontend.Helpers.Session;
 
 namespace Frontend.Controllers
@@ -21,16 +20,14 @@ namespace Frontend.Controllers
         private const string OutgoingAcademyIdSessionKey = "OutgoingAcademyIds";
         private const string IncomingTrustIdSessionKey = "IncomingTrustId";
         private const string OutgoingTrustIdSessionKey = "OutgoingTrustId";
-        private readonly IAcademies _academiesRepository;
+        private const string ProjectCreatedSessionKey = "ProjectCreated";
         private readonly IProjects _projectsRepository;
         private readonly ITrusts _trustsRepository;
         private readonly IReferenceNumberService _referenceNumberService;
 
-
-        public TransfersController(IAcademies academiesRepository, IProjects projectsRepository,
+        public TransfersController(IProjects projectsRepository,
             ITrusts trustsRepository, IReferenceNumberService referenceNumberService)
         {
-            _academiesRepository = academiesRepository;
             _projectsRepository = projectsRepository;
             _trustsRepository = trustsRepository;
             _referenceNumberService = referenceNumberService;
@@ -150,7 +147,7 @@ namespace Frontend.Controllers
                 TempData["ErrorMessage"] = validationResult.Errors.First().ErrorMessage;
                 return RedirectToAction("OutgoingTrustAcademies");
             }
-            
+
             var academyIdsString = string.Join(",", academyIds.Select(id => id.ToString()).ToList());
             HttpContext.Session.SetString(OutgoingAcademyIdSessionKey, academyIdsString);
 
@@ -253,12 +250,25 @@ namespace Frontend.Controllers
             return View(model);
         }
 
+        [HttpPost]
         public async Task<IActionResult> SubmitProject()
         {
             var outgoingTrustId = HttpContext.Session.GetString(OutgoingTrustIdSessionKey);
             var incomingTrustId = HttpContext.Session.GetString(IncomingTrustIdSessionKey);
             var academyIds = Session.GetStringListFromSession(HttpContext.Session, OutgoingAcademyIdSessionKey);
-
+            
+            //Redirect any duplicate requests (Session has been cleared)
+            if (string.IsNullOrWhiteSpace(outgoingTrustId) || string.IsNullOrWhiteSpace(incomingTrustId) ||
+                !academyIds.Any())
+            {
+                var urnCreated = HttpContext.Session.GetString(ProjectCreatedSessionKey);
+                return !string.IsNullOrWhiteSpace(urnCreated)
+                    ? RedirectToPage($"/Projects/{nameof(Pages.Projects.Index)}", new
+                    {
+                        urn = urnCreated
+                    })
+                    : throw new Exception("Cannot create project");
+            }
 
             var project = new Project
             {
@@ -271,15 +281,20 @@ namespace Frontend.Controllers
             };
 
             var createResponse = await _projectsRepository.Create(project);
+            HttpContext.Session.SetString(ProjectCreatedSessionKey, createResponse.Result.Urn);
 
-            createResponse.Result.Reference = _referenceNumberService.GenerateReferenceNumber(createResponse.Result);
+            createResponse.Result.Reference =
+                _referenceNumberService.GenerateReferenceNumber(createResponse.Result);
             await _projectsRepository.Update(createResponse.Result);
-            
+
             HttpContext.Session.Remove(OutgoingTrustIdSessionKey);
             HttpContext.Session.Remove(IncomingTrustIdSessionKey);
             HttpContext.Session.Remove(OutgoingAcademyIdSessionKey);
 
-            return RedirectToPage($"/Projects/{nameof(Pages.Projects.Index)}", new {urn = createResponse.Result.Urn});
+            return RedirectToPage($"/Projects/{nameof(Pages.Projects.Index)}", new
+            {
+                urn = createResponse.Result.Urn
+            });
         }
     }
 }

--- a/Frontend/Helpers/Session.cs
+++ b/Frontend/Helpers/Session.cs
@@ -15,7 +15,9 @@ namespace Frontend.Helpers
         public static List<string> GetStringListFromSession(ISession session, string key)
         {
             var sessionString = session.GetString(key);
-            return sessionString?.Split(",").ToList();
+            return sessionString == null 
+                ? new List<string>() 
+                : sessionString.Split(",").ToList();
         }
     }
 }

--- a/Frontend/Helpers/Session.cs
+++ b/Frontend/Helpers/Session.cs
@@ -15,7 +15,7 @@ namespace Frontend.Helpers
         public static List<string> GetStringListFromSession(ISession session, string key)
         {
             var sessionString = session.GetString(key);
-            return sessionString.Split(",").ToList();
+            return sessionString?.Split(",").ToList();
         }
     }
 }

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -82,7 +82,7 @@ namespace Frontend
 
             services.AddSession(options =>
             {
-                options.IdleTimeout = TimeSpan.FromMinutes(30);
+                options.IdleTimeout = TimeSpan.FromMinutes(60);
                 options.Cookie.Name = ".ManageAnAcademyTransfer.Session";
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;

--- a/Frontend/Views/Transfers/CheckYourAnswers.cshtml
+++ b/Frontend/Views/Transfers/CheckYourAnswers.cshtml
@@ -119,7 +119,7 @@
                 <dd class="govuk-summary-list__actions"></dd>
             </div>
         </dl>
-        <form method="get" asp-action="SubmitProject">
+        <form method="post" asp-action="SubmitProject">
             <button type="submit" data-module="govuk-button" data-prevent-double-click="true" class="govuk-button govuk-button-primary" data-test="create-project">Continue</button>
         </form>
     </div>


### PR DESCRIPTION
### Context
If more than double clicks are sent the session values can be null

### Changes proposed in this pull request
Handle session null values gracefully

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

