### PR TITLE
Remove option to sign out

### DIFF
--- a/Frontend.Integration.Tests/BasicTests.cs
+++ b/Frontend.Integration.Tests/BasicTests.cs
@@ -27,7 +27,6 @@ namespace Frontend.Integration.Tests
             Document.QuerySelector("#main-content > div:nth-child(2) > div > div:nth-child(3) > div > h3 > a")
                 ?.TextContent
                 .Trim().Should().Be(projects.First().TransferringAcademies[0].IncomingTrustName.ToTitleCase());
-            Document.QuerySelector("a.dfe-sign-out")?.TextContent.Trim().Should().Be("Sign out");
         }
     }
 }

--- a/Frontend/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml
+++ b/Frontend/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml
@@ -1,9 +1,0 @@
-@page "/signed-out"
-@model Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.SignedOutModel
-@{
-    Layout = "_Layout";
-    ViewData["Title"] = "Signed out";
-}
-
-<h1 class="govuk-heading-l">Signed out</h1>
-<p class="govuk-body-m">You're signed out of Manage an academy transfer</p>

--- a/Frontend/Startup.cs
+++ b/Frontend/Startup.cs
@@ -26,16 +26,12 @@ using Newtonsoft.Json.Linq;
 using StackExchange.Redis;
 using System;
 using System.Security.Claims;
-using System.Threading.Tasks;
 using Frontend.Authorization;
 using Frontend.BackgroundServices;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
-
 
 namespace Frontend
 {
@@ -100,12 +96,11 @@ namespace Frontend
                 options =>
                 {
                     options.AccessDeniedPath = "/access-denied";
-                    options.LogoutPath = "/signed-out";
                     options.Cookie.Name = "ManageAnAcademyTransfer.Login";
                     options.Cookie.HttpOnly = true;
                     options.Cookie.IsEssential = true;
                     options.ExpireTimeSpan =
-                        TimeSpan.FromMinutes(Int32.Parse(Configuration["AuthenticationExpirationInMinutes"]));
+                        TimeSpan.FromMinutes(int.Parse(Configuration["AuthenticationExpirationInMinutes"]));
                     options.SlidingExpiration = true;
                     if (string.IsNullOrEmpty(Configuration["CI"]))
                     {

--- a/Frontend/Views/Shared/_Layout.cshtml
+++ b/Frontend/Views/Shared/_Layout.cshtml
@@ -64,12 +64,6 @@
                 </span>
             </a>
         </div>
-     @if (User.Identity.IsAuthenticated)
-     {
-         <div class="govuk-grid-column-one-third">
-             <a class="govuk-header__link dfe-sign-out" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignOut">Sign out</a>
-         </div>
-     }
     </div>
 </header>
 

--- a/Frontend/wwwroot/src/css/site.scss
+++ b/Frontend/wwwroot/src/css/site.scss
@@ -67,10 +67,6 @@ aside.app-related-items {
   padding-top: 10px;
 }
 
-.dfe-sign-out {
-  float: right;
-}
-
 .not-visible {
   display:none;
   visibility:hidden


### PR DESCRIPTION
### Context
Currently, we have a link which will sign the user out of all other applications that use their Microsoft account for authentication (single sign-out). After various discussions, we have decided that there is no need for this, and we are happy for it to be removed. 

The service will therefore appear seamless, users will have access when signed in elsewhere (or will be redirected to the sign in page when not), but they will have to sign out somewhere else.

### Changes proposed in this pull request
- Remove option to sign out

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

