### PR TITLE
Fix Content-Type HTTP Header

### DIFF
--- a/Dfe.PrepareTransfers.Web/Startup.cs
+++ b/Dfe.PrepareTransfers.Web/Startup.cs
@@ -250,14 +250,20 @@ public class Startup
         {
             httpClient.BaseAddress = new Uri(tramsApiBase);
             httpClient.DefaultRequestHeaders.Add("ApiKey", tramsApiKey);
-            httpClient.DefaultRequestHeaders.Add("ContentType", "application/json");
+            // Content-Type only works with requests when a BODY is attached, otherwise it's ignored
+            httpClient.DefaultRequestHeaders.AddWithoutValidation("Content-Type", "application/json");
+            // Always expect a JSON response from the API
+            httpClient.DefaultRequestHeaders.Accept.Add("application/json");
         });
 
         services.AddHttpClient("AcademisationApiClient", httpClient =>
         {
             httpClient.BaseAddress = new Uri(academisationApiBase);
             httpClient.DefaultRequestHeaders.Add("x-api-key", academisationApiKey);
-            httpClient.DefaultRequestHeaders.Add("ContentType", "application/json");
+            // Content-Type only works with requests when a BODY is attached, otherwise it's ignored
+            httpClient.DefaultRequestHeaders.AddWithoutValidation("Content-Type", "application/json");
+            // Always expect a JSON response from the API
+            httpClient.DefaultRequestHeaders.Accept.Add("application/json");
         });
 
         services.AddScoped<IReferenceNumberService, ReferenceNumberService>();


### PR DESCRIPTION
* Fix: Content-Type header is set https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
* Accept HTTP Header is defined to inform responses from the APIs