### PR TITLE
115304 update accessibility statement for Transfers

### DIFF
--- a/Frontend/Pages/AccessibilityStatement.cshtml
+++ b/Frontend/Pages/AccessibilityStatement.cshtml
@@ -76,12 +76,10 @@
 		Non-compliance with the accessibility regulations
 		</h4>
 		<ul class="govuk-list govuk-list--bullet">
-			<li>keyboard users cannot select the save and continue button on conversions project pages. This fails WCAG 2.1 AA success criteria 2.1 (Keyboard Accessible) </li>
-			<li>the website tells JAWS users there are form fields present where there are none. This fails WCAG 2.1 AA success criteria 2.4.4 (Link Purpose (In Context)) </li>
-			<li>main headings on some pages are contained within groups of elements and so may not be read out correctly by some screen reader software. This fails WCAG 2.1 AA success criteria 2.4.6 (Headings and Labels)</li>
-			<li>some labelling on primary action buttons are not consistent. The labels were selected to give users a better description of the purpose of the action based on user research. This fails WCAG 2.1 AA success criteria 3.2.4 (Consistent Identification) </li>
-			<li>when information is deleted from a required field, this is not announced when the page is reloaded. Users must navigate down the page to find the error message. This fails WCAG 2.1 AA success criteria 3.3.1 (Error Identification) </li>
-			<li>when users start a new transfer project and do not select an outgoing trust, the error message is not clear about what users should do. This fails WCAG 2.1 AA success criteria 3.3.1 (Error Identification) </li>
+			<li>main headings on some pages are contained within groups of elements and so may not be read out correctly by some screen readers. This fails WCAG 2.1 AA success criteria 2.4.6 (Headings and Labels) </li>
+			<li>the navigation pane heading structure on exported transfer project Word documents does not match the headings in the document. This fails WCAG 2.1 AA success criteria 2.4.6 (Headings and Labels)  </li>
+			<li>error summaries and messages do not appear for all mistakes users make on certain conversions project pages. This fails WCAG 2.1 A success criteria 3.3.1 (Error Identification) </li>
+			<li>only an error summary appears and no error message when users experience an error on certain transfers project pages. This fails WCAG 2.1 A success criteria 3.3.2 (Labels or Instructions)</li>
 		</ul>
 
 		<h4 class="govuk-heading-s">

--- a/Frontend/Pages/AccessibilityStatement.cshtml
+++ b/Frontend/Pages/AccessibilityStatement.cshtml
@@ -65,7 +65,7 @@
 
 		<h2 class="govuk-heading-l">Compliance status</h2>
 		<p class="govuk-body">
-			This website is partially compliant with the WCAG version 2.1 AA standard, due to the following non-compliance(s) and exemptions. 
+			This website is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the following non-compliances and exemptions.
 		</p>
 
 		<h3 class="govuk-heading-m">Non-accessible content </h3>


### PR DESCRIPTION
### Context
Update content on the accessibility statement page on Transfers
- Update non-compliances
- Change WCAG to Web Content Accessibility Guidelines

DevOps ticket: 
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_sprints/taskboard/Prepare%20conversions%20and%20transfers/Academies-and-Free-Schools-SIP/Manage%20an%20academy%20transfer/Sprint%2040?workitem=115304
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_sprints/taskboard/Prepare%20conversions%20and%20transfers/Academies-and-Free-Schools-SIP/Manage%20an%20academy%20transfer/Sprint%2040?workitem=115307

### Changes proposed in this pull request
- updated the non compliances paragraph
- Change WCAG to Web Content Accessibility Guidelines

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally


### Before 
<img width="701" alt="Screenshot 2022-12-14 at 15 54 54" src="https://user-images.githubusercontent.com/6421298/207646108-35c7a797-a0e0-4d66-bacc-7437677894fc.png">

### After
<img width="682" alt="Screenshot 2022-12-14 at 16 01 44" src="https://user-images.githubusercontent.com/6421298/207646161-f8f2a291-361c-45cf-a5a7-2ef9217e6ae9.png">

