### PR TITLE
Cookie policy for Transfers

### DIFF
--- a/end-to-end-tests/cypress/e2e/cookie-policy/110944_cookies-policy.cy.js
+++ b/end-to-end-tests/cypress/e2e/cookie-policy/110944_cookies-policy.cy.js
@@ -1,0 +1,63 @@
+/// <reference types ='Cypress'/>
+
+Cypress._.each(['ipad-mini'], (viewport) => {
+	describe(`110944 Cookie consent details for Transfers on ${viewport}`, () => {
+		beforeEach(() => {
+			cy.login()
+			cy.viewport(viewport)
+			cy.selectTrustListing(2)
+			cy.url().then(url => {
+				//Changes the current URL
+				let modifiedUrl = url + '/transfer-dates'
+				cy.visit(modifiedUrl)
+			});
+		})
+
+		it('TC01: should show top cookie banner when no consent option set', () => {
+			cy.get('[data-test="cookie-banner"]').should('be.visible')
+		});
+
+		context("when cookie banner clicked", () => {
+			beforeEach(() => {
+				cy.get('[data-test="cookie-banner-accept"]').click()
+			})
+
+			it('TC02: should consent to cookies from cookie header button', () => {
+				let consentCookie = cy.getCookie('.ManageAnAcademyTransfer.Consent')
+				consentCookie.should('exist')
+				consentCookie.should('have.property', 'value', 'True')
+			});
+
+			it('TC03: should hide the cookie banner when consent has been given', () => {
+				cy.get("[data-test='cookie-banner']").should('not.exist')
+			});
+		})
+
+		context("when cookie link in footer clicked", () => {
+			beforeEach(() => {
+				cy.get("[data-test='cookie-preferences']").click()
+			})
+
+			it('TC04: should navigate to cookies page', () => {
+				cy.url().then(href => {
+					expect(href).includes('cookie-preferences')
+				});
+			});
+
+			it('TC05: should set cookie preferences', () => {
+				cy.get('#cookie-consent-deny').click()
+				cy.get("[data-qa='submit']").click()
+				cy.getCookie('.ManageAnAcademyTransfer.Consent').should('have.property', 'value', 'False')
+			});
+
+			it('TC06: should return show success banner', () => {
+				cy.get('#cookie-consent-deny').click()
+				cy.get("[data-qa='submit']").click()
+				cy.get('[data-test="success-banner-return-link"]').click()
+				cy.url().then(href => {
+					expect(href).includes('/transfer-dates')
+				});
+			});
+		})
+	});
+});

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -181,3 +181,10 @@ Cypress.Commands.add('foundationConsentLink', () => {
 Cypress.Commands.add('foundationConsentStatus', () => {
     cy.get('[data-test="foundation-consent"]')
 })
+
+// Trust Listing Summary Page (Universal)
+Cypress.Commands.add('selectTrustListing', (listing) => {
+    cy.get('[data-id^="project-link-"]').first().click()
+    cy.get('*[href*="features"]').should('be.visible')
+    cy.saveLocalStorage()
+});


### PR DESCRIPTION
### Context
This PR covers the cookie policy for Transfers. Covering the cookie banner and cookie link in the footer functionality as covered in Conversions.

### Checklist
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
![Transfers cookies cypress](https://user-images.githubusercontent.com/116153732/200007956-a3ea62fc-64f7-454e-a6f8-b979fb95ad0f.png)
