### PR TITLE
Use single row for layout

### DIFF
--- a/Frontend/Pages/TaskList/HtbDocument/Preview.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/Preview.cshtml
@@ -24,16 +24,13 @@
         </h1>
         <hr class="govuk-section-break govuk-section-break--l">
     </div>
-</div>
-
-<div class="govuk-grid-row">
+    
     <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
         <h2 class="govuk-heading-l">
             Transfer details
         </h2>
     </div>
-</div>
-<div class="govuk-grid-row">
+
     <div class="govuk-grid-column-full">
         <section class="app-summary-card govuk-!-margin-bottom-7">
             <header class="app-summary-card__header">
@@ -171,9 +168,7 @@
             }
         }
     </div>
-</div>
-
-<div class="govuk-grid-row">
+    
     <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">
             Generate project template


### PR DESCRIPTION
### Context
On the preview page, we can take advantage of column wrapping in order to simplify the layout and reduce the number of `govuk-grid-row` wrappers.

### Changes proposed in this pull request
- Use single row for layout on the preview page

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

