### PR TITLE
Fix date validation AB#93306

### DIFF
--- a/Frontend.Tests/PagesTests/Projects/TransferDates/TargetTests.cs
+++ b/Frontend.Tests/PagesTests/Projects/TransferDates/TargetTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using FluentValidation.AspNetCore;
 using Frontend.Models;
 using Frontend.Models.Forms;
 using Frontend.Models.TransferDates;
@@ -73,6 +75,17 @@ namespace Frontend.Tests.PagesTests.Projects.TransferDates
                 await _subject.OnPostAsync();
 
                 ProjectRepository.Verify(r => r.GetByUrn(ProjectUrn0001), Times.Once);
+            }
+            
+            [Fact]
+            public void TargetDateViewModel_SkipsAutomaticValidation()
+            {
+                var attribute = (CustomizeValidatorAttribute)typeof(Target)
+                    .GetProperty("TargetDateViewModel")
+                    ?.GetCustomAttributes(typeof(CustomizeValidatorAttribute), false).First();
+
+                Assert.NotNull(attribute);
+                Assert.True(attribute.Skip);
             }
 
             [Theory]

--- a/Frontend.Tests/PagesTests/Projects/TransferDates/TargetTests.cs
+++ b/Frontend.Tests/PagesTests/Projects/TransferDates/TargetTests.cs
@@ -75,17 +75,30 @@ namespace Frontend.Tests.PagesTests.Projects.TransferDates
                 ProjectRepository.Verify(r => r.GetByUrn(ProjectUrn0001), Times.Once);
             }
 
-            [Fact]
-            public async void GivenErrorOnModel_ShouldReturnPage()
+            [Theory]
+            [InlineData(null, null)]
+            [InlineData("01", null)]
+            [InlineData(null, "2099")]
+            public async void WhenMonthAndYearAreNotSet_DoesNotSetDay(string monthValue, string yearValue)
             {
-                _subject.ModelState.AddModelError(nameof(_subject.TargetDateViewModel.TargetDate.Date),
-                    "error");
-                var result = await _subject.OnPostAsync();
+                _subject.TargetDateViewModel.TargetDate.Date.Day = null;
+                _subject.TargetDateViewModel.TargetDate.Date.Month = monthValue;
+                _subject.TargetDateViewModel.TargetDate.Date.Year = yearValue;
 
-                ProjectRepository.Verify(r =>
-                    r.Update(It.Is<Data.Models.Project>(project => project.Urn == ProjectUrn0001)), Times.Never);
+                await _subject.OnPostAsync();
 
-                Assert.IsType<PageResult>(result);
+                Assert.Null(_subject.TargetDateViewModel.TargetDate.Date.Day);
+            }
+            
+            [Fact]
+            public async void WhenMonthAndYearAreSet_SetsDayToFirstOfMonth()
+            {
+                _subject.TargetDateViewModel.TargetDate.Date.Month = "01";
+                _subject.TargetDateViewModel.TargetDate.Date.Year = "2099";
+
+                await _subject.OnPostAsync();
+
+                Assert.Equal("01", _subject.TargetDateViewModel.TargetDate.Date.Day);
             }
 
             [Fact]

--- a/Frontend/Pages/Projects/TransferDates/Target.cshtml
+++ b/Frontend/Pages/Projects/TransferDates/Target.cshtml
@@ -42,8 +42,6 @@
                     <p asp-gds-validation-for="TargetDateViewModel.TargetDate.Date"></p>
 
                     <div class="govuk-date-input" id="transfer-first-discussed-date">
-                       <input asp-for="TargetDateViewModel.TargetDate.Date.Day" type="hidden" pattern="[0-9]*" inputmode="numeric" value=01 />
-
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="TargetDateViewModel.TargetDate.Date.Month" class="govuk-label govuk-date-input__label">

--- a/Frontend/Pages/Projects/TransferDates/Target.cshtml.cs
+++ b/Frontend/Pages/Projects/TransferDates/Target.cshtml.cs
@@ -40,6 +40,12 @@ namespace Frontend.Pages.Projects.TransferDates
         
         public async Task<IActionResult> OnPostAsync()
         {
+            if (TargetDateViewModel.TargetDate.Date.Month != null && TargetDateViewModel.TargetDate.Date.Year != null)
+            {
+                // Transfers always happen on the 1st of the month.
+                TargetDateViewModel.TargetDate.Date.Day = "01";
+            }
+            
             var project = await _projectsRepository.GetByUrn(Urn);
 
             var projectResult = project.Result;

--- a/Frontend/Pages/Projects/TransferDates/Target.cshtml.cs
+++ b/Frontend/Pages/Projects/TransferDates/Target.cshtml.cs
@@ -13,7 +13,9 @@ namespace Frontend.Pages.Projects.TransferDates
     {
         private readonly IProjects _projectsRepository;
 
-        [BindProperty] public TargetDateViewModel TargetDateViewModel { get; set; }
+        [BindProperty] 
+        [CustomizeValidator(Skip = true)]
+        public TargetDateViewModel TargetDateViewModel { get; set; }
 
         public Target(IProjects projectsRepository)
         {

--- a/Frontend/Pages/Projects/TransferDates/Target.cshtml.cs
+++ b/Frontend/Pages/Projects/TransferDates/Target.cshtml.cs
@@ -42,13 +42,8 @@ namespace Frontend.Pages.Projects.TransferDates
         {
             var project = await _projectsRepository.GetByUrn(Urn);
 
-            if (!ModelState.IsValid)
-            {
-                return Page();
-            }
-            
             var projectResult = project.Result;
-            
+
             var validationContext = new ValidationContext<TargetDateViewModel>(TargetDateViewModel)
             {
                 RootContextData =

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -63,8 +63,7 @@ namespace Frontend
             
             services.AddFluentValidation(fv =>
             {
-                fv.RegisterValidatorsFromAssemblyContaining<FeaturesReasonValidator>(discoveredType =>
-                    discoveredType.ValidatorType != typeof(TargetDateValidator));
+                fv.RegisterValidatorsFromAssemblyContaining<FeaturesReasonValidator>();
                 fv.DisableDataAnnotationsValidation = true;
             });
                 

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -26,14 +26,12 @@ using Newtonsoft.Json.Linq;
 using StackExchange.Redis;
 using System;
 using System.Security.Claims;
-using System.Threading.Tasks;
 using Frontend.BackgroundServices;
+using Frontend.Validators.TransferDates;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
-
 
 namespace Frontend
 {
@@ -62,14 +60,14 @@ namespace Frontend
                     new AutoValidateAntiforgeryTokenAttribute()))
                 .AddSessionStateTempDataProvider()
                 .AddMicrosoftIdentityUI();
-
-
+            
             services.AddFluentValidation(fv =>
             {
-                fv.RegisterValidatorsFromAssemblyContaining<FeaturesReasonValidator>();
+                fv.RegisterValidatorsFromAssemblyContaining<FeaturesReasonValidator>(discoveredType =>
+                    discoveredType.ValidatorType != typeof(TargetDateValidator));
                 fv.DisableDataAnnotationsValidation = true;
             });
-
+                
             var policyBuilder = SetupAuthorizationPolicyBuilder();
 
             services.AddAuthorization(options =>


### PR DESCRIPTION
### Changes proposed in this pull request
**Prevent target date validation being called twice:**
Currently, the TargetDateValidator gets called twice. The first time it gets executed by fluentvalidation's automatic integration and returns early, then later it's called explicitly with some additional context.

To prevent this we can exclude certain validators from being automatically registered in Startup - exclude the TargetDateValidator.

**Fix date validation:**
We want the expected date of transfer to always be the first of the month.

I was previously setting the day property unconditionally, which meant that the validation was returning an "invalid date" message, instead of a "required field" message when the other fields were empty.

To fix - conditionally set day only if month and year are also set.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

