### PR TITLE
Make sure TRAMS test project runs in Visual Studio

### DIFF
--- a/Data.TRAMS.Tests/Data.TRAMS.Tests.csproj
+++ b/Data.TRAMS.Tests/Data.TRAMS.Tests.csproj
@@ -14,6 +14,10 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Moq" Version="4.17.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Context
We need the `xunit.runner.visualstudio` package to run tests in Visual Studio. We've already included it in most of the test projects, but it's missing in the TRAMS tests.

### Changes proposed in this pull request
- Make sure TRAMS test project runs in Visual Studio

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

