### PR TITLE
Fix src for main Webpack bundle

### DIFF
--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -140,6 +140,6 @@
     </div>
 </footer>
 
-<script src="~/dist/index.bundle.js" asp-add-nonce></script>
+<script src="~/dist/main.bundle.js" asp-add-nonce></script>
 </body>
 </html>


### PR DESCRIPTION
### Context
The Webpack configuration was updated in the previous PR, using the `main` key for `site.js`.

I forgot to update the src of the script in the main layout file.

### Changes proposed in this pull request
- Fix src for main Webpack bundle

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

