### PR TITLE
"target" to "expected" and remove day field

### DIFF
--- a/Frontend/Pages/Projects/TransferDates/Target.cshtml
+++ b/Frontend/Pages/Projects/TransferDates/Target.cshtml
@@ -39,17 +39,11 @@
                         For example, 9 2007. You can change this date later.
                     </div>
 
-                    <p asp-gds-validation-for="TargetDateViewModel.TargetDate.Date.Day"></p>
+                    <p asp-gds-validation-for="TargetDateViewModel.TargetDate.Date"></p>
 
                     <div class="govuk-date-input" id="transfer-first-discussed-date">
-                        <div class="govuk-date-input__item">
-                            <div class="govuk-form-group">
-                                <label asp-for="TargetDateViewModel.TargetDate.Date.Day" class="govuk-label govuk-date-input__label">
-                                    Day
-                                </label>
-                                <input asp-for="TargetDateViewModel.TargetDate.Date.Day" class="govuk-input govuk-date-input__input govuk-input--width-2 @inputError" type="text" pattern="[0-9]*" inputmode="numeric" data-test="day">
-                            </div>
-                        </div>
+                       <input asp-for="TargetDateViewModel.TargetDate.Date.Day" type="hidden" pattern="[0-9]*" inputmode="numeric" value=01 />
+
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="TargetDateViewModel.TargetDate.Date.Month" class="govuk-label govuk-date-input__label">

--- a/Frontend/Pages/Projects/TransferDates/Target.cshtml
+++ b/Frontend/Pages/Projects/TransferDates/Target.cshtml
@@ -4,7 +4,7 @@
 
 
 @{
-    ViewBag.Title = (!ViewData.ModelState.IsValid ? "Error: " : "") + "When is the target date for the transfer?";
+    ViewBag.Title = (!ViewData.ModelState.IsValid ? "Error: " : "") + "When is the expected date for the transfer?";
     Layout = "_Layout";
     var formClasses = !ViewData.ModelState.IsValid ? "govuk-form-group--error" : "";
     var inputError = ViewData.ModelState.GetFieldValidationState(nameof(Model.TargetDateViewModel.TargetDate.Date.Day)) == ModelValidationState.Invalid ? "govuk-input--error" : "";
@@ -32,7 +32,7 @@
                             <span class="govuk-caption-l">
                                 @Model.IncomingTrustName
                             </span>
-                            When is the target date for the transfer?
+                            When is the expected date for the transfer?
                         </h1>
                     </legend>
                     <div id="target-date-for-transfer-hint" class="govuk-hint">

--- a/Frontend/Pages/Shared/_TransferDatesSummary.cshtml
+++ b/Frontend/Pages/Shared/_TransferDatesSummary.cshtml
@@ -31,7 +31,7 @@
     </div>
     <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-            Target date for transfer
+            Expected date for transfer
         </dt>
         <dd class="govuk-summary-list__value">
             <datesummary value="@Model.TargetDate" has-date="@Model.HasTargetDate"></datesummary>
@@ -39,7 +39,7 @@
         <dd class="govuk-summary-list__actions">
             <a class="govuk-link" asp-page="/Projects/TransferDates/Target" data-test="target-date"
                asp-route-urn="@Model.Urn" asp-route-returnToPreview="@(Model.ReturnToPreview  ? "true" : null)">
-                Change<span class="govuk-visually-hidden"> target date for transfer</span>
+                Change<span class="govuk-visually-hidden"> expected date for transfer</span>
             </a>
         </dd>
     </div>


### PR DESCRIPTION
### Changes proposed in this pull request
Update "target" date for transfer to "expected": We want to remove the word "target" because delivery officers find it too rigid, replacing it with "expected" instead.

Remove the day field of the expected transfer date: Transfers always happen on the 1st of the month, so we've been recommended to remove the day field.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

