### PR TITLE
107871 Fixing project list content alignment for Transfers

### DIFF
--- a/Frontend/wwwroot/src/css/site.scss
+++ b/Frontend/wwwroot/src/css/site.scss
@@ -80,3 +80,28 @@ abbr {
 .prepare-text-align-right {
     text-align: right !important;
 }
+
+.app-\!-width-one-fifth {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 20% !important;
+	}
+}
+.app-\!-width-two-fifths {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 40% !important;
+	}
+}
+.app-\!-width-three-fifths {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 60% !important;
+	}
+}
+.app-\!-width-four-fifths {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 80% !important;
+	}
+}


### PR DESCRIPTION
### Context
Fixing project list content alignment for Transfers

DevOps ticket: https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_sprints/taskboard/Prepare%20conversions%20and%20transfers/Academies-and-Free-Schools-SIP/Manage%20an%20academy%20transfer/Sprint%2040?workitem=107871

### Changes proposed in this pull request
- Fixing project list content alignment for Transfers to make the columns 60% + 40%

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

### Before 
<img width="1353" alt="Screenshot 2022-10-12 at 12 25 00" src="https://user-images.githubusercontent.com/6421298/195331404-f77ba92f-2cf2-4602-9cd1-80adf471a7e8.png">

### After 
<img width="1344" alt="Screenshot 2022-10-12 at 12 24 43" src="https://user-images.githubusercontent.com/6421298/195331441-a2279c6c-971e-415f-a8a6-2377a7fa8cf1.png">
