### PR TITLE
Disable x-xss protection header

### DIFF
--- a/end-to-end-tests/cypress/e2e/x-xss-protection/113746_disable_x-xss-protection.cy.js
+++ b/end-to-end-tests/cypress/e2e/x-xss-protection/113746_disable_x-xss-protection.cy.js
@@ -1,0 +1,19 @@
+/// <reference types ='Cypress'/>
+
+Cypress._.each(['ipad-mini'], (viewport) => {
+    describe(`113746 X-xss-Protection Header on transfers ${viewport}`, () => {
+        beforeEach(() => {
+        cy.login()
+        cy.viewport(viewport)    
+        });
+        
+        it('TC01: should be disabled', () => {
+            cy.url().then(urlString => {
+              let modifiedUrl = urlString
+              cy.request('GET', modifiedUrl).then((response) => {
+                expect(response.headers).to.have.property('x-xss-protection', '0')
+              });
+            });  
+        });
+    });
+});


### PR DESCRIPTION
This PR verifies if x-xss protect is disabled for transfers.
The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks.
<img width="955" alt="protection header - transfers" src="https://user-images.githubusercontent.com/116153732/204776027-4de4383b-9931-4d87-9749-95f12e41823c.png">
