### PR TITLE
Fix syntax issue

### DIFF
--- a/end-to-end-tests/cypress/e2e/footer/112379_footer-links-navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/footer/112379_footer-links-navigation.cy.js
@@ -17,7 +17,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
         it('TC02: should navigate to Give Feedback link', () => {
           cy.get('h2').should('contain', 'Give feedback');
           cy.get('li').should('contain', 'Email');
-          cy.get('data-cy="footer-feedback-link"')
+          cy.get('[data-cy="footer-feedback-link"]')
             .should('contain', 'Give feedback on Prepare conversions and transfers (opens in a new tab)');
         });
 


### PR DESCRIPTION
One of the cypress test was failing due to syntax error issue. This PR is fixing the same.
![cypress fix new](https://user-images.githubusercontent.com/116153732/203531781-4bebc6c6-4cf8-421e-844d-af8edb5baafe.png)
