### PR TITLE
Suppress view override warnings

### DIFF
--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -6,6 +6,14 @@
     <Platforms>AnyCPU</Platforms>
     <UserSecretsId>d227be51-e8df-4258-9943-78e14a94484a</UserSecretsId>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>0436</NoWarn>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>0436</NoWarn>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <Content Remove="wwwroot\package-lock.json" />
     <Content Remove="wwwroot\package.json" />


### PR DESCRIPTION
### Context
We override the MicrosoftIdentity access-denied view in order to provide a custom message.

Unfortunately, we now see the warning `The type 'Areas_MicrosoftIdentity_Pages_Account_AccessDenied' conflicts with the imported type`. It seems as though this is expected and the only choices we have are to ignore it, or suppress the warning, so choosing to suppress.

### Changes proposed in this pull request
- Suppress view override warnings

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

