### PR TITLE
Update the template file name

### DIFF
--- a/Frontend.Tests/PagesTests/TaskList/HtbDocument/DownloadTests.cs
+++ b/Frontend.Tests/PagesTests/TaskList/HtbDocument/DownloadTests.cs
@@ -21,7 +21,13 @@ namespace Frontend.Tests.PagesTests.TaskList.HtbDocument
             };
 
             _createHtbDocument.Setup(s => s.Execute(ProjectUrn0001)).ReturnsAsync(new CreateProjectTemplateResponse
-                {Document = new byte[] {0, 1}});
+            {
+                Document = new byte[] { 0, 1 }
+            });
+
+            FoundInformationForProject.Project.TransferringAcademies[0].IncomingTrustName = "Incoming Trust";
+            FoundInformationForProject.Project.OutgoingTrustName = "Outgoing Trust";
+            FoundInformationForProject.Project.Reference = "SW-MAT-10000001";
         }
 
         public class GetTests : DownloadTests
@@ -29,10 +35,17 @@ namespace Frontend.Tests.PagesTests.TaskList.HtbDocument
             [Fact]
             public async void GivenId_GetsProjectInformation()
             {
-                FoundInformationForProject.Project.TransferringAcademies[0].IncomingTrustName = "Incoming Trust";
                 await _subject.OnGetAsync();
 
                 GetInformationForProject.Verify(s => s.Execute(ProjectUrn0001), Times.Once);
+            }
+
+            [Fact]
+            public async void GivenId_SetsFileName()
+            {
+                await _subject.OnGetAsync();
+
+                Assert.Equal("SW-MAT-10000001_Outgoing-Trust_Incoming-Trust_project-template", _subject.FileName);
             }
         }
 
@@ -41,25 +54,26 @@ namespace Frontend.Tests.PagesTests.TaskList.HtbDocument
             [Fact]
             public async void GivenId_GeneratesAnHtbDocumentForTheProject()
             {
-                FoundInformationForProject.Project.TransferringAcademies[0].IncomingTrustName = "Incoming Trust";
                 await _subject.OnGetGenerateDocumentAsync();
+
                 _createHtbDocument.Verify(s => s.Execute(ProjectUrn0001), Times.Once);
             }
 
             [Fact]
             public async void GivenId_ReturnsAFileWithTheGeneratedDocument()
             {
-                var fileContents = new byte[] {1, 2, 3, 4};
+                var fileContents = new byte[] { 1, 2, 3, 4 };
                 var createDocumentResponse = new CreateProjectTemplateResponse
                 {
                     Document = fileContents
                 };
                 _createHtbDocument.Setup(s => s.Execute(ProjectUrn0001)).ReturnsAsync(createDocumentResponse);
-                FoundInformationForProject.Project.TransferringAcademies[0].IncomingTrustName = "Incoming Trust";
-                var response = await _subject.OnGetGenerateDocumentAsync();
-                var fileResponse = Assert.IsType<FileContentResult>(response);
 
+                var response = await _subject.OnGetGenerateDocumentAsync();
+
+                var fileResponse = Assert.IsType<FileContentResult>(response);
                 Assert.Equal(fileContents, fileResponse.FileContents);
+                Assert.Equal("SW-MAT-10000001_Outgoing-Trust_Incoming-Trust_project-template.docx", fileResponse.FileDownloadName);
             }
         }
     }

--- a/Frontend/Pages/TaskList/HtbDocument/Download.cshtml
+++ b/Frontend/Pages/TaskList/HtbDocument/Download.cshtml
@@ -31,7 +31,7 @@
             <div class="dfe-c-attachment__details">
                 <h2 class="dfe-c-attachment__title">
                     <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener" download asp-page-handler="GenerateDocument" asp-route-urn="@Model.Urn" data-test="download-htb">
-                       @Model.IncomingTrustName, @Model.ProjectReference project template
+                       @Model.FileName
                     </a>
                 </h2>
                 <p class="dfe-c-attachment__metadata">

--- a/Frontend/Pages/TaskList/HtbDocument/Download.cshtml.cs
+++ b/Frontend/Pages/TaskList/HtbDocument/Download.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using Data.Models;
 using Frontend.Models;
 using Frontend.Services.Interfaces;
 using Helpers;
@@ -11,28 +12,54 @@ namespace Frontend.Pages.TaskList.HtbDocument
     {
         private readonly ICreateProjectTemplate _createProjectTemplate;
         private readonly IGetInformationForProject _getInformationForProject;
+
         public Download(ICreateProjectTemplate createProjectTemplate,
             IGetInformationForProject getInformationForProject)
         {
             _createProjectTemplate = createProjectTemplate;
             _getInformationForProject = getInformationForProject;
         }
-      
+
+        public string FileName { get; private set; }
+
         public async Task<IActionResult> OnGetAsync()
         {
-            var projectInformation = await _getInformationForProject.Execute(Urn);
-            ProjectReference = projectInformation.Project.Reference;
-            IncomingTrustName = projectInformation.Project.IncomingTrustName.ToTitleCase();
+            var project = await GetProject();
+            ProjectReference = project.Reference;
+            FileName = GenerateFormattedFileName(project);
+
             return Page();
         }
-        
+
         public async Task<IActionResult> OnGetGenerateDocumentAsync()
         {
-            var projectInformation = await _getInformationForProject.Execute(Urn);
+            var project = await GetProject();
+            FileName = GenerateFormattedFileName(project);
+
             var document = await _createProjectTemplate.Execute(Urn);
+
             return File(document.Document.ToArray(),
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                $"ProjectTemplateFor{projectInformation.Project.IncomingTrustName.ToTitleCase().Replace(" ","")}–{projectInformation.Project.Reference}.docx");
+                $"{FileName}.docx");
+        }
+
+        private async Task<Project> GetProject()
+        {
+            var projectInformation = await _getInformationForProject.Execute(Urn);
+            return projectInformation.Project;
+        }
+
+        private static string GenerateFormattedFileName(Project project)
+        {
+            var formattedOutgoingTrustName = FormatTrustName(project.OutgoingTrustName);
+            var formattedIncomingTrustName = FormatTrustName(project.IncomingTrustName);
+
+            return $"{project.Reference}_{formattedOutgoingTrustName}_{formattedIncomingTrustName}_project-template";
+        }
+
+        private static string FormatTrustName(string trustName)
+        {
+            return trustName.ToTitleCase().ToHyphenated().RemoveNonAlphanumericOrWhiteSpace();
         }
     }
 }

--- a/Helpers.Tests/StringHelperTests.cs
+++ b/Helpers.Tests/StringHelperTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Helpers.Tests
+{
+    public class StringHelperTests
+    {
+        public class ToHtmlName
+        {
+            [Fact]
+            public void ReplacesCharacters()
+            {
+                const string text = "some]text[for.testing";
+
+                var result = text.ToHtmlName();
+
+                Assert.Equal("some_text_for_testing", result);
+            }
+        }
+
+        public class ToTitleCase
+        {
+            [Theory]
+            [InlineData("A TITLE", "A Title")]
+            [InlineData("a title", "A Title")]
+            public void FormatsAsTitleCase(string input, string expectedOutput)
+            {
+                var result = input.ToTitleCase();
+
+                Assert.Equal(expectedOutput, result);
+            }
+        }
+
+        public class ToHyphenated
+        {
+            [Theory]
+            [InlineData("some text", "some-text")]
+            [InlineData("some    text", "some-text")]
+            [InlineData("some\ttext", "some-text")]
+            public void ReplacesWhiteSpaceWithHyphens(string input, string expectedOutput)
+            {
+                var result = input.ToHyphenated();
+
+                Assert.Equal(expectedOutput, result);
+            }
+        }
+
+        public class RemoveNonAlphanumericOrWhiteSpace
+        {
+            [Fact]
+            public void RemovesCharacters()
+            {
+                const string text = "some text-with-punctuation_and'numbers99][()";
+
+                var result = text.RemoveNonAlphanumericOrWhiteSpace();
+
+                Assert.Equal("some text-with-punctuation_andnumbers99", result);
+            }
+        }
+    }
+}

--- a/Helpers/StringHelper.cs
+++ b/Helpers/StringHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Helpers
 {
@@ -7,14 +8,26 @@ namespace Helpers
         public static string ToHtmlName(this string propertyName)
         {
             return propertyName.Replace('.', '_')
-                .Replace('[','_')
-                .Replace(']','_');
-        } 
-        
+                .Replace('[', '_')
+                .Replace(']', '_');
+        }
+
         public static string ToTitleCase(this string str)
         {
             var textInfo = CultureInfo.CurrentCulture.TextInfo;
             return textInfo.ToTitleCase(str.ToLower());
+        }
+
+        public static string ToHyphenated(this string str)
+        {
+            var whitespaceRegex = new Regex(@"\s+");
+            return whitespaceRegex.Replace(str, "-");
+        }
+
+        public static string RemoveNonAlphanumericOrWhiteSpace(this string str)
+        {
+            var notAlphanumericWhiteSpaceOrHyphen = new Regex(@"[^\w\s-]");
+            return notAlphanumericWhiteSpaceOrHyphen.Replace(str, string.Empty);
         }
     }
 }


### PR DESCRIPTION
### Context
We want the project file to be more intuitive, which we can achieve by including the outgoing trust name (in addition to the incoming trust name) and moving the project reference to the beginning.

### Changes proposed in this pull request
**Update the template file name:**
Add string helpers to hyphenate sentences and remove non-alphanumeric characters so that trust names can be formatted as they are in the [updated design](https://academy-transfers-prototype.london.cloudapps.digital/version-4/pre-htb/school-1/download).

Also, add missing string helper tests and DRY up some duplication between the download handler methods.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/47089130/168031033-01bfbf12-f49e-4306-9348-f83d6dc14d01.png)|![image](https://user-images.githubusercontent.com/47089130/168030843-2f1b15c9-06e9-404a-9944-f57d955323fd.png)|

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

