### PR TITLE
97087 Fixing accessibility issue: error messages not read aloud

### DIFF
--- a/Frontend.Tests/HelpersTests/TagHelperTests/GdsValidationSummaryTagHelperTests.cs
+++ b/Frontend.Tests/HelpersTests/TagHelperTests/GdsValidationSummaryTagHelperTests.cs
@@ -109,14 +109,16 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
                 var expectedOutput = 
                     "<div class='govuk-grid-row'>" +
                         "<div class='govuk-grid-column-full'>" +
-                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' " +
+                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' " +
                                 "data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>" +
-                                "<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>There is a problem" +
-                                "</h2>" +
-                                "<div class='govuk-error-summary__body'>" +
-                                    "<ul class='govuk-list govuk-error-summary__list'>" +
-                                        "<li><a href='#testField' data-qa='error_text'>Test error</a></li>" +
-                                    "</ul>" +
+                                "<div role='alert'>" +
+                                    "<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>There is a problem" +
+                                    "</h2>" +
+                                    "<div class='govuk-error-summary__body'>" +
+                                        "<ul class='govuk-list govuk-error-summary__list'>" +
+                                            "<li><a href='#testField' data-qa='error_text'>Test error</a></li>" +
+                                        "</ul>" +
+                                    "</div>" +
                                 "</div>" +
                             "</div>" +
                         "</div>" +
@@ -162,19 +164,21 @@ namespace Frontend.Tests.HelpersTests.TagHelperTests
                 var expectedOutput = 
                     "<div class='govuk-grid-row'>" +
                         "<div class='govuk-grid-column-full'>" +
-                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' " +
+                            "<div class='govuk-error-summary' aria-labelledby='error-summary-title' " +
                                 "data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>" +
-                                "<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>There is a problem" +
-                                "</h2>" +
-                                "<div class='govuk-error-summary__body'>" +
-                                    "<ul class='govuk-list govuk-error-summary__list'>" +
-                                        "<li><a href='#testField' data-qa='error_text'>Test error 1</a></li>" +
-                                        "<li><a href='#testField' data-qa='error_text'>Test error 2</a></li>" +
-                                        "<li><a href='#testField2' data-qa='error_text'>Test field 2 error 1</a></li>" +
-                                        "<li><a href='#testField3' data-qa='error_text'>Test field 3 error 1</a></li>" +
-                                        "<li><a href='#testField3' data-qa='error_text'>Test field 3 error 2</a></li>" +
-                                        "<li><a href='#testField3' data-qa='error_text'>Test field 3 error 3</a></li>" +
-                                    "</ul>" +
+                                "<div role='alert'>" +
+                                    "<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>There is a problem" +
+                                    "</h2>" +
+                                    "<div class='govuk-error-summary__body'>" +
+                                        "<ul class='govuk-list govuk-error-summary__list'>" +
+                                            "<li><a href='#testField' data-qa='error_text'>Test error 1</a></li>" +
+                                            "<li><a href='#testField' data-qa='error_text'>Test error 2</a></li>" +
+                                            "<li><a href='#testField2' data-qa='error_text'>Test field 2 error 1</a></li>" +
+                                            "<li><a href='#testField3' data-qa='error_text'>Test field 3 error 1</a></li>" +
+                                            "<li><a href='#testField3' data-qa='error_text'>Test field 3 error 2</a></li>" +
+                                            "<li><a href='#testField3' data-qa='error_text'>Test field 3 error 3</a></li>" +
+                                        "</ul>" +
+                                    "</div>" +
                                 "</div>" +
                             "</div>" +
                         "</div>" +

--- a/Frontend/Helpers/TagHelpers/GdsValidationSummaryTagHelper.cs
+++ b/Frontend/Helpers/TagHelpers/GdsValidationSummaryTagHelper.cs
@@ -36,7 +36,8 @@ namespace Frontend.Helpers.TagHelpers
             var sb = new StringBuilder();
             sb.Append("<div class='govuk-grid-row'>");
             sb.Append("<div class='govuk-grid-column-full'>");
-            sb.Append("<div class='govuk-error-summary' aria-labelledby='error-summary-title' role='alert' data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>");
+            sb.Append("<div class='govuk-error-summary' aria-labelledby='error-summary-title' data-module='govuk-error-summary' data-ga-event-form='error' data-qa='error'>");
+            sb.Append("<div role='alert'>");
             sb.Append("<h2 class='govuk-error-summary__title' id='error-summary-title' data-qa='error__heading'>");
             sb.Append("There is a problem");
             sb.Append("</h2>");
@@ -56,6 +57,7 @@ namespace Frontend.Helpers.TagHelpers
             }
 
             sb.Append("</ul>");
+            sb.Append("</div>");
             sb.Append("</div>");
             sb.Append("</div>");
             sb.Append("</div>");

--- a/Frontend/Views/Shared/_FormErrorSummary.cshtml
+++ b/Frontend/Views/Shared/_FormErrorSummary.cshtml
@@ -3,21 +3,23 @@
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
-                <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
-                    There is a problem
-                </h2>
-                <div class="govuk-error-summary__body">
-                    <ul class="govuk-list govuk-error-summary__list">
-                        @foreach (var error in Model.Errors)
-                        {
-                            <li>
-                                <a href="#@error.ErrorElementId" data-qa="error__text">
-                                    @error.ErrorMessage
-                                </a>
-                            </li>
-                        }
-                    </ul>
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+                        There is a problem
+                    </h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            @foreach (var error in Model.Errors)
+                            {
+                                <li>
+                                    <a href="#@error.ErrorElementId" data-qa="error__text">
+                                        @error.ErrorMessage
+                                    </a>
+                                </li>
+                            }
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Context
Fixing accessibility issue: error messages not read aloud

DevOps ticket: https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_sprints/taskboard/Prepare%20conversions%20and%20transfers/Academies-and-Free-Schools-SIP/Manage%20an%20academy%20transfer/Sprint%2040?workitem=97087

### Changes proposed in this pull request
- fixing markup structure for error summary in Transfers

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally



