### PR TITLE
Split workflow tasks apart into steps to improve readibility

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -5,46 +5,94 @@ on:
     branches:
       - main
 
+env:
+  DOCKER_IMAGE: acatran-app
+
 jobs:
-  build-and-push-image-development:
-    name: Build and push image development
+  set-env:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.var.outputs.branch }}
+      release: ${{ steps.var.outputs.release }}
+    steps:
+      - id: var
+        run: |
+          GIT_REF=${{ github.ref }}
+          GIT_BRANCH=${GIT_REF##*/}
+          RELEASE=dev-`date +%Y-%m-%d`.${{ github.run_number }}
+          echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
+          echo "release=${RELEASE}" >> $GITHUB_OUTPUT
+
+  build-and-push-image:
+    name: Build and push image
+    needs: [ set-env ]
     environment: Dev
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Azure Container Registry login
+      - name: Login to ACR
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DEVELOPMENT_AZURE_ACR_CLIENTID }}
           password: ${{ secrets.DEVELOPMENT_AZURE_ACR_SECRET }}
           registry: ${{ secrets.DEVELOPMENT_AZURE_ACR_URL }}
 
-      - name: Prepare tags
-        id: prepare-tags
-        run: |
-          DOCKER_IMAGE=${{ secrets.DEVELOPMENT_AZURE_ACR_URL }}/acatran-app
-          VERSION=dev-`date +%Y-%m-%d`.${{ github.run_number }}
-          SHA=sha-${GITHUB_SHA}
-          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHA}"
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-          echo "deploy-version=${VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Push image
+      - name: Build and push image
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./Dockerfile.gpaas-azure-migration
+          file: Dockerfile.gpaas-azure-migration
+          tags: |
+            ${{ secrets.DEVELOPMENT_AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.branch }}
+            ${{ secrets.DEVELOPMENT_AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }}
+            ${{ secrets.DEVELOPMENT_AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:latest
           push: true
-          tags: ${{ steps.prepare-tags.outputs.tags }}
 
-      - name: Azure login with ACA credentials
+  create-tag:
+    name: Tag and release
+    needs: [ set-env ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create tag
+        run: |
+          git tag ${{ needs.set-env.outputs.release }}
+          git push origin ${{ needs.set-env.outputs.release }}
+
+      - name: Create release
+        uses: "actions/github-script@v6"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            try {
+              await github.rest.repos.createRelease({
+                draft: false,
+                generate_release_notes: true,
+                name: "${{ needs.set-env.outputs.release }}",
+                owner: context.repo.owner,
+                prerelease: false,
+                repo: context.repo.repo,
+                tag_name: "${{ needs.set-env.outputs.release }}",
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }
+
+  deploy-image:
+    name: Deploy to Development
+    needs: [ build-and-push-image, set-env ]
+    runs-on: ubuntu-latest
+    environment: Dev
+    steps:
+      - name: Login to Azure
         uses: azure/login@v1
         with:
           creds: ${{ secrets.DEVELOPMENT_AZURE_ACA_CREDENTIALS }}
 
-      - name: Update Azure Container Apps Revision
+      - name: Update Container Revision
         uses: azure/CLI@v1
         with:
           azcliversion: 2.40.0
@@ -53,5 +101,5 @@ jobs:
             az containerapp update \
               --name ${{ secrets.DEVELOPMENT_AZURE_ACA_CONTAINERAPP_NAME }} \
               --resource-group ${{ secrets.DEVELOPMENT_AZURE_ACA_RESOURCE_GROUP }} \
-              --image ${{ secrets.DEVELOPMENT_AZURE_ACR_URL }}/acatran-app:${{ steps.prepare-tags.outputs.deploy-version }} \
+              --image ${{ secrets.DEVELOPMENT_AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }} \
               --output none


### PR DESCRIPTION
This change brings the workflow closer to the [DFE-Digital/a2b-internal](https://github.com/DFE-Digital/a2b-internal/actions/workflows/build-and-push-image.yml) deployment pipeline by splitting the steps into separate jobs to make it easier to view the progress at-a-glance. 

It will also add the `latest` tag back onto the Docker image tags that get pushed to Azure Container Registry.