### PR TITLE
Verify Transfers cookie links and content

### DIFF
--- a/Frontend/Pages/Shared/_CookieBanner.cshtml
+++ b/Frontend/Pages/Shared/_CookieBanner.cshtml
@@ -10,7 +10,7 @@
 				<p class="govuk-body">
 					We use cookies to
 					<a class="govuk-link" data-test="cookie-banner-link-1" asp-page="@Links.CookiePreferences.PageName">collect information</a>
-					about how you use the <a asp-page="@Links.ProjectList.Index.PageName">transfers part of our service.</a>
+					about how you use the <a asp-page="@Links.ProjectList.Index.PageName" data-test="cookie-banner-transfer-link">transfers part of our service.</a>
 				</p>
 				<div>
 					<a role="button" draggable="false" data-test="cookie-banner-accept" class="govuk-button govuk-!-margin-bottom-2" asp-page="@Links.CookiePreferences.PageName" asp-route-consent="true" asp-route-returnUrl="@Context.Request.Path">

--- a/end-to-end-tests/cypress/e2e/cookie-policy/107471_cookie-policy-content.cy.js
+++ b/end-to-end-tests/cypress/e2e/cookie-policy/107471_cookie-policy-content.cy.js
@@ -1,0 +1,51 @@
+Cypress._.each(['ipad-mini'], (viewport) => {
+    describe(`107471: Cookie content details on Transfers on ${viewport}`, () => {
+      beforeEach(() => {
+        cy.viewport(viewport);
+        cy.login();
+      })
+  
+      afterEach(() => {
+        cy.clearCookies();
+      });
+  
+      it('TC01: should navigate to preference page when user click on collect information link', () => {
+        cy.get('[data-test="cookie-banner-link-1"]')
+          .should('have.text', 'collect information')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/cookie-preferences');
+        cy.get('h1').contains('Cookie preferences');  
+        });
+      });
+      
+      it('TC02: should navigate to preference page when user click on transfers part of our service link', () => {
+        cy.get('[data-test="cookie-banner-transfer-link"]')
+          .should('contain', 'transfers part of our service')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/cookie-preferences');
+        });
+      });
+
+      it('TC03: should navigate to preference page when user click on Accept cookies  link', () => {
+        cy.get('[data-test="cookie-banner-accept"]')
+          .should('contain', 'Accept cookies for the transfers part of this service')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/home');
+        cy.get('[data-test="create-transfer"]');  
+        });
+      });
+
+      it('TC04: should navigate to preference page when user click on set your cookie preferences link', () => {
+        cy.get('[data-test="cookie-banner-link-2"]')
+          .should('have.text', 'set your cookie preferences')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/cookie-preferences');
+        cy.get('h1').contains('Cookie preferences');  
+        });
+      });  
+    });
+});


### PR DESCRIPTION
This PR covers the verification of Cookie links for Transfers, it's text as well as the redirection of the links.
Also added a selector to cshtml file (The related test will pass once the changes are merged to Dev env. )
![transfers cypress](https://user-images.githubusercontent.com/116153732/202473486-a3300cc3-4f6f-493b-a1aa-19a3a46c16b2.png)


