### PR TITLE
Updates to benefits and risks summary #AB87228

### DIFF
--- a/Data/Models/Projects/TransferBenefits.cs
+++ b/Data/Models/Projects/TransferBenefits.cs
@@ -46,15 +46,15 @@ namespace Data.Models.Projects
         {
             Empty = 0,
 
-            [Display(Name = "High profile transfer (ministers and media could be involved)")]
-            HighProfile,
-
             [Display(Name = "Complex land and building issues")]
             ComplexLandAndBuildingIssues,
-
+            
             [Display(Name = "Finance and debt concerns")]
             FinanceAndDebtConcerns,
             
+            [Display(Name = "High profile transfer")]
+            HighProfile,
+
             [Display(Name = "Other risks")]
             OtherRisks
         }

--- a/Frontend.Tests/ServicesTests/GetProjectTemplateModelTests.cs
+++ b/Frontend.Tests/ServicesTests/GetProjectTemplateModelTests.cs
@@ -84,7 +84,7 @@ namespace Frontend.Tests.ServicesTests
                 Assert.Equal("Closure of a SAT and the academy joining a MAT", projectTemplateModel.TypeOfTransfer);
                 Assert.Equal("Strengthening governance\nStronger leadership\n", projectTemplateModel.TransferBenefits);
                 Assert.Equal("Yes", projectTemplateModel.AnyRisks);
-                Assert.Equal(getTestInformationForProject.Project.Benefits.OtherFactors.Select(o => o.Value),
+                Assert.Equal(getTestInformationForProject.Project.Benefits.OtherFactors.OrderBy(o => o.Key).Select(o => o.Value),
                     projectTemplateModel.OtherFactors.Select(o => o.Item2));
                 Assert.Equal(academy.PupilNumbers.GirlsOnRoll, projectTemplateAcademyModel.GirlsOnRoll);
                 Assert.Equal(academy.PupilNumbers.BoysOnRoll, projectTemplateAcademyModel.BoysOnRoll);

--- a/Frontend.Tests/TestFixtures/GetInformationForProject.cs
+++ b/Frontend.Tests/TestFixtures/GetInformationForProject.cs
@@ -43,7 +43,7 @@ namespace Frontend.Tests.TestFixtures
                     OtherFactors = new Dictionary<TransferBenefits.OtherFactor, string>
                     {
                         {TransferBenefits.OtherFactor.HighProfile, "testHighProfile"},
-                        {TransferBenefits.OtherFactor.FinanceAndDebtConcerns, "debtConcerns"},
+                        {TransferBenefits.OtherFactor.FinanceAndDebtConcerns, "debtConcerns"}
                     },
                     AnyRisks = true
                 },

--- a/Frontend/Pages/Projects/BenefitsAndRisks/ComplexLandAndBuilding.cshtml
+++ b/Frontend/Pages/Projects/BenefitsAndRisks/ComplexLandAndBuilding.cshtml
@@ -3,6 +3,7 @@
 
 @{
     Layout = "_Layout";
+    ViewBag.Title = "Complex land and building issues";
 }
 
 @section BeforeMain

--- a/Frontend/Pages/Projects/BenefitsAndRisks/FinanceAndDebt.cshtml
+++ b/Frontend/Pages/Projects/BenefitsAndRisks/FinanceAndDebt.cshtml
@@ -3,6 +3,7 @@
 
 @{
     Layout = "_Layout";
+    ViewBag.Title = "Finance and debt concerns";
 }
 
 @section BeforeMain

--- a/Frontend/Pages/Projects/BenefitsAndRisks/HighProfileTransfer.cshtml
+++ b/Frontend/Pages/Projects/BenefitsAndRisks/HighProfileTransfer.cshtml
@@ -3,6 +3,7 @@
 
 @{
     Layout = "_Layout";
+    ViewBag.Title = "High profile transfer";
 }
 
 @section BeforeMain
@@ -30,6 +31,9 @@
                         Why is this a high profile transfer? (optional)
                     </label>
                 </h1>
+                <div id="hp-hint" class="govuk-hint">
+                    For example, ministers and media could be involved
+                </div>
                 <textarea asp-for="Answer" class="govuk-textarea" rows="5" data-test="high-profile-transfer"></textarea>
             </div>
             <button class="govuk-button" data-module="govuk-button" type="submit">

--- a/Frontend/Pages/Projects/BenefitsAndRisks/OtherRisks.cshtml
+++ b/Frontend/Pages/Projects/BenefitsAndRisks/OtherRisks.cshtml
@@ -3,6 +3,7 @@
 
 @{
     Layout = "_Layout";    
+    ViewBag.Title = "Other risks";
 }
 
 @section BeforeMain


### PR DESCRIPTION
### Context
Content changes for benefits and risks

### Changes proposed in this pull request
Remove (ministers and media could be involved) from the What are the risks? page
Add this hint text to the Why is this a high profile transfer? page: For example, ministers and media could be involved
Remove (ministers and media could be involved) from the summary page
Re-order the risk checklist items in alphabetical order on the What are the risks? page. This is based on GOV.UK Design System guidance.
Add unique titles to the conditional risk pages, such as Why is this a high profile transfer?. I recommend these titles:
High profile transfer
Complex land and building issues
Finance and debt concerns
Other risks

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

