### PR TITLE
Add custom Google Tag Manager event when project template downloaded AB#90214

### DIFF
--- a/Frontend/Helpers/TagHelpers/ProjectStatusTagHelper.cs
+++ b/Frontend/Helpers/TagHelpers/ProjectStatusTagHelper.cs
@@ -21,9 +21,12 @@ namespace Frontend.Helpers.TagHelpers
                     tagColourClass = "govuk-tag--blue";
                     break;
             }
-            
+
+            var section = context.AllAttributes["id"].Value;
+
             output.Attributes.SetAttribute("class", $"govuk-tag {tagColourClass} moj-task-list__tag");
-            output.Attributes.SetAttribute("data-test", context.AllAttributes["id"].Value.ToString());
+            output.Attributes.SetAttribute("data-test", section);
+            output.Attributes.SetAttribute($"data-google-analytics-project-status", $"{section},{Status == ProjectStatuses.Completed}".ToLower());
             output.TagName = "strong";
             output.Content.SetContent(EnumHelpers<ProjectStatuses>.GetDisplayValue(Status));
             base.Process(context, output);

--- a/Frontend/Pages/Projects/Index.cshtml
+++ b/Frontend/Pages/Projects/Index.cshtml
@@ -92,9 +92,11 @@
                 <button class="govuk-button" data-module="govuk-button" data-test="preview-htb">Preview project template</button>
             </form>
             <form asp-page="/TaskList/HtbDocument/Download" asp-route-urn="@Model.Urn" method="get">
-                <button class="govuk-button govuk-button--secondary" data-module="govuk-button" data-test="generate-htb">Generate project template</button>
+                <button class="govuk-button govuk-button--secondary" data-module="govuk-button" data-test="generate-htb" data-google-analytics-project-generate>Generate project template</button>
             </form>
 
         </div>
     </div>
 </div>
+
+<script src="~/dist/google-analytics-events.bundle.js" asp-add-nonce></script>

--- a/Frontend/wwwroot/src/js/google-analytics-events.js
+++ b/Frontend/wwwroot/src/js/google-analytics-events.js
@@ -1,0 +1,27 @@
+﻿const statusAttributeName = "data-google-analytics-project-status";
+const generateButtonAttributeName = "data-google-analytics-project-generate";
+
+function initialise() {
+  const eventBody = { 'event': "project-template-downloaded" };
+
+  const statuses = document.querySelectorAll(`[${statusAttributeName}]`);
+
+  statuses.forEach((status) => {
+    const attributeValue = status.getAttribute(statusAttributeName);
+    const [statusName, completed] = attributeValue.split(",");
+    // Easiest way to convert string to Boolean in JS.
+    eventBody[statusName] = completed === "true";
+  });
+
+  const generateButton = document.querySelectorAll(
+    `[${generateButtonAttributeName}]`
+  )[0];
+
+  // Using the click event because the button performs a GET request
+  generateButton.addEventListener("click", () => {
+    const dataLayer = window.dataLayer = window.dataLayer || [];
+    dataLayer.push(eventBody);
+  });
+}
+
+initialise();

--- a/Frontend/wwwroot/webpack.config.js
+++ b/Frontend/wwwroot/webpack.config.js
@@ -3,8 +3,11 @@ var path = require('path');
 
 module.exports = {
     mode: 'production',
-    entry: ['./src/js/site.js', './src/css/site.scss'],
-    plugins: [new MiniCssExtractPlugin({filename: 'site.css'})],
+    entry: {
+        main: ['./src/js/site.js', './src/css/site.scss'],
+        'google-analytics-events': './src/js/google-analytics-events.js',
+    },
+    plugins: [new MiniCssExtractPlugin({ filename: 'site.css' })],
     module: {
         rules: [
             {
@@ -18,13 +21,13 @@ module.exports = {
                     "sass-loader",
                 ],
             },
-            {test: /\.css$/, use: ['style-loader', 'css-loader']},
-            {test: /\.(jpe?g|png|gif|svg)$/i, use: 'file-loader'},
-            {test: /\.(woff2?)$/i, use: 'file-loader'}
+            { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+            { test: /\.(jpe?g|png|gif|svg)$/i, use: 'file-loader' },
+            { test: /\.(woff2?)$/i, use: 'file-loader' }
         ]
     },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'index.bundle.js',
+        filename: "[name].bundle.js",
     }
 };


### PR DESCRIPTION
### Context
Spike. We want to know which sections have been completed when the project template is downloaded. This isn't captured by GTM out-of-the-box, so we need to add a custom event.

### Changes proposed in this pull request
Add custom Google Tag Manager event when project template downloaded: Add data attributes to the section statuses and generate button in order to build and dispatch the custom event. This also reconfigures Webpack so that we can add multiple JavaScript files.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

