### PR TITLE
Make sure signing out persists

### DIFF
--- a/Frontend/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml
+++ b/Frontend/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml
@@ -1,0 +1,9 @@
+@page "/signed-out"
+@model Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.SignedOutModel
+@{
+    Layout = "_Layout";
+    ViewData["Title"] = "Signed out";
+}
+
+<h1 class="govuk-heading-l">Signed out</h1>
+<p class="govuk-body-m">You're signed out of Manage an academy transfer</p>

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -35,6 +35,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.24.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.24.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.16.1" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.16.1" />
     <PackageReference Include="Sentry.AspNetCore" Version="3.14.1" />

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -26,9 +26,9 @@ using Newtonsoft.Json.Linq;
 using StackExchange.Redis;
 using System;
 using Frontend.BackgroundServices;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.UI;
 
 
 namespace Frontend
@@ -56,7 +56,8 @@ namespace Frontend
 
             services.AddControllersWithViews(options => options.Filters.Add(
                     new AutoValidateAntiforgeryTokenAttribute()))
-                .AddSessionStateTempDataProvider();
+                .AddSessionStateTempDataProvider()
+                .AddMicrosoftIdentityUI();
 
 
             services.AddFluentValidation(fv =>

--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -1,5 +1,7 @@
 ﻿@using Microsoft.Extensions.Configuration
 @inject IConfiguration _configuration
+@using System.Security.Principal
+
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 <head>
@@ -63,12 +65,12 @@
                 </span>
             </a>
         </div>
-        @if (Context.User.Identity.IsAuthenticated)
-        {
-            <div class="govuk-grid-column-one-third">
-                <a href="https://login.microsoftonline.com/common/oauth2/v2.0/logout" class="govuk-header__link dfe-sign-out">Sign out</a>
-            </div>
-        }
+     @if (User.Identity.IsAuthenticated)
+     {
+         <div class="govuk-grid-column-one-third">
+             <a class="govuk-header__link dfe-sign-out" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignOut">Sign out</a>
+         </div>
+     }
     </div>
 </header>
 


### PR DESCRIPTION
### Context
Currently, when signing out of Azure AD, the cookie persists, so the user will remain signed in until the session ends.

### Changes proposed in this pull request
Make sure signing out persists: Use the Microsoft.Identity.Web.Ui library to handle signing out, which clears the cookie for us. Override the SignedOut page to provide a custom message.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

