### PR TITLE
100529 Accessibility issue: select the trust

### DIFF
--- a/Frontend.Tests/PagesTests/Transfers/OutgoingTrustDetailsTests.cs
+++ b/Frontend.Tests/PagesTests/Transfers/OutgoingTrustDetailsTests.cs
@@ -123,7 +123,7 @@ namespace Frontend.Tests.PagesTests.Transfers
 
                 var redirectResponse = AssertRedirectToPage(response, "/Transfers/TrustSearch");
                 Assert.Equal("", redirectResponse.RouteValues["query"]);
-                Assert.Equal("Select the outgoing trust", subject.TempData["ErrorMessage"]);
+                Assert.Equal("Select a trust", subject.TempData["ErrorMessage"]);
             }
         }
 

--- a/Frontend.Tests/ValidatorTests/Transfers/IncomingTrustConfirmValidatorTests.cs
+++ b/Frontend.Tests/ValidatorTests/Transfers/IncomingTrustConfirmValidatorTests.cs
@@ -35,7 +35,7 @@ namespace Frontend.Tests.ValidatorTests.Transfers
             var result = await _validator.TestValidateAsync(trustSearch);
 
             result.ShouldHaveValidationErrorFor(x => x.SelectedTrustId)
-                .WithErrorMessage("Select an incoming trust");
+                .WithErrorMessage("Select a trust");
         }
 
         [Fact]

--- a/Frontend.Tests/ValidatorTests/Transfers/OutgoingTrustConfirmValidatorTests.cs
+++ b/Frontend.Tests/ValidatorTests/Transfers/OutgoingTrustConfirmValidatorTests.cs
@@ -32,7 +32,7 @@ namespace Frontend.Tests.ValidatorTests.Transfers
             var result = await _validator.TestValidateAsync(outgoingTrustDetails);
 
             result.ShouldHaveValidationErrorFor(x => x.TrustId)
-                .WithErrorMessage("Select the outgoing trust");
+                .WithErrorMessage("Select a trust");
         }
 
         [Fact]

--- a/Frontend/Pages/Transfers/SearchIncomingTrust.cshtml
+++ b/Frontend/Pages/Transfers/SearchIncomingTrust.cshtml
@@ -23,7 +23,7 @@
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl" id="@nameof(Model.Trusts)">
                         <h1 class="govuk-fieldset__heading">
-                            Select an incoming trust
+                            Select the incoming trust
                         </h1>
                     </legend>
 

--- a/Frontend/Validators/Transfers/IncomingTrustConfirmValidator.cs
+++ b/Frontend/Validators/Transfers/IncomingTrustConfirmValidator.cs
@@ -9,7 +9,7 @@ namespace Frontend.Validators.Transfers
         {
             RuleFor(x => x.SelectedTrustId)
                 .NotEmpty()
-                .WithMessage("Select an incoming trust");
+                .WithMessage("Select a trust");
         }
 
         protected override void EnsureInstanceNotNull(object instanceToValidate)

--- a/Frontend/Validators/Transfers/OutgoingTrustConfirmValidator.cs
+++ b/Frontend/Validators/Transfers/OutgoingTrustConfirmValidator.cs
@@ -9,7 +9,7 @@ namespace Frontend.Validators.Transfers
         {
             RuleFor(x => x.TrustId)
                 .NotEmpty()
-                .WithMessage("Select the outgoing trust");
+                .WithMessage("Select a trust");
         }
 
         protected override void EnsureInstanceNotNull(object instanceToValidate)

--- a/end-to-end-tests/cypress/e2e/End2EndTests/project-runthrough.cy.js
+++ b/end-to-end-tests/cypress/e2e/End2EndTests/project-runthrough.cy.js
@@ -93,14 +93,14 @@ describe("Creating and editing an academy transfer", { tags: '@dev'}, function (
         cy.get("[name='query']").clear().type("burnt")
         cy.get('.govuk-button').should('contain.text', 'Search').click();
 
-        cy.get("h1").should('contain.text', "Select an incoming trust");
+        cy.get("h1").should('contain.text', "Select the incoming trust");
         cy.clickBackLink()
 
         cy.get("h1").should('contain.text', "What is the incoming trust name?");
         cy.get("[name='query']").clear().type("burnt")
         cy.get('.govuk-button').should('contain.text', 'Search').click();
 
-        cy.get("h1").should('contain.text', "Select an incoming trust");
+        cy.get("h1").should('contain.text', "Select the incoming trust");
         selectFirstRadio()
         cy.get('.govuk-button').should('contain.text', 'Continue').click();
 
@@ -111,7 +111,7 @@ describe("Creating and editing an academy transfer", { tags: '@dev'}, function (
         cy.get("[name='query']").clear().type("burnt")
         cy.get('.govuk-button').should('contain.text', 'Search').click();
 
-        cy.get("h1").should('contain.text', "Select an incoming trust");
+        cy.get("h1").should('contain.text', "Select the incoming trust");
         selectFirstRadio()
         cy.get('.govuk-button').should('contain.text', 'Continue').click();
 

--- a/end-to-end-tests/cypress/e2e/Performance/preview and download template.cy.js
+++ b/end-to-end-tests/cypress/e2e/Performance/preview and download template.cy.js
@@ -61,7 +61,7 @@ describe("Performance test for preview and download template with multiple acade
         cy.get("[name='query']").clear().type("burnt")
         cy.get('.govuk-button').should('contain.text', 'Search').click();
 
-        cy.get("h1").should('contain.text', "Select an incoming trust");
+        cy.get("h1").should('contain.text', "Select the incoming trust");
         selectFirstRadio()
         cy.get('.govuk-button').should('contain.text', 'Continue').click();
 

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -100,7 +100,7 @@ Cypress.Commands.add('OutGoingSearch_Link_Back', () => cy.get(`${backLink}`))
 // PAGE: Outgoing trust details
 // PAGE: Select the transferring academies 
 // PAGE: What is the incoming trust name?
-// PAGE: Select an incoming trust
+// PAGE: Select the incoming trust
 // PAGE: Check trust and academy details
 
 /*


### PR DESCRIPTION
### Context
Updating error messages for the Incoming Trust page and Outgoing Trust page so that they are no longer the same as the page titles. Also we decided to rename the page title of Incoming Trust page to make it consistent with the Outgoing Trust page. 

You may have noticed that the error message of the Incoming Trust page is missing from the area above radio buttons. It will be fixed in a separate ticket. 

DevOps ticket: https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_sprints/taskboard/Prepare%20conversions%20and%20transfers/Academies-and-Free-Schools-SIP/Manage%20an%20academy%20transfer/Sprint%2040?workitem=100529

### Changes proposed in this pull request
- Updated error messages for outgoing trust
- Updated error messages and page title for incoming trust

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

### Before 
<img width="1039" alt="Screenshot 2022-11-30 at 12 27 02" src="https://user-images.githubusercontent.com/6421298/204841137-d71b8af1-91f9-4d4c-8c3b-a3719270e687.png">

<img width="1039" alt="Screenshot 2022-11-30 at 12 24 55" src="https://user-images.githubusercontent.com/6421298/204841172-3300af41-f7c7-4142-a0b1-b284855248a7.png">


### After 
<img width="1030" alt="Screenshot 2022-11-30 at 12 24 22" src="https://user-images.githubusercontent.com/6421298/204841263-e54920e2-64e8-449d-9bb6-c6e69ba59858.png">

<img width="1036" alt="Screenshot 2022-11-30 at 15 27 15" src="https://user-images.githubusercontent.com/6421298/204841323-b97c8cdf-4a2d-42e0-ab40-e9cbf61afc37.png">


