### PR TITLE
Signout azure 2

### DIFF
--- a/Frontend.Tests/PagesTests/Home/SignOutTests.cs
+++ b/Frontend.Tests/PagesTests/Home/SignOutTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Frontend.Pages.Home;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Xunit;
+
+namespace Frontend.Tests.PagesTests.Home
+{
+    public class SignOutTests
+    {
+        public class OnGetAsync : SignOutTests
+        {
+            private readonly SignOut _subject;
+
+            public OnGetAsync()
+            {
+                _subject = new SignOut();
+            }
+
+            [Fact]
+            public async void WhenUserIsSignedOut_ShowsSignOutPage()
+            {
+                _subject.PageContext = new PageContext()
+                {
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                         {
+                             new Claim(ClaimTypes.Name, "username")
+                         }, null))
+                    }
+                };
+
+                var result = await _subject.OnGetAsync();
+
+                Assert.IsType<PageResult>(result);
+            }
+
+            [Fact]
+            public async void WhenUserIsSignedIn_CallsSignOutToRemoveSessionCookieAndRedirect()
+            {
+                var httpContextMock = new Mock<HttpContext>();
+                httpContextMock.Setup(context => context.User).Returns(new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, "username")
+                }, "some-auth-type")));
+
+                var authServiceMock = new Mock<IAuthenticationService>();
+                authServiceMock.Setup(authService => authService.SignOutAsync(It.IsAny<HttpContext>(), It.IsAny<string>(), It.IsAny<AuthenticationProperties>())).Returns(Task.FromResult((object)null));
+                var serviceProviderMock = new Mock<IServiceProvider>();
+                serviceProviderMock.Setup(serviceProvider => serviceProvider.GetService(typeof(IAuthenticationService))).Returns(authServiceMock.Object);
+                var mockUrlFactory = new Mock<IUrlHelperFactory>();
+
+                var mockUrlHelper = new Mock<IUrlHelper>();
+                mockUrlHelper.Setup(urlHelper => urlHelper.ActionContext).Returns(new ActionContext()
+                {
+                    ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor(),
+                    RouteData = new RouteData()
+                });
+
+                httpContextMock.Setup(context => context.RequestServices)
+                  .Returns(serviceProviderMock.Object);
+
+                _subject.Url = mockUrlHelper.Object;
+                _subject.PageContext = new PageContext()
+                {
+                    HttpContext = httpContextMock.Object,
+                };
+
+                var result = await _subject.OnGetAsync();
+
+                authServiceMock.Verify(authService => authService.SignOutAsync(It.IsAny<HttpContext>(), It.IsAny<string>(), It.IsAny<AuthenticationProperties>()), Times.Exactly(2));
+                Assert.Null(result);
+            }
+        }
+    }
+}

--- a/Frontend/Pages/Home/SignOut.cshtml
+++ b/Frontend/Pages/Home/SignOut.cshtml
@@ -1,0 +1,8 @@
+@page "/sign-out"
+@model Frontend.Pages.Home.SignOut
+
+@{
+    Layout = "_Layout";
+}
+
+<h1 class="govuk-heading-l">You're signed out of Manage an academy transfer</h1>

--- a/Frontend/Pages/Home/SignOut.cshtml.cs
+++ b/Frontend/Pages/Home/SignOut.cshtml.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Frontend.Pages.Home
+{
+    [AllowAnonymous]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public class SignOut : PageModel
+    {
+        public async Task<IActionResult> OnGetAsync()
+        {
+            // We redirect back to this handler once signed out of Azure AD. At that point
+            // we want to show the user a signed out page.
+            if (!User.Identity.IsAuthenticated)
+            {
+                return Page();
+            }
+
+            // SignOutAsync with a redirect overwrites the redirect to the OIDC endsession URL that SignOutAsync tries to issue.
+            // The solution is to call it twice, once to delete the session cookie, then again to redirect.
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+            await HttpContext.SignOutAsync(new AuthenticationProperties { RedirectUri = Url.Page("/Home/SignOut") });
+
+            return null;
+        }
+    }
+}

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -26,7 +26,6 @@ using Newtonsoft.Json.Linq;
 using StackExchange.Redis;
 using System;
 using Frontend.BackgroundServices;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Identity.Web;
 
@@ -92,19 +91,9 @@ namespace Frontend
                     options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                 }
             });
-            services.AddMicrosoftIdentityWebAppAuthentication(Configuration);
-            services.ConfigureApplicationCookie(options =>
-            {
-                options.Cookie.Name = "ManageAnAcademyTransfer.Login";
-                options.Cookie.HttpOnly = true;
-                options.Cookie.IsEssential = true;
-                options.ExpireTimeSpan = TimeSpan.FromMinutes(Int32.Parse(Configuration["AuthenticationExpirationInMinutes"]));
-                options.SlidingExpiration = true;
-                if (string.IsNullOrEmpty(Configuration["CI"]))
-                {
-                    options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-                }
-            });
+            
+            services.AddMicrosoftIdentityWebAppAuthentication(Configuration, "AzureAd", cookieScheme: "Authentication");
+
             services.AddHealthChecks();
         }
 

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -92,7 +92,7 @@ namespace Frontend
                 }
             });
             
-            services.AddMicrosoftIdentityWebAppAuthentication(Configuration, "AzureAd", cookieScheme: "Authentication");
+            services.AddMicrosoftIdentityWebAppAuthentication(Configuration);
 
             services.AddHealthChecks();
         }

--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -66,7 +66,7 @@
         @if (Context.User.Identity.IsAuthenticated)
         {
             <div class="govuk-grid-column-one-third">
-                <a href="https://login.microsoftonline.com/common/oauth2/v2.0/logout" class="govuk-header__link dfe-sign-out">Sign out</a>
+                <a asp-page="/Home/SignOut" class="govuk-header__link dfe-sign-out">Sign out</a>
             </div>
         }
     </div>


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Remove `ManageAnAcademyTransfer.Login` cookie config: The AddMicrosoftIdentityWebAppAuthentication method also configures the authentication cookie. Remove the call to `ConfigureApplicationCookie` as it is no longer used for authentication.
- Clear session cookie when user signs out of Azure AD: We can use SignOutAsync to sign out of Azure AD if we specify the scheme as OpenIDConnect (default value). We also need to clear the .NET Core authentication session cookie, which can be achieved by calling SignOutAsync with the cookie name. When a user signs out they will see the Azure AD sign-out page followed by a "You have signed out" page on the service.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

