### PR TITLE
Gov frontend 4

### DIFF
--- a/Frontend.Tests/HelpersTests/TagHelperTests/GdsKeyValueTagHelperTests.cs
+++ b/Frontend.Tests/HelpersTests/TagHelperTests/GdsKeyValueTagHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Frontend.Helpers.TagHelpers;
@@ -30,26 +31,26 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
                     return Task.FromResult(helperContent);
                 });
         }
-        
+
         [Fact]
         public void GivenKeyValues_RenderSummaryListRow()
         {
             var tagHelper = new GdsKeyValueTagHelper(HtmlEncoder.Default)
             {
-               Key = "My Key",
-               Value = "My Value"
+                Key = "My Key",
+                Value = "My Value"
             };
 
             tagHelper.Process(_tagHelperContext, _tagHelperOutput);
-            
+
             var expectedContent =
                 "<dt class=\"govuk-summary-list__key\">My Key</dt><dd class=\"govuk-summary-list__value dfe-summary-list__value--width-50\">My Value</dd>";
-            
+
             Assert.Equal("div", _tagHelperOutput.TagName);
             Assert.Equal("govuk-summary-list__row", _tagHelperOutput.Attributes["class"].Value);
-            Assert.Equal(expectedContent,_tagHelperOutput.Content.GetContent());
+            Assert.Equal(expectedContent, _tagHelperOutput.Content.GetContent());
         }
-        
+
         [Fact]
         public void GivenKeyValuesWithHtml_RenderSummaryListRowWithHtml()
         {
@@ -60,17 +61,17 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
             };
 
             tagHelper.Process(_tagHelperContext, _tagHelperOutput);
-            
+
             var expectedContent =
                 "<dt class=\"govuk-summary-list__key\">My Key</dt><dd class=\"govuk-summary-list__value dfe-summary-list__value--width-50\"><a>test</a></dd>";
-            
+
             Assert.Equal("div", _tagHelperOutput.TagName);
             Assert.Equal("govuk-summary-list__row", _tagHelperOutput.Attributes["class"].Value);
-            Assert.Equal(expectedContent,_tagHelperOutput.Content.GetContent());
+            Assert.Equal(expectedContent, _tagHelperOutput.Content.GetContent());
         }
-        
+
         [Fact]
-        public void GivenShowAction_RenderSummaryListRowWithBlankAction()
+        public void GivenShowAction_AddsNoActionClassToSummaryListRow()
         {
             var tagHelper = new GdsKeyValueTagHelper(HtmlEncoder.Default)
             {
@@ -80,10 +81,11 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
             };
 
             tagHelper.Process(_tagHelperContext, _tagHelperOutput);
-            
-            Assert.Contains("<dd class=\"govuk-summary-list__actions\"></dd>",_tagHelperOutput.Content.GetContent());
+
+            _tagHelperOutput.Attributes.TryGetAttributes("class", out IReadOnlyList<TagHelperAttribute> attributes);
+            Assert.Equal("govuk-summary-list__row govuk-summary-list__row--no-actions", attributes.First().Value.ToString());
         }
-        
+
         [Fact]
         public void GivenShowActionFalse_DoNotRenderBlankAction()
         {
@@ -94,8 +96,8 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
             };
 
             tagHelper.Process(_tagHelperContext, _tagHelperOutput);
-            
-            Assert.DoesNotContain("<dd class=\"govuk-summary-list__actions\"></dd>",_tagHelperOutput.Content.GetContent());
+
+            Assert.DoesNotContain("<dd class=\"govuk-summary-list__actions\"></dd>", _tagHelperOutput.Content.GetContent());
         }
     }
 }

--- a/Frontend.Tests/HelpersTests/TagHelperTests/GdsValidationSummaryTagHelperTests.cs
+++ b/Frontend.Tests/HelpersTests/TagHelperTests/GdsValidationSummaryTagHelperTests.cs
@@ -109,7 +109,7 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
                 var expectedOutput = 
                     "<div class='govuk-grid-row'>" +
                         "<div class='govuk-grid-column-full'>" +
-                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' tabindex='-1' " +
+                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' " +
                                 "data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>" +
                                 "<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>There is a problem" +
                                 "</h2>" +
@@ -162,7 +162,7 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
                 var expectedOutput = 
                     "<div class='govuk-grid-row'>" +
                         "<div class='govuk-grid-column-full'>" +
-                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' tabindex='-1' " +
+                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' " +
                                 "data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>" +
                                 "<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>There is a problem" +
                                 "</h2>" +

--- a/Frontend/Helpers/TagHelpers/GdsKeyValueTagHelper.cs
+++ b/Frontend/Helpers/TagHelpers/GdsKeyValueTagHelper.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
+﻿using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
@@ -31,6 +26,10 @@ namespace Frontend.Helpers.TagHelpers
             output.TagMode = TagMode.StartTagAndEndTag;
             output.TagName = "div";
             output.AddClass("govuk-summary-list__row", _htmlEncoder);
+            if (ShowAction)
+            {
+                output.AddClass("govuk-summary-list__row--no-actions", _htmlEncoder);
+            }
 
             var dt = new TagBuilder("dt");
             dt.AddCssClass("govuk-summary-list__key");
@@ -49,14 +48,6 @@ namespace Frontend.Helpers.TagHelpers
             output.Content.AppendHtml(dd.RenderStartTag());
             output.Content.AppendHtml(dd.RenderBody());
             output.Content.AppendHtml(dd.RenderEndTag());
-
-            if (ShowAction)
-            {
-                var ddAction = new TagBuilder("dd");
-                ddAction.AddCssClass("govuk-summary-list__actions");
-                output.Content.AppendHtml(ddAction.RenderStartTag());
-                output.Content.AppendHtml(ddAction.RenderEndTag());
-            }
         }
     }
 }

--- a/Frontend/Helpers/TagHelpers/GdsValidationForTagHelper.cs
+++ b/Frontend/Helpers/TagHelpers/GdsValidationForTagHelper.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Frontend.Helpers.TagHelpers
 {
-    [HtmlTargetElement("span", Attributes = GdsValidationForAttributeName)]
+    [HtmlTargetElement("p", Attributes = GdsValidationForAttributeName)]
     public class GdsValidationForTagHelper : TagHelper
     {
         private const string GdsValidationForAttributeName = "asp-gds-validation-for";
@@ -30,7 +30,7 @@ namespace Frontend.Helpers.TagHelpers
             ViewContext.ViewData.ModelState.TryGetValue(For.Name, out var modelStateEntry);
             if (modelStateEntry != null && modelStateEntry.Errors.Count > 0)
             {
-                var builder = new TagBuilder("span");
+                var builder = new TagBuilder("p");
                 builder.Attributes.Add("id", For.Name+"-error");
                 builder.AddCssClass("govuk-error-message");
                 output.MergeAttributes(builder);

--- a/Frontend/Helpers/TagHelpers/GdsValidationSummaryTagHelper.cs
+++ b/Frontend/Helpers/TagHelpers/GdsValidationSummaryTagHelper.cs
@@ -36,7 +36,7 @@ namespace Frontend.Helpers.TagHelpers
             var sb = new StringBuilder();
             sb.Append("<div class='govuk-grid-row'>");
             sb.Append("<div class='govuk-grid-column-full'>");
-            sb.Append("<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' tabindex='-1' data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>");
+            sb.Append("<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>");
             sb.Append("<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>");
             sb.Append("There is a problem");
             sb.Append("</h2>");

--- a/Frontend/Pages/Projects/BenefitsAndRisks/IntendedBenefits.cshtml
+++ b/Frontend/Pages/Projects/BenefitsAndRisks/IntendedBenefits.cshtml
@@ -40,7 +40,7 @@
                         Select all that apply.
                     </div>
 
-                    <span asp-gds-validation-for="IntendedBenefitsViewModel.SelectedIntendedBenefits"></span>
+                    <p asp-gds-validation-for="IntendedBenefitsViewModel.SelectedIntendedBenefits"></p>
 
                     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
 
@@ -62,7 +62,7 @@
                                     Enter the benefit
                                 </label>
 
-                                <span asp-gds-validation-for="IntendedBenefitsViewModel.OtherBenefit"></span>
+                                <p asp-gds-validation-for="IntendedBenefitsViewModel.OtherBenefit"></p>
 
                                 <input class="govuk-input govuk-!-width-two-thirds" asp-for="IntendedBenefitsViewModel.OtherBenefit">
                             </div>

--- a/Frontend/Pages/Projects/BenefitsAndRisks/Risks.cshtml
+++ b/Frontend/Pages/Projects/BenefitsAndRisks/Risks.cshtml
@@ -34,7 +34,7 @@
                         </h1>
                     </legend>
 
-                    <span asp-gds-validation-for="RisksViewModel.RisksInvolved"></span>
+                    <p asp-gds-validation-for="RisksViewModel.RisksInvolved"></p>
                     <partial for="RadioButtonsYesNo" name="Shared/_InlineRadioButtons"/>
                     
                 </fieldset>

--- a/Frontend/Pages/Projects/Features/Initiated.cshtml
+++ b/Frontend/Pages/Projects/Features/Initiated.cshtml
@@ -35,7 +35,7 @@
                         </h1>
                     </legend>
 
-                    <span asp-gds-validation-for="FeaturesInitiatedViewModel.WhoInitiated"></span>
+                    <p asp-gds-validation-for="FeaturesInitiatedViewModel.WhoInitiated"></p>
 
                     @await Html.PartialAsync("_RadioButtons", Initiated.InitiatedRadioButtons(Model.FeaturesInitiatedViewModel.WhoInitiated))
                 </fieldset>

--- a/Frontend/Pages/Projects/Features/Reason.cshtml
+++ b/Frontend/Pages/Projects/Features/Reason.cshtml
@@ -34,7 +34,7 @@
                         Has this transfer started because of an intervention with the academy or trust?
                     </legend>
 
-                    <span asp-gds-validation-for="FeaturesReasonViewModel.IsSubjectToIntervention"></span>
+                    <p asp-gds-validation-for="FeaturesReasonViewModel.IsSubjectToIntervention"></p>
 
                     @await Html.PartialAsync("_InlineRadioButtons", Model.ReasonRadioButtons())
                 </fieldset>

--- a/Frontend/Pages/Projects/Features/Type.cshtml
+++ b/Frontend/Pages/Projects/Features/Type.cshtml
@@ -40,7 +40,7 @@
                         </h1>
                     </legend>
 
-                    <span asp-gds-validation-for="FeaturesTypeViewModel.TypeOfTransfer"></span>
+                    <p asp-gds-validation-for="FeaturesTypeViewModel.TypeOfTransfer"></p>
 
                     <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
                         @await Html.PartialAsync("_RadioButtons", Model.TypeOfTransferRadioButtons())
@@ -57,7 +57,7 @@
                                     Enter the type of transfer
                                 </label>
 
-                                <span asp-gds-validation-for="FeaturesTypeViewModel.OtherType"></span>
+                                <p asp-gds-validation-for="FeaturesTypeViewModel.OtherType"></p>
 
                                 <input class="govuk-input govuk-!-width-two-thirds" name='@($"{nameof(Model.FeaturesTypeViewModel)}.{nameof(Model.FeaturesTypeViewModel.OtherType)}")' asp-for="FeaturesTypeViewModel.OtherType">
                             </div>

--- a/Frontend/Pages/Projects/Rationale/Project.cshtml
+++ b/Frontend/Pages/Projects/Rationale/Project.cshtml
@@ -38,7 +38,7 @@
                     You can format this section after you download your project template.
                 </div>
 
-                <span asp-gds-validation-for="ViewModel.ProjectRationale"></span>
+                <p asp-gds-validation-for="ViewModel.ProjectRationale"></p>
                 
                 <textarea asp-for="ViewModel.ProjectRationale" class="govuk-textarea" rows="20" aria-describedby="rationale-hint" data-test="project-rationale"></textarea>
             </div>

--- a/Frontend/Pages/Projects/Rationale/TrustOrSponsor.cshtml
+++ b/Frontend/Pages/Projects/Rationale/TrustOrSponsor.cshtml
@@ -38,7 +38,7 @@
                     You can format this section after you download your project template.
                 </div>
 
-                <span asp-gds-validation-for="ViewModel.TrustOrSponsorRationale"></span>
+                <p asp-gds-validation-for="ViewModel.TrustOrSponsorRationale"></p>
 
                 <textarea asp-for="ViewModel.TrustOrSponsorRationale" class="govuk-textarea" rows="20" aria-describedby="rationale-hint" data-test="trust-rationale"></textarea>
             </div>

--- a/Frontend/Pages/Projects/TransferDates/AdvisoryBoard.cshtml
+++ b/Frontend/Pages/Projects/TransferDates/AdvisoryBoard.cshtml
@@ -39,7 +39,7 @@
                         For example, 12 11 2021. You can change this date later.
                     </div>
 
-                   <span asp-gds-validation-for="AdvisoryBoardViewModel.AdvisoryBoardDate.Date.Day"></span>
+                   <p asp-gds-validation-for="AdvisoryBoardViewModel.AdvisoryBoardDate.Date.Day"></p>
 
                     <div class="govuk-date-input" id="ab-date">
                         <div class="govuk-date-input__item">

--- a/Frontend/Pages/Projects/TransferDates/FirstDiscussed.cshtml
+++ b/Frontend/Pages/Projects/TransferDates/FirstDiscussed.cshtml
@@ -42,7 +42,7 @@
                         For example, 23 03 2007
                     </div>
 
-                    <span asp-gds-validation-for="FirstDiscussedViewModel.FirstDiscussed.Date.Day"></span>
+                    <p asp-gds-validation-for="FirstDiscussedViewModel.FirstDiscussed.Date.Day"></p>
 
                     <div class="govuk-date-input" id="transfer-first-discussed-date">
                         <div class="govuk-date-input__item">

--- a/Frontend/Pages/Projects/TransferDates/Target.cshtml
+++ b/Frontend/Pages/Projects/TransferDates/Target.cshtml
@@ -39,7 +39,7 @@
                         For example, 23 03 2007
                     </div>
 
-                    <span asp-gds-validation-for="TargetDateViewModel.TargetDate.Date.Day"></span>
+                    <p asp-gds-validation-for="TargetDateViewModel.TargetDate.Date.Day"></p>
 
                     <div class="govuk-date-input" id="transfer-first-discussed-date">
                         <div class="govuk-date-input__item">

--- a/Frontend/Pages/Shared/_AcademyAndTrustSummary.cshtml
+++ b/Frontend/Pages/Shared/_AcademyAndTrustSummary.cshtml
@@ -44,40 +44,36 @@
             </a>
         </dd>
     </div>
-    <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
         <dt class="govuk-summary-list__key">
             Advisory Board
         </dt>
         <dd class="govuk-summary-list__value ">
             <displaynodataforemptystring>@DatesHelper.DateStringToGovUkDate(Model.AdvisoryBoardDate)</displaynodataforemptystring>
         </dd>
-        <dd class="govuk-summary-list__value "/>
     </div>
-    <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
         <dt class="govuk-summary-list__key">
             Project name
         </dt>
         <dd class="govuk-summary-list__value ">
             <displaynodataforemptystring>@Model.IncomingTrustName</displaynodataforemptystring>
         </dd>
-        <dd class="govuk-summary-list__value "/>
     </div>
-    <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
         <dt class="govuk-summary-list__key">
             Proposed academy transfer
         </dt>
         <dd class="govuk-summary-list__value ">
             <displaynodataforemptystring>@DatesHelper.DateStringToGovUkDate(Model.TargetDate)</displaynodataforemptystring>
         </dd>
-        <dd class="govuk-summary-list__value "/>
     </div>
-    <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
         <dt class="govuk-summary-list__key">
             Date the transfer was discussed with outgoing trust
         </dt>
         <dd class="govuk-summary-list__value ">
             <displaynodataforemptystring>@DatesHelper.DateStringToGovUkDate(Model.FirstDiscussedDate)</displaynodataforemptystring>
         </dd>
-        <dd class="govuk-summary-list__value "/>
     </div>
 </dl>

--- a/Frontend/Pages/Transfers/CheckYourAnswers.cshtml
+++ b/Frontend/Pages/Transfers/CheckYourAnswers.cshtml
@@ -25,10 +25,9 @@
                     </a>
                 </dd>
             </div>
-            <div class="govuk-summary-list__row">
+            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                 <dt class="govuk-summary-list__key">UKPRN</dt>
                 <dd class="govuk-summary-list__value">@Model.OutgoingTrust.Ukprn</dd>
-                <dd class="govuk-summary-list__actions"></dd>
             </div>
         </dl>
         @foreach (var academy in Model.OutgoingAcademies)
@@ -42,47 +41,41 @@
                         <a class="govuk-link" asp-page="/Transfers/OutgoingTrustAcademies" asp-route-change="true">Change <span class="govuk-visually-hidden"> Academy</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                     <dt class="govuk-summary-list__key">URN</dt>
                     <dd class="govuk-summary-list__value">@academy.Urn</dd>
-                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
-                <div class="govuk-summary-list__row">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                     <dt class="govuk-summary-list__key">Local Authority</dt>
                     <dd class="govuk-summary-list__value">
                         <displaynodataforemptystring>@academy.LocalAuthorityName</displaynodataforemptystring>
                     </dd>
-                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
-                <div class="govuk-summary-list__row">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                     <dt class="govuk-summary-list__key">School type</dt>
                     <dd class="govuk-summary-list__value">
                         <displaynodataforemptystring>@academy.EstablishmentType</displaynodataforemptystring>
                     </dd>
-                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
-                <div class="govuk-summary-list__row">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                     <dt class="govuk-summary-list__key">Faith School</dt>
                     <dd class="govuk-summary-list__value">
                         <displaynodataforemptystring>@academy.FaithSchool</displaynodataforemptystring>
                     </dd>
-                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
-                <div class="govuk-summary-list__row">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                     <dt class="govuk-summary-list__key">Ofsted Rating</dt>
                     <dd class="govuk-summary-list__value">
                         <displaynodataforemptystring>@academy.LatestOfstedJudgement.OverallEffectiveness</displaynodataforemptystring>
                     </dd>
-                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
-                <div class="govuk-summary-list__row">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                     <dt class="govuk-summary-list__key">Last inspection</dt>
                     <dd class="govuk-summary-list__value">
                         <displaynodataforemptystring>@DatesHelper.DateStringToGovUkDate(academy.LatestOfstedJudgement.InspectionDate)</displaynodataforemptystring>
                     </dd>
-                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
-                <div class="govuk-summary-list__row">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                     <dt class="govuk-summary-list__key">PFI (private finance initiative)</dt>
                     @if (string.IsNullOrEmpty(academy.Pfi))
                     {
@@ -92,7 +85,6 @@
                     {
                         <dd class="govuk-summary-list__value">@academy.Pfi</dd>
                     }
-                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
             </dl>
         }
@@ -112,10 +104,9 @@
                     <a class="govuk-link" asp-page="/Transfers/IncomingTrust" asp-route-change="true">Change <span class="govuk-visually-hidden"> incoming trust</span></a>
                 </dd>
             </div>
-            <div class="govuk-summary-list__row">
+            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
                 <dt class="govuk-summary-list__key">UKPRN</dt>
                 <dd class="govuk-summary-list__value">@Model.IncomingTrust?.Ukprn</dd>
-                <dd class="govuk-summary-list__actions"></dd>
             </div>
         </dl>
         <form method="post">

--- a/Frontend/Pages/Transfers/IncomingTrust.cshtml
+++ b/Frontend/Pages/Transfers/IncomingTrust.cshtml
@@ -29,7 +29,7 @@
                         <h1 class="govuk-fieldset__heading">What is the incoming trust name?</h1>
                     </legend>
 
-                    <span asp-gds-validation-for="SearchQuery"></span>
+                    <p asp-gds-validation-for="SearchQuery"></p>
 
                     <div id="query-hint" class="govuk-hint">
                         Search by name, trust reference number or companies house number

--- a/Frontend/Pages/Transfers/OutgoingTrustAcademies.cshtml
+++ b/Frontend/Pages/Transfers/OutgoingTrustAcademies.cshtml
@@ -33,7 +33,7 @@
                         </h1>
                     </legend>
 
-                    <span asp-gds-validation-for="Academies"></span>
+                    <p asp-gds-validation-for="Academies"></p>
 
                     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                         @foreach (var academy in Model.Academies)

--- a/Frontend/Pages/Transfers/SearchIncomingTrust.cshtml
+++ b/Frontend/Pages/Transfers/SearchIncomingTrust.cshtml
@@ -27,7 +27,7 @@
                         </h1>
                     </legend>
 
-                    <span asp-gds-validation-for="Trusts"></span>
+                    <p asp-gds-validation-for="Trusts"></p>
 
                     <div class="govuk-radios">
                         @foreach (var trust in Model.Trusts)

--- a/Frontend/Pages/Transfers/TrustName.cshtml
+++ b/Frontend/Pages/Transfers/TrustName.cshtml
@@ -31,7 +31,7 @@
                     </label>
                 </h1>
 
-                <span asp-gds-validation-for="SearchQuery"></span>
+                <p asp-gds-validation-for="SearchQuery"></p>
 
                 <div id="query-hint" class="govuk-hint">
                     Search by name, UKPRN or Companies House number

--- a/Frontend/Pages/Transfers/TrustSearch.cshtml
+++ b/Frontend/Pages/Transfers/TrustSearch.cshtml
@@ -27,7 +27,7 @@
                         </h1>
                     </legend>
 
-                     <span asp-gds-validation-for="Trusts"></span>
+                     <p asp-gds-validation-for="Trusts"></p>
 
                     <div class="govuk-radios">
                         @foreach (var trust in Model.Trusts)

--- a/Frontend/Views/Shared/_FormErrorSummary.cshtml
+++ b/Frontend/Views/Shared/_FormErrorSummary.cshtml
@@ -3,7 +3,7 @@
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
                 <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
                     There is a problem
                 </h2>

--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -52,7 +52,7 @@
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
 
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+<a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
 <header class="govuk-header " role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">

--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -92,7 +92,7 @@
 <footer class="govuk-footer " role="contentinfo">
     <div class="govuk-width-container ">
         <div class="govuk-footer__navigation">
-            <div class="govuk-footer__section">
+            <div class="govuk-footer__section govuk-grid-column-one-half">
                 <h2 class="govuk-footer__heading govuk-heading-m">Get support</h2>
                 <ul class="govuk-footer__list">
                     <li class="govuk-footer__list-item govuk-!-margin-bottom-1">
@@ -103,7 +103,7 @@
                     </li>
                 </ul>
             </div>
-      <div class="govuk-footer__section">
+      <div class="govuk-footer__section govuk-grid-column-one-half">
         <h2 class="govuk-footer__heading govuk-heading-m">Give feedback</h2>
         <ul class="govuk-footer__list ">
           <li class="govuk-footer__list-item">

--- a/Frontend/wwwroot/package-lock.json
+++ b/Frontend/wwwroot/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@ministryofjustice/frontend": "^0.2.2",
-        "govuk-frontend": "^3.11.0"
+        "govuk-frontend": "^4.0.1"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^7.0.0",
@@ -911,9 +911,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
-      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
+      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -2919,9 +2919,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
-      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
+      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
     },
     "graceful-fs": {
       "version": "4.2.6",

--- a/Frontend/wwwroot/package.json
+++ b/Frontend/wwwroot/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^0.2.2",
-    "govuk-frontend": "^3.11.0"
+    "govuk-frontend": "^4.0.1"
   }
 }


### PR DESCRIPTION
### Context
Update to GOV.UK frontend 4

### Changes proposed in this pull request
- Remove `tabindex` from error summary: Applying tabindex to the error summary means that it takes focus when clicked. The frontend team now handle the error summary focus in JavaScript to prevent this behaviour, and recommend we remove the attribute.
- Add data-module attribute to skip link: The GOV.UK frontend team have improved the skip link by adding JavaScript to assist screen readers. Update the skip link by adding the new attribute.
- Update error message element type: Follow the latest GOV.UK frontend advice and use a `p` tag for error messages, which is more semantically correct.
- Fix footer appearance: The footer component has been updated to align with the grid system. Set grid classes on `govuk-footer__section` to make sure footer appearance is as before.
- Update the HTML for summary lists: We currently add an empty `dd` tag in the place of an action in summary lists when there are a mix of rows with and without actions. We do this both manually, and through the `gds-key-value` tag helper when `show-action` is true. The recommended way of handling this is now to apply the `govuk-summary-list__row--no-action` class which inserts an empty cell pseudo-element instead.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

